### PR TITLE
feat: add uvx as alternative MCP server startup method

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,8 @@ FROM python:3.10-slim
 WORKDIR /app
 
 COPY pyproject.toml LICENSE README.md ./
-COPY jupyter_mcp_server/* jupyter_mcp_server/
+COPY jupyter_mcp_server/ jupyter_mcp_server/
+COPY jupyter-config/ jupyter-config/
 
 RUN pip install --no-cache-dir -e . && \
     pip uninstall -y pycrdt datalayer_pycrdt && \

--- a/README.md
+++ b/README.md
@@ -76,7 +76,47 @@ jupyter lab --port 8888 --IdentityProvider.token MY_TOKEN --ip 0.0.0.0
 > - **Flexible:** Even if you set `DOCUMENT_ID`, the MCP client can still browse, list, switch to, or even create new notebooks at any time.
 > 
 
-#### MacOS and Windows
+You can choose between two deployment methods: **uvx** (lightweight and faster, recommended for first try) or **Docker** (recommended for production).
+
+<details>
+
+<summary>using uvx (Quick Start)</summary>
+
+```bash
+pip install uv
+uv --version
+# should be 0.6.14 or higher
+```
+
+see more details on [uv installation](https://docs.astral.sh/uv/getting-started/installation/)
+
+```json
+{
+  "mcpServers": {
+    "jupyter": {
+      "command": "uvx",
+      "args": ["jupyter-mcp-server"],
+      "env": {
+        "DOCUMENT_URL": "http://localhost:8888",
+        "DOCUMENT_TOKEN": "MY_TOKEN",
+        "DOCUMENT_ID": "notebook.ipynb",
+        "RUNTIME_URL": "http://localhost:8888",
+        "RUNTIME_TOKEN": "MY_TOKEN",
+        "ALLOW_IMG_OUTPUT": "true"
+      }
+    }
+  }
+}
+```
+
+</details>
+
+
+<details>
+
+<summary>using Docker (Production)</summary>
+
+**MacOS and Windows**
 
 ```json
 {
@@ -106,7 +146,7 @@ jupyter lab --port 8888 --IdentityProvider.token MY_TOKEN --ip 0.0.0.0
 }
 ```
 
-#### Linux
+**Linux**
 
 ```json
 {
@@ -136,6 +176,8 @@ jupyter lab --port 8888 --IdentityProvider.token MY_TOKEN --ip 0.0.0.0
   }
 }
 ```
+
+</details>
 
 For detailed instructions on configuring various MCP clients—including [Claude Desktop](https://jupyter-mcp-server.datalayer.tech/clients/claude_desktop), [VS Code](https://jupyter-mcp-server.datalayer.tech/clients/vscode), [Cursor](https://jupyter-mcp-server.datalayer.tech/clients/cursor), [Cline](https://jupyter-mcp-server.datalayer.tech/clients/cline), and [Windsurf](https://jupyter-mcp-server.datalayer.tech/clients/windsurf) — see the [Clients documentation](https://jupyter-mcp-server.datalayer.tech/clients).
 

--- a/jupyter_mcp_server/__main__.py
+++ b/jupyter_mcp_server/__main__.py
@@ -2,8 +2,8 @@
 #
 # BSD 3-Clause License
 
-from jupyter_mcp_server.server import start_command
+from jupyter_mcp_server.server import server
 
 if __name__ == "__main__":
     """Start the Jupyter MCP Server."""
-    start_command()
+    server()

--- a/jupyter_mcp_server/__version__.py
+++ b/jupyter_mcp_server/__version__.py
@@ -4,4 +4,4 @@
 
 """Jupyter MCP Server."""
 
-__version__ = "0.15.1"
+__version__ = "0.15.2"

--- a/jupyter_mcp_server/config.py
+++ b/jupyter_mcp_server/config.py
@@ -23,7 +23,7 @@ class JupyterMCPConfig(BaseModel):
     
     # Document configuration
     document_url: str = Field(default="http://localhost:8888", description="The document URL to use, or 'local' for direct serverapp access")
-    document_id: str = Field(default="notebook.ipynb", description="The document id to use")
+    document_id: Optional[str] = Field(default=None, description="The document id to use. Optional - if omitted, can list and select notebooks interactively")
     document_token: Optional[str] = Field(default=None, description="The document token to use for authentication")
     
     # Server configuration
@@ -67,12 +67,12 @@ def set_config(**kwargs) -> JupyterMCPConfig:
         return isinstance(value, str) and value.lower() in ("none", "null", "")
     
     # Filter out string "None" values and let defaults be used instead
-    # For optional fields (tokens, runtime_id), convert to actual None
+    # For optional fields (tokens, runtime_id, document_id), convert to actual None
     normalized_kwargs = {}
     for key, value in kwargs.items():
         if should_skip(value):
             # For optional fields, set to None; for required fields, skip (use default)
-            if key in ("runtime_token", "document_token", "runtime_id"):
+            if key in ("runtime_token", "document_token", "runtime_id", "document_id"):
                 normalized_kwargs[key] = None
             # For required string fields like runtime_url, document_url, skip the key
             # to let the default value be used

--- a/jupyter_mcp_server/tools/assign_kernel_to_notebook_tool.py
+++ b/jupyter_mcp_server/tools/assign_kernel_to_notebook_tool.py
@@ -76,7 +76,8 @@ Returns:
             if mode == ServerMode.MCP_SERVER and server_client is not None:
                 # Check notebook exists using HTTP API
                 try:
-                    server_client.contents.get_file(notebook_path)
+                    # FIXED: contents.get_file -> contents.get
+                    server_client.contents.get(notebook_path)
                 except NotFoundError:
                     return f"Error: Notebook '{notebook_path}' not found on Jupyter server"
             elif mode == ServerMode.JUPYTER_SERVER and contents_manager is not None:

--- a/jupyter_mcp_server/tools/use_notebook_tool.py
+++ b/jupyter_mcp_server/tools/use_notebook_tool.py
@@ -167,11 +167,23 @@ Returns:
         
         # Create notebook if needed
         if use_mode == "create":
+            content = {
+                "cells": [{
+                    "cell_type": "markdown",
+                    "metadata": {},
+                    "source": [
+                        "New Notebook Created by Jupyter MCP Server",
+                    ]
+                }],
+                "metadata": {},
+                "nbformat": 4,
+                "nbformat_minor": 4
+            }
             if mode == ServerMode.JUPYTER_SERVER and contents_manager is not None:
                 # Use local API to create notebook
                 await contents_manager.new(model={'type': 'notebook'}, path=notebook_path)
             elif mode == ServerMode.MCP_SERVER and server_client is not None:
-                server_client.contents.create_notebook(notebook_path)
+                server_client.contents.create_notebook(notebook_path, content=content)
         
         # Create/connect to kernel based on mode
         if mode == ServerMode.JUPYTER_SERVER and kernel_manager is not None:


### PR DESCRIPTION
- Refactor CLI to support direct invocation without subcommands
  - Add invoke_without_command=True to server() group
  - Extract _do_start() for shared startup logic
  - Enable 'uvx jupyter-mcp-server' quick start

- Make document_id optional in configuration
  - Change from required string to Optional[str] with default None
  - Allow interactive notebook selection without pre-specifying document_id
  - Update set_config() to normalize None values properly

- Update documentation
  - Add uvx quick start section with example configuration
  - Organize Docker and uvx methods using collapsible sections
  - Mark uvx as recommended for first-time users
  - Mark Docker as recommended for production deployments

- Bug fixes
  - Fix assign_kernel_to_notebook: contents.get_file -> contents.get
  - Improve use_notebook: add proper initial content for new notebooks

- Other improvements
  - Update Dockerfile to include jupyter-config directory
  - Bump version from 0.15.1 to 0.15.2
  - Maintain backward compatibility with all existing commands