### PR TITLE
Fix: Unify remote file paths for cross-platform compatibility

### DIFF
--- a/jupyter_mcp_server/__version__.py
+++ b/jupyter_mcp_server/__version__.py
@@ -4,4 +4,4 @@
 
 """Jupyter MCP Server."""
 
-__version__ = "0.15.3"
+__version__ = "0.15.4"

--- a/jupyter_mcp_server/tools/use_notebook_tool.py
+++ b/jupyter_mcp_server/tools/use_notebook_tool.py
@@ -45,7 +45,7 @@ Returns:
         """Check if path exists using HTTP API."""
         path = Path(notebook_path)
         try:
-            parent_path = str(path.parent) if str(path.parent) != "." else ""
+            parent_path = path.parent.as_posix() if path.parent.as_posix() != "." else ""
             
             if parent_path:
                 dir_contents = server_client.contents.list_directory(parent_path)
@@ -59,7 +59,7 @@ Returns:
             
             return True, None
         except NotFoundError:
-            parent_dir = str(path.parent) if str(path.parent) != "." else "root directory"
+            parent_dir = path.parent.as_posix() if path.parent.as_posix() != "." else "root directory"
             return False, f"'{parent_dir}' not found in jupyter server, please check the directory path already exists."
         except Exception as e:
             return False, f"Failed to check the path '{notebook_path}': {e}"


### PR DESCRIPTION
This change addresses an bug where file paths could be inconsistent when connecting from a Windows client to a Jupyter Lab on a Linux host server on remote connection.

The primary modification is in the 'use_notebook_tool.py' file, where 'path.parent' is now explicitly converted to a POSIX-standard path using '.as_posix()'. This ensures that the directory paths sent to the Jupyter server use forward slashes ('/'), regardless of the client's operating system.