### PR TITLE
Add new endpoints for managing existing cells

### DIFF
--- a/jupyter_mcp_server/server.py
+++ b/jupyter_mcp_server/server.py
@@ -4,6 +4,7 @@
 
 import logging
 import os
+from typing import Union
 
 from jupyter_kernel_client import KernelClient
 from jupyter_nbmodel_client import (
@@ -15,11 +16,11 @@ from mcp.server.fastmcp import FastMCP
 mcp = FastMCP("jupyter")
 
 
-NOTEBOOK_PATH = os.getenv("NOTEBOOK_PATH", "notebook.ipynb")
+NOTEBOOK_PATH: str = os.getenv("NOTEBOOK_PATH", "notebook.ipynb")
 
-SERVER_URL = os.getenv("SERVER_URL", "http://localhost:8888")
+SERVER_URL: str = os.getenv("SERVER_URL", "http://localhost:8888")
 
-TOKEN = os.getenv("TOKEN", "MY_TOKEN")
+TOKEN: str = os.getenv("TOKEN", "MY_TOKEN")
 
 
 logger = logging.getLogger(__name__)
@@ -78,6 +79,28 @@ async def add_markdown_cell(cell_content: str) -> str:
 
 
 @mcp.tool()
+async def overwrite_cell_source(cell_index: int, cell_source: str) -> str:
+    """Overwrite the source of an existing cell.
+       Note this does not execute the modified cell by itself.
+
+    Args:
+        cell_index: Index of the cell to overwrite (0-based)
+        cell_source: New cell source - must match existing cell type
+
+    Returns:
+        str: Success message
+    """
+    # TODO: Add check on cell_type
+    notebook = NbModelClient(
+        get_jupyter_notebook_websocket_url(server_url=SERVER_URL, token=TOKEN, path=NOTEBOOK_PATH)
+    )
+    await notebook.start()
+    notebook.set_cell_source(cell_index, cell_source)
+    await notebook.stop()
+    return f"Cell {cell_index} overwritten successfully - use execute_cell to execute it if code"
+
+
+@mcp.tool()
 async def add_execute_code_cell(cell_content: str) -> list[str]:
     """Add and execute a code cell in a Jupyter notebook.
 
@@ -99,8 +122,175 @@ async def add_execute_code_cell(cell_content: str) -> list[str]:
     str_outputs = [extract_output(output) for output in outputs]
 
     await notebook.stop()
-    
+
     return str_outputs
+
+
+# TODO: Add clear_outputs(cell_index: int) function
+# But we need to expose reset_cell in NbModelClient:
+# https://github.com/datalayer/jupyter-nbmodel-client/blob/main/jupyter_nbmodel_client/model.py#L297-L301
+
+
+@mcp.tool()
+async def execute_cell(cell_index: int) -> list[str]:
+    """Execute a specific cell from the Jupyter notebook.
+    Args:
+        cell_index: Index of the cell to execute (0-based)
+    Returns:
+        list[str]: List of outputs from the executed cell
+    """
+    notebook = NbModelClient(
+        get_jupyter_notebook_websocket_url(server_url=SERVER_URL, token=TOKEN, path=NOTEBOOK_PATH)
+    )
+    await notebook.start()
+
+    ydoc = notebook._doc
+
+    if cell_index < 0 or cell_index >= len(ydoc._ycells):
+        await notebook.stop()
+        raise ValueError(
+            f"Cell index {cell_index} is out of range. Notebook has {len(ydoc._ycells)} cells."
+        )
+
+    notebook.execute_cell(cell_index, kernel)
+
+    ydoc = notebook._doc
+    outputs = ydoc._ycells[cell_index]["outputs"]
+    str_outputs = [extract_output(output) for output in outputs]
+
+    await notebook.stop()
+    return str_outputs
+
+
+@mcp.tool()
+async def read_all_cells() -> list[dict[str, Union[str, int, list[str]]]]:
+    """Read all cells from the Jupyter notebook.
+    Returns:
+        list[dict]: List of cell information including index, type, content,
+                    and outputs (for code cells)
+    """
+    notebook = NbModelClient(
+        get_jupyter_notebook_websocket_url(server_url=SERVER_URL, token=TOKEN, path=NOTEBOOK_PATH)
+    )
+    await notebook.start()
+
+    ydoc = notebook._doc
+    cells = []
+
+    for i, cell in enumerate(ydoc._ycells):
+        cell_info = {
+            "index": i,
+            "type": cell.get("cell_type", "unknown"),
+            "content": cell.get("source", ""),
+        }
+
+        # Add outputs for code cells
+        if cell.get("cell_type") == "code":
+            outputs = cell.get("outputs", [])
+            cell_info["outputs"] = [extract_output(output) for output in outputs]
+
+        cells.append(cell_info)
+
+    await notebook.stop()
+    return cells
+
+
+@mcp.tool()
+async def read_cell(cell_index: int) -> dict[str, Union[str, int, list[str]]]:
+    """Read a specific cell from the Jupyter notebook.
+    Args:
+        cell_index: Index of the cell to read (0-based)
+    Returns:
+        dict: Cell information including index, type, content, and outputs (for code cells)
+    """
+    notebook = NbModelClient(
+        get_jupyter_notebook_websocket_url(server_url=SERVER_URL, token=TOKEN, path=NOTEBOOK_PATH)
+    )
+    await notebook.start()
+
+    ydoc = notebook._doc
+
+    if cell_index < 0 or cell_index >= len(ydoc._ycells):
+        await notebook.stop()
+        raise ValueError(
+            f"Cell index {cell_index} is out of range. Notebook has {len(ydoc._ycells)} cells."
+        )
+
+    cell = ydoc._ycells[cell_index]
+    cell_info = {
+        "index": cell_index,
+        "type": cell.get("cell_type", "unknown"),
+        "content": cell.get("source", ""),
+    }
+
+    # Add outputs for code cells
+    if cell.get("cell_type") == "code":
+        outputs = cell.get("outputs", [])
+        cell_info["outputs"] = [extract_output(output) for output in outputs]
+
+    await notebook.stop()
+    return cell_info
+
+
+@mcp.tool()
+async def get_notebook_info() -> dict[str, Union[str, int, dict[str, int]]]:
+    """Get basic information about the notebook.
+    Returns:
+        dict: Notebook information including path, total cells, and cell type counts
+    """
+    notebook = NbModelClient(
+        get_jupyter_notebook_websocket_url(server_url=SERVER_URL, token=TOKEN, path=NOTEBOOK_PATH)
+    )
+    await notebook.start()
+
+    ydoc = notebook._doc
+    total_cells: int = len(ydoc._ycells)
+
+    cell_types: dict[str, int] = {}
+    for cell in ydoc._ycells:
+        cell_type: str = str(cell.get("cell_type", "unknown"))
+        cell_types[cell_type] = cell_types.get(cell_type, 0) + 1
+
+    # TODO: We could also get notebook metadata
+    # e.g. to know the language if using different kernels
+    info: dict[str, Union[str, int, dict[str, int]]] = {
+        "notebook_path": NOTEBOOK_PATH,
+        "total_cells": total_cells,
+        "cell_types": cell_types,
+    }
+
+    await notebook.stop()
+    return info
+
+
+@mcp.tool()
+async def delete_cell(cell_index: int) -> str:
+    """Delete a specific cell from the Jupyter notebook.
+    Args:
+        cell_index: Index of the cell to delete (0-based)
+    Returns:
+        str: Success message
+    """
+    notebook = NbModelClient(
+        get_jupyter_notebook_websocket_url(server_url=SERVER_URL, token=TOKEN, path=NOTEBOOK_PATH)
+    )
+    await notebook.start()
+
+    ydoc = notebook._doc
+
+    if cell_index < 0 or cell_index >= len(ydoc._ycells):
+        await notebook.stop()
+        raise ValueError(
+            f"Cell index {cell_index} is out of range. Notebook has {len(ydoc._ycells)} cells."
+        )
+
+    cell_type = ydoc._ycells[cell_index].get("cell_type", "unknown")
+
+    # Delete the cell
+    del ydoc._ycells[cell_index]
+
+    await notebook.stop()
+    return f"Cell {cell_index} ({cell_type}) deleted successfully."
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Adds the following MCP tool endpoints:
- overwrite_cell_source(cell_index: int, cell_source: str) -> str
- execute_cell(cell_index: int) -> list[str]
- read_all_cells() -> list[dict[str, Union[str, int, list[str]] ]]
- read_cell(cell_index: int) -> dict[str, Union[str, int, list[ str]]]
- get_notebook_info() -> dict[str, Union[str, int, dict[str, int]]]
- delete_cell(cell_index: int)

This server is awesome btw I was able to watch the agent as it went one-by-one modifying the cells in the notebook!

I think the only thing still missing is clearing outputs.