### PR TITLE
Fix duplicate kernel creation bug in use_notebook tool

### DIFF
--- a/jupyter_mcp_server/tools/use_notebook_tool.py
+++ b/jupyter_mcp_server/tools/use_notebook_tool.py
@@ -213,7 +213,8 @@ class UseNotebookTool(BaseTool):
                     kernel = {"id": kernel_id}
                 else:
                     kernel = await self._start_kernel_local(kernel_manager)
-                
+                    kernel_id = kernel['id']
+
                 info_list.append(f"[INFO] Connected to kernel '{kernel_id}'.")
                 # Create a Jupyter session to associate the kernel with the notebook
                 # This is CRITICAL for JupyterLab to recognize the kernel-notebook connection


### PR DESCRIPTION
Fixed a bug where kernel_id variable was not being updated after creating a new kernel in JUPYTER_SERVER mode. This caused create_session() to receive None as kernel_id, which resulted in creating a second kernel while the first kernel remained unused.

The fix ensures that when a new kernel is created via _start_kernel_local(), the kernel_id variable is properly assigned from the returned kernel dictionary.
