### PR TITLE
pyproject: drop stale test pins and unused datalayer_pycrdt

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,9 +45,8 @@ test = [
     "pytest>=7.0", 
     "pytest-asyncio",
     "pytest-timeout>=2.1.0",
-    "jupyterlab==4.4.1",
-    "jupyter-collaboration==4.0.2",
-    "datalayer_pycrdt==0.12.17",
+    "jupyterlab",
+    "jupyter-collaboration",
     "pillow>=10.0.0"
 ]
 lint = ["mdformat>0.7", "mdformat-gfm>=0.3.5", "ruff"]


### PR DESCRIPTION
## Summary

- Unpin `jupyterlab` (was `==4.4.1`) and `jupyter-collaboration` (was `==4.0.2`) in the `test` extra — the exact pins look stale and aren't guarding a known incompatibility.
- Remove `datalayer_pycrdt==0.12.17` from the `test` extra; #241 switched the project to upstream `pycrdt`, so this dependency is no longer used.

## Test plan

- [ ] CI test matrix passes against the unpinned `jupyterlab` / `jupyter-collaboration` versions
- [ ] No remaining references to `datalayer_pycrdt` in the codebase