### PR TITLE
#61 Documentation update for JupyterHub

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,11 @@ pip install datalayer_pycrdt==0.12.17
 jupyter lab --port 8888 --IdentityProvider.token MY_TOKEN --ip 0.0.0.0
 ```
 
+#### JupyterHub
+If you are running notebooks through JupyterHub instead of JupyterLab as above, you should:
+* Set the environment variable `JUPYTERHUB_ALLOW_TOKEN_IN_URL=1` in the single-user environment.
+* Ensure your API token (`MY_TOKEN`) is created with `access:servers` scope in the Hub.
+
 ### 3. Configure Your Preferred MCP Client
 
 > [!NOTE]


### PR DESCRIPTION
Here's a brief update to docs for JupyterHub environments per discussion in #61.

It would probably make sense to review _why_ `JUPYTERHUB_ALLOW_TOKEN_IN_URL` is needed, given the [websocket request](https://github.com/datalayer/jupyter-nbmodel-client/blob/a357640c2bfc99b94d2167c967bb482c7dd924b5/jupyter_nbmodel_client/helpers.py#L83) itself should be allowed per [allow_token_in_url](https://jupyterhub.readthedocs.io/en/latest/reference/api/services.auth.html#jupyterhub.services.auth.HubAuth.allow_token_in_url):

>Has no effect on websocket requests, which can only reliably authenticate via token in the URL, as recommended by browser Websocket implementations.

Based on the issue report, I did a quick search for `/api/collaboration/room/json` requests in the `datalayer` org to see if I could find the culprit, but it looks like a deeper dive is required.