### PR TITLE
fix: add FORCE_SAVE environment variable for automatic notebook saving

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ jupyter lab --port 8888 --IdentityProvider.token MY_TOKEN --ip 0.0.0.0
 > 
 > - **Optional:** If you omit `DOCUMENT_ID`, the MCP client can automatically list all available notebooks on the Jupyter server, allowing you to select one interactively via your prompts.
 > - **Flexible:** Even if you set `DOCUMENT_ID`, the MCP client can still browse, list, switch to, or even create new notebooks at any time.
-> 
+> - **Optional:** If you meet same issue as [issue #96](https://github.com/datalayer/jupyter-mcp-server/issues/96), set `FORCE_SAVE` to `true`, the MCP client can automatically save the notebook after each change.
 
 #### MacOS and Windows
 
@@ -91,6 +91,7 @@ jupyter lab --port 8888 --IdentityProvider.token MY_TOKEN --ip 0.0.0.0
         "-e", "RUNTIME_URL",
         "-e", "RUNTIME_TOKEN",
         "-e", "ALLOW_IMG_OUTPUT",
+        "-e", "FORCE_SAVE",
         "datalayer/jupyter-mcp-server:latest"
       ],
       "env": {
@@ -99,7 +100,8 @@ jupyter lab --port 8888 --IdentityProvider.token MY_TOKEN --ip 0.0.0.0
         "DOCUMENT_ID": "notebook.ipynb",
         "RUNTIME_URL": "http://host.docker.internal:8888",
         "RUNTIME_TOKEN": "MY_TOKEN",
-        "ALLOW_IMG_OUTPUT": "true"
+        "ALLOW_IMG_OUTPUT": "true",
+        "FORCE_SAVE": "false"
       }
     }
   }
@@ -121,6 +123,7 @@ jupyter lab --port 8888 --IdentityProvider.token MY_TOKEN --ip 0.0.0.0
         "-e", "RUNTIME_URL",
         "-e", "RUNTIME_TOKEN",
         "-e", "ALLOW_IMG_OUTPUT",
+        "-e", "FORCE_SAVE",
         "--network=host",
         "datalayer/jupyter-mcp-server:latest"
       ],
@@ -130,7 +133,8 @@ jupyter lab --port 8888 --IdentityProvider.token MY_TOKEN --ip 0.0.0.0
         "DOCUMENT_ID": "notebook.ipynb",
         "RUNTIME_URL": "http://localhost:8888",
         "RUNTIME_TOKEN": "MY_TOKEN",
-        "ALLOW_IMG_OUTPUT": "true"
+        "ALLOW_IMG_OUTPUT": "true",
+        "FORCE_SAVE": "false"
       }
     }
   }

--- a/jupyter_mcp_server/__version__.py
+++ b/jupyter_mcp_server/__version__.py
@@ -4,4 +4,4 @@
 
 """Jupyter MCP Server."""
 
-__version__ = "0.14.0"
+__version__ = "0.14.1"

--- a/jupyter_mcp_server/config_env.py
+++ b/jupyter_mcp_server/config_env.py
@@ -45,3 +45,4 @@ def _get_env_bool(env_name: str, default_value: bool = True) -> bool:
 # Multimodal Output Configuration
 # Environment variable controls whether to return actual image content or text placeholder
 ALLOW_IMG_OUTPUT: bool = _get_env_bool("ALLOW_IMG_OUTPUT", True)
+FORCE_SAVE: bool = _get_env_bool("FORCE_SAVE", False)

--- a/jupyter_mcp_server/notebook_manager.py
+++ b/jupyter_mcp_server/notebook_manager.py
@@ -15,8 +15,10 @@ from contextlib import asynccontextmanager
 
 from jupyter_nbmodel_client import NbModelClient, get_notebook_websocket_url
 from jupyter_kernel_client import KernelClient
+from jupyter_server_api import JupyterServerClient
 
 from .config import get_config
+from .config_env import FORCE_SAVE
 
 
 class NotebookConnection:
@@ -50,6 +52,11 @@ class NotebookConnection:
     ) -> None:
         """Exit context, clean up connection."""
         if self._notebook:
+            if FORCE_SAVE:
+                config = get_config()
+                server_client = JupyterServerClient(config.document_url, config.document_token)
+                server_client.contents.save_notebook(self.notebook_info["path"], self._notebook.as_dict())
+                server_client.close()
             await self._notebook.__aexit__(exc_type, exc_val, exc_tb)
 
 


### PR DESCRIPTION
- Introduced FORCE_SAVE variable to control automatic saving of notebooks after changes.
- Updated README.md with instructions for setting FORCE_SAVE.
- Modified config_env.py to include FORCE_SAVE with a default value of false.
- Enhanced notebook_manager.py to save notebooks automatically when FORCE_SAVE is enabled.
- Bumped version to 0.14.1 to reflect changes.