### PR TITLE
Fix test_jupyter_cite failing when both test modes run together

### DIFF
--- a/tests/test_prompts.py
+++ b/tests/test_prompts.py
@@ -21,23 +21,23 @@ pytestmark = pytest.mark.skipif(
 
 @pytest.mark.asyncio
 @timeout_wrapper(60)
-async def test_jupyter_cite(mcp_client_parametrized: MCPClient):
+async def test_jupyter_cite(mcp_client: MCPClient):
     """Test jupyter cite prompt feature"""
-    async with mcp_client_parametrized:
-        await mcp_client_parametrized.use_notebook("new", "new.ipynb")
-        await mcp_client_parametrized.use_notebook("notebook", "notebook.ipynb")
+    async with mcp_client:
+        await mcp_client.use_notebook("new", "new.ipynb")
+        await mcp_client.use_notebook("notebook", "notebook.ipynb")
         # Test prompt injection
-        response = await mcp_client_parametrized.jupyter_cite(prompt="test prompt", cell_indices="0")
+        response = await mcp_client.jupyter_cite(prompt="test prompt", cell_indices="0")
         assert "# Matplotlib Examples" in response[0], "Cell 0 should contain Matplotlib Examples"
         assert "test prompt" in response[0], "Prompt should be injected"
         # Test mixed cell_indices
-        response = await mcp_client_parametrized.jupyter_cite(prompt="", cell_indices="0-2,4")
+        response = await mcp_client.jupyter_cite(prompt="", cell_indices="0-2,4")
         assert "USER Cite cells [0, 1, 2, 4]" in response[0], "Cell indices should be [0, 1, 2, 4]"
         assert "## 1. Import Required Libraries" in response[0], "Cell 1 should contain Import Required Libraries"
         assert "%matplotlib inline" in response[0], "Cell 2 should contain %matplotlib inline"
         assert "## 2. Basic Line Plot" not in response[0], "Cell 3 should not be cited"
         assert "y = np.sin(x)" in response[0], "Cell 4 should contain y = np.sin(x)"
         # Test cite other notebook
-        response = await mcp_client_parametrized.jupyter_cite(prompt="", cell_indices="0", notebook_name="new")
+        response = await mcp_client.jupyter_cite(prompt="", cell_indices="0", notebook_name="new")
         assert "from notebook new" in response[0], "should cite new notebook"
         assert "# A New Notebook" in response[0], "Cell 0 of new notebook should contain A New Notebook"


### PR DESCRIPTION
## Summary

- Switch `test_jupyter_cite` from `mcp_client_parametrized` to `mcp_client` fixture

## Why

`make test` (which sets both `TEST_MCP_SERVER=true` and `TEST_JUPYTER_SERVER=true`) always fails, while CI doesn't hit this because it runs `make test-mcp-server` and `make test-jupyter-server` separately.

`test_jupyter_cite` uses `mcp_client_parametrized`, which injects both `mcp_server` and `jupyter_extension` params. But prompts are only supported in MCP_SERVER mode — the `jupyter_extension` variant always fails with `Method not found: prompts/get`.

The module-level `pytestmark` skipif only guards against `TEST_MCP_SERVER=false`, it doesn't filter out the `jupyter_extension` parametrization. The fix is to use the `mcp_client` fixture, which only targets the standalone MCP server — matching the test's intent.

## Test plan

- [x] `make test` passes (142 passed, 0 failed)
- [x] Verified failure is pre-existing on unmodified code