### PR TITLE
Refactoring of the read cell / cell info model

### DIFF
--- a/jupyter_mcp_server/models.py
+++ b/jupyter_mcp_server/models.py
@@ -1,8 +1,9 @@
 # Copyright (c) 2023-2024 Datalayer, Inc.
 #
 # BSD 3-Clause License
-
+from typing import Optional, Literal
 from pydantic import BaseModel
+from jupyter_mcp_server.utils import extract_output, safe_extract_outputs
 
 
 class DocumentRuntime(BaseModel):
@@ -13,3 +14,27 @@ class DocumentRuntime(BaseModel):
     runtime_url: str
     runtime_id: str
     runtime_token: str
+
+
+class CellInfo(BaseModel):
+    """Notebook cell information as returned by the MCP server"""
+
+    index: int
+    type: Literal["unknown", "code", "markdown"]
+    source: list[str]
+    outputs: Optional[list[str]]
+
+    @classmethod
+    def from_cell(cls, cell_index: int, cell: dict):
+        """Extract cell info (create a CellInfo object) from an index and a Notebook cell"""
+        outputs = None
+        type = cell.get("cell_type", "unknown")
+        if type == "code":
+            try:
+                outputs = cell.get("outputs", [])
+                outputs = safe_extract_outputs(outputs)
+            except Exception as e:
+                outputs = [f"[Error reading outputs: {str(e)}]"]
+        return cls(
+            index=cell_index, type=type, source=cell.get("source", ""), outputs=outputs
+        )

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -154,6 +154,11 @@ class MCPClient:
         return result.structuredContent
 
     @requires_session
+    async def read_all_cells(self):
+        result = await self._session.call_tool("read_all_cells")  # type: ignore
+        return result.structuredContent
+
+    @requires_session
     async def delete_cell(self, cell_index):
         result = await self._session.call_tool("delete_cell", arguments={"cell_index": cell_index})  # type: ignore
         return MCPClient._extract_text_content(result)
@@ -169,7 +174,7 @@ def _start_server(name, host, port, command, readiness_endpoint="/", max_retries
     url_readiness = f"{url}{readiness_endpoint}"
     logging.info(f"{_log_prefix}: starting ...")
     p_serv = subprocess.Popen(command, stdout=subprocess.PIPE)
-    _log_prefix = f"{_log_prefix} ({p_serv.pid})"
+    _log_prefix = f"{_log_prefix} [{p_serv.pid}]"
     while max_retries > 0:
         try:
             response = requests.get(url_readiness)
@@ -329,6 +334,12 @@ async def test_markdown_cell(mcp_client, content="Hello **World** !"):
         assert cell_info["type"] == "markdown"
         # TODO: don't now if it's normal to get a list of characters instead of a string
         assert "".join(cell_info["source"]) == content
+        # reading all cells
+        result = await mcp_client.read_all_cells()
+        cells_info = result["result"]
+        logging.debug(f"cells_info: {cells_info}")
+        assert len(cells_info) == 2
+        assert "".join(cells_info[index]["source"]) == content
         # delete created cell
         result = await mcp_client.delete_cell(index)
         assert result == f"Cell {index} (markdown) deleted successfully."
@@ -354,6 +365,12 @@ async def test_code_cell(mcp_client, content="1 + 1"):
         assert cell_info["index"] == index
         assert cell_info["type"] == "code"
         assert "".join(cell_info["source"]) == content
+        # reading all cells
+        result = await mcp_client.read_all_cells()
+        cells_info = result["result"]
+        logging.debug(f"cells_info: {cells_info}")
+        assert len(cells_info) == 2
+        assert "".join(cells_info[index]["source"]) == content
         # delete created cell
         result = await mcp_client.delete_cell(index)
         assert result == f"Cell {index} (code) deleted successfully."

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -361,7 +361,7 @@ async def test_code_cell(mcp_client, content="1 + 1"):
         """Check and delete a code cell"""
         # reading and checking the content of the created cell
         cell_info = await mcp_client.read_cell(index)
-        logging.info(f"cell_info: {cell_info}")
+        logging.debug(f"cell_info: {cell_info}")
         assert cell_info["index"] == index
         assert cell_info["type"] == "code"
         assert "".join(cell_info["source"]) == content


### PR DESCRIPTION
Hello,

I made a careful (I hope 😄 ) refactoring of the extract of the cell info data that is returned by the tools `read_cell` and `read_all_cells`. I did not change the interfaces (tests are passing before and after the change) but I created a model `CellInfo` model that can instantiate itself from index and notebook cell info. I have also enhanced the tests to include `read_all_cells` in their logic.

This permits to get more structured data from the external interface (model validation) and to regroup logic (and avoid code duplication) related to data extraction.

Cheers 🍰 
