### PR TITLE
chore: update tool names

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Compatible with any Jupyter deployment (local, JupyterHub, ...) and with [Datala
 
 ![Jupyter MCP Server Demo](https://assets.datalayer.tech/jupyter-mcp/mcp-demo-multimodal.gif)
 
-🛠️ This MCP offers multiple tools such as `insert_cell`, `execute_cell`, `list_all_files`, `read_cell`, and more, enabling advanced interactions with Jupyter notebooks. Explore our [tools documentation](https://jupyter-mcp-server.datalayer.tech/tools) to learn about all the tools powering Jupyter MCP Server.
+🛠️ This MCP offers multiple tools such as `insert_cell`, `execute_cell`, `list_files`, `read_cell`, and more, enabling advanced interactions with Jupyter notebooks. Explore our [tools documentation](https://jupyter-mcp-server.datalayer.tech/tools) to learn about all the tools powering Jupyter MCP Server.
 
 ## 🏁 Getting Started
 

--- a/docs/docs/releases/index.mdx
+++ b/docs/docs/releases/index.mdx
@@ -1,5 +1,9 @@
 # Releases
 
+## 0.15.x - 08 Oct 2025
+
+- [0.15.1: Rename Tools](https://github.com/datalayer/jupyter-mcp-server/pull/98)
+
 ## 0.14.0 - 03 Oct 2025
 
 - [Additional Tools & Bug fixes](https://github.com/datalayer/jupyter-mcp-server/pull/93).

--- a/docs/docs/tools/index.mdx
+++ b/docs/docs/tools/index.mdx
@@ -14,7 +14,7 @@ The server currently offers 18 tools organized into 3 categories:
   - `kernel_id`(string, optional): Specific kernel ID to use (optional, will create new if not provided)
 - Returns: Success message with notebook information
 
-#### 2. `list_notebook`
+#### 2. `list_notebooks`
 
 - List all notebooks in the Jupyter server (including subdirectories) and show which ones are managed by the notebook manager.     To interact with a notebook, it has to be "managed". If a notebook is not managed, you can connect to it using the `connect_notebook` tool.
 - Input: None
@@ -48,7 +48,7 @@ The server currently offers 18 tools organized into 3 categories:
 
 ## Server Management Tools (2 tools)
 
-#### 6. `list_all_files`
+#### 6. `list_files`
 
 - List all files and directories in the Jupyter server's file system.
 - This tool recursively lists files and directories from the Jupyter server's content API, showing the complete file structure including notebooks, data files, scripts, and directories.
@@ -61,7 +61,7 @@ The server currently offers 18 tools organized into 3 categories:
   - **Size**: File size formatted as B, KB, or MB (empty for directories)
   - **Last_Modified**: Last modification timestamp in YYYY-MM-DD HH:MM:SS format
 
-#### 7. `list_kernel`
+#### 7. `list_kernels`
 
 - List all available kernels in the Jupyter server.
 - This tool shows all running and available kernel sessions on the Jupyter server, including their IDs, names, states, connection information, and kernel specifications. Useful for monitoring kernel resources and identifying specific kernels for connection.
@@ -109,7 +109,7 @@ The server currently offers 18 tools organized into 3 categories:
   - `cell_index`(int): Index of the cell to read (0-based).
 - Returns: Dictionary with cell index, type, source, and outputs (for code cells).
 
-#### 12. `read_all_cells`
+#### 12. `read_cells`
 
 - Read all cells from the notebook.
 - Returns:  List of cell information including index, type, source, and outputs (for code cells).

--- a/jupyter_mcp_server/__version__.py
+++ b/jupyter_mcp_server/__version__.py
@@ -4,4 +4,4 @@
 
 """Jupyter MCP Server."""
 
-__version__ = "0.14.0"
+__version__ = "0.15.1"

--- a/jupyter_mcp_server/server.py
+++ b/jupyter_mcp_server/server.py
@@ -520,7 +520,7 @@ async def connect_notebook(
 
 
 @mcp.tool()
-async def list_notebook() -> str:
+async def list_notebooks() -> str:
     """List all notebooks in the Jupyter server (including subdirectories) and show which ones are managed.
     
     To interact with a notebook, it has to be "managed". If a notebook is not managed, you can connect to it using the `connect_notebook` tool.
@@ -993,7 +993,7 @@ async def execute_cell_streaming(cell_index: int, timeout_seconds: int = 300, pr
     return await __safe_notebook_operation(_execute_streaming, max_retries=1)
 
 @mcp.tool()
-async def read_all_cells() -> list[dict[str, Union[str, int, list[Union[str, ImageContent]]]]]:
+async def read_cells() -> list[dict[str, Union[str, int, list[Union[str, ImageContent]]]]]:
     """Read all cells from the Jupyter notebook.
     Returns:
         list[dict]: List of cell information including index, type, source,
@@ -1151,7 +1151,7 @@ async def execute_ipython(code: str, timeout: int = 60) -> list[Union[str, Image
 
 
 @mcp.tool()
-async def list_all_files(path: str = "", max_depth: int = 3) -> str:
+async def list_files(path: str = "", max_depth: int = 3) -> str:
     """List all files and directories in the Jupyter server's file system.
     
     This tool recursively lists files and directories from the Jupyter server's content API,
@@ -1188,7 +1188,7 @@ async def list_all_files(path: str = "", max_depth: int = 3) -> str:
 
 
 @mcp.tool()
-async def list_kernel() -> str:
+async def list_kernels() -> str:
     """List all available kernels in the Jupyter server.
     
     This tool shows all running and available kernel sessions on the Jupyter server,

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -86,7 +86,7 @@ def windows_timeout_wrapper(timeout_seconds=30):
 JUPYTER_TOOLS = [
     # Multi-Notebook Management Tools
     "connect_notebook",
-    "list_notebook", 
+    "list_notebooks", 
     "restart_notebook",
     "disconnect_notebook",
     "switch_notebook",
@@ -97,13 +97,13 @@ JUPYTER_TOOLS = [
     "execute_cell_with_progress",
     "execute_cell_simple_timeout",
     "execute_cell_streaming",
-    "read_all_cells",
+    "read_cells",
     "list_cell",
     "read_cell",
     "delete_cell",
     "execute_ipython",
-    "list_all_files",
-    "list_kernel",
+    "list_files",
+    "list_kernels",
 ]
 
 
@@ -194,8 +194,8 @@ class MCPClient:
         return self._extract_text_content(result)
     
     @requires_session
-    async def list_notebook(self):
-        result = await self._session.call_tool("list_notebook")  # type: ignore
+    async def list_notebooks(self):
+        result = await self._session.call_tool("list_notebooks")  # type: ignore
         return self._extract_text_content(result)
     
     @requires_session
@@ -229,8 +229,8 @@ class MCPClient:
         return self._get_structured_content_safe(result)
 
     @requires_session
-    async def read_all_cells(self):
-        result = await self._session.call_tool("read_all_cells")  # type: ignore
+    async def read_cells(self):
+        result = await self._session.call_tool("read_cells")  # type: ignore
         return self._get_structured_content_safe(result)
 
     @requires_session
@@ -488,8 +488,8 @@ async def test_markdown_cell(mcp_client, content="Hello **World** !"):
         # TODO: don't now if it's normal to get a list of characters instead of a string
         assert "".join(cell_info["source"]) == content
         # reading all cells
-        result = await mcp_client.read_all_cells()
-        assert result is not None, "read_all_cells result should not be None"
+        result = await mcp_client.read_cells()
+        assert result is not None, "read_cells result should not be None"
         cells_info = result["result"]
         logging.debug(f"cells_info: {cells_info}")
         # Check that our cell is in the expected position with correct content
@@ -533,7 +533,7 @@ async def test_code_cell(mcp_client, content="1 + 1"):
         assert cell_info["type"] == "code"
         assert "".join(cell_info["source"]) == content
         # reading all cells
-        result = await mcp_client.read_all_cells()
+        result = await mcp_client.read_cells()
         cells_info = result["result"]
         logging.debug(f"cells_info: {cells_info}")
         # Check that our cell is in the expected position with correct content
@@ -793,7 +793,7 @@ async def test_multi_notebook_management(mcp_client):
     """Test multi-notebook management functionality"""
     async with mcp_client:
         # Test initial state - should show default notebook or no notebooks
-        initial_list = await mcp_client.list_notebook()
+        initial_list = await mcp_client.list_notebooks()
         logging.debug(f"Initial notebook list: {initial_list}")
         
         # Connect to a new notebook
@@ -803,7 +803,7 @@ async def test_multi_notebook_management(mcp_client):
         assert "new.ipynb" in connect_result
         
         # List notebooks - should now show the connected notebook
-        notebook_list = await mcp_client.list_notebook()
+        notebook_list = await mcp_client.list_notebooks()
         logging.debug(f"Notebook list after connect: {notebook_list}")
         assert "test_notebook" in notebook_list
         assert "new.ipynb" in notebook_list
@@ -848,7 +848,7 @@ async def test_multi_notebook_management(mcp_client):
         assert "disconnected successfully" in disconnect_result
         
         # Verify notebook is no longer in the list
-        final_list = await mcp_client.list_notebook()
+        final_list = await mcp_client.list_notebooks()
         logging.debug(f"Final notebook list: {final_list}")
         if "No notebooks are currently connected" not in final_list:
             assert "test_notebook" not in final_list


### PR DESCRIPTION
One of change in #95 : rename tool names

- Renamed tools for consistency: `list_notebook` to `list_notebooks`, `read_all_cells` to `read_cells`, `list_all_files` to `list_files`, and `list_kernel` to `list_kernels`.
- Updated README and documentation to reflect these changes.
- Bumped version to 0.15.1 and added release notes for the new version.