### PR TITLE
feat: add password-based authentication support

### DIFF
--- a/docs/docs/reference/configuration/index.mdx
+++ b/docs/docs/reference/configuration/index.mdx
@@ -52,11 +52,12 @@ For most users with standard JupyterLab setups:
 |----------|-------------|---------|---------|----------|
 | `JUPYTER_URL` | URL of your Jupyter server | `http://localhost:8888` | `http://localhost:8888` | No |
 | `JUPYTER_TOKEN` | Authentication token for Jupyter server | `my-secret-token` | `None` | No* |
+| `JUPYTER_PASSWORD` | Password for Jupyter server authentication (alternative to token) | `my-password` | `None` | No* |
 | `DOCUMENT_ID` | Default notebook path (relative to Jupyter root) | `notebook.ipynb` | `None` | No |
 | `ALLOWED_JUPYTER_MCP_TOOLS` | Comma-separated list of jupyter-mcp-tools to enable | `notebook_run-all-cells,notebook_get-selected-cell` | `notebook_run-all-cells,notebook_get-selected-cell` | No |
 | `ALLOW_IMG_OUTPUT` | Enable multimodal image support | `true` / `false` | `true` | No |
 
-*Required for authentication when connecting to secured Jupyter servers
+*At least one of `JUPYTER_TOKEN` or `JUPYTER_PASSWORD` is required when connecting to a secured Jupyter server. They are independent authentication mechanisms — a server may have both configured, and supplying either one is sufficient to connect. When both are provided to the MCP server, password authentication takes precedence. See [Security](../security) for details on when to use each.
 
 ### Advanced Configuration (Complex Deployments)
 
@@ -67,6 +68,7 @@ For deployments requiring granular control over document storage and runtime exe
 |----------|-------------|---------|---------|
 | `DOCUMENT_URL` | URL for notebook file operations | `http://notebook-storage:8888` | `http://localhost:8888` |
 | `DOCUMENT_TOKEN` | Authentication for document operations | `storage-access-token` | `None` |
+| `DOCUMENT_PASSWORD` | Password for document server authentication (alternative to token) | `storage-password` | `None` |
 | `DOCUMENT_ID` | Notebook path/ID | `shared/analysis.ipynb` | `None` |
 
 #### Runtime Execution Variables
@@ -74,6 +76,7 @@ For deployments requiring granular control over document storage and runtime exe
 |----------|-------------|---------|---------|
 | `RUNTIME_URL` | URL for kernel/execution operations | `http://compute-cluster:8888` | `http://localhost:8888` |
 | `RUNTIME_TOKEN` | Authentication for runtime operations | `compute-access-token` | `None` |
+| `RUNTIME_PASSWORD` | Password for runtime server authentication (alternative to token) | `compute-password` | `None` |
 | `RUNTIME_ID` | Specific kernel ID to use | `kernel-abc123` | `None` |
 
 #### MCP Client Authentication
@@ -173,6 +176,10 @@ Variables are resolved in this order:
 2. **Simplified variables** (`JUPYTER_*`) - fallback
 3. **Default values** - when no variables are set
 
+This applies to tokens, passwords, and URLs alike. For example, `RUNTIME_PASSWORD` takes precedence over `JUPYTER_PASSWORD` for runtime server authentication.
+
+When both a password and a token are configured for the same server, password authentication takes precedence and the token is ignored.
+
 ## Configuration Examples
 
 ### Standard JupyterLab Setup
@@ -202,6 +209,13 @@ RUNTIME_TOKEN=compute-access-token
 ALLOW_IMG_OUTPUT=false
 ```
 
+### Password-Protected Jupyter Server
+```bash
+JUPYTER_URL=http://localhost:8888
+JUPYTER_PASSWORD=my-jupyter-password
+DOCUMENT_ID=my-notebook.ipynb
+```
+
 ### Development Setup
 ```bash
 JUPYTER_URL=http://localhost:8888
@@ -224,6 +238,7 @@ Options:
   --jupyterlab BOOLEAN               Enable JupyterLab mode (default: true)
   --runtime-url TEXT                  Runtime URL for kernel operations (default: None)
   --runtime-token TEXT                Runtime authentication token (default: None)
+  --runtime-password TEXT             Password for runtime Jupyter server authentication (default: None)
   --mcp-token TEXT                    Token for authenticating MCP clients (required unless --insecure-mcp-noauth)
   --insecure-mcp-noauth               Allow streamable-http without MCP client auth (not recommended)
   --runtime-id TEXT                   Specific kernel ID to use (default: None)
@@ -231,8 +246,10 @@ Options:
   --document-url TEXT                 Document URL for notebook operations (default: None)
   --document-id TEXT                  Notebook path/ID (default: None)
   --document-token TEXT               Document authentication token (default: None)
+  --document-password TEXT            Password for document Jupyter server authentication (default: None)
   --jupyter-url TEXT                  Jupyter URL as default for both document and runtime URLs (default: None)
   --jupyter-token TEXT                Jupyter token as default for both document and runtime tokens (default: None)
+  --jupyter-password TEXT             Shared password for both runtime and document servers (default: None)
   --allowed-jupyter-mcp-tools TEXT    Comma-separated list of jupyter-mcp-tools to enable (default: notebook_run-all-cells,notebook_get-selected-cell)
   --reconnect-interval INTEGER         Seconds before retrying a dropped kernel WebSocket connection (default: 0)
   --execution-timeout INTEGER RANGE   Default timeout in seconds for code execution when a tool call passes no timeout (default: 120)

--- a/docs/docs/reference/security/index.mdx
+++ b/docs/docs/reference/security/index.mdx
@@ -161,28 +161,117 @@ Cross-Site Request Forgery (XSRF/CSRF) protection prevents unauthorized commands
 As described in [issue #183](https://github.com/datalayer/jupyter-mcp-server/issues/183), some Jupyter deployments don't use Bearer tokens but rely on XSRF cookies for authentication:
 
 **Affected Environments:**
-- Jupyter servers started without a token: `jupyter lab --IdentityProvider.token ''`
+- Jupyter servers that run without a Bearer token (for example, password-protected servers)
 - Enterprise deployments with SSO/OAuth/IAM
 - Managed environments (AWS SageMaker Studio, Google Colab Enterprise, Azure ML)
 - JupyterHub where authentication is handled by the Hub
 
-### Current Limitations
+## Password Authentication
 
-:::info Current Status
+For Jupyter servers configured with password-based login (instead of or in addition to tokens), the MCP server can authenticate by performing the standard Jupyter `/login` flow and using the resulting session cookies for all subsequent requests.
 
-**Bearer Token Required**: Currently, Jupyter MCP Server requires a Bearer token (`JUPYTER_TOKEN`) to authenticate with the Jupyter collaboration API.
+This is useful when:
+- Your Jupyter server uses a password set via `jupyter server password` or `--ServerApp.password`
+- You don't have a Bearer token available
+- Your deployment relies on XSRF cookie protection
 
-**Issue**: The server fails with `403 Forbidden` when connecting to Jupyter deployments that use XSRF protection without Bearer tokens.
+### How It Works
 
-**Tracking**: We're working on automatic XSRF cookie handling - see [issue #183](https://github.com/datalayer/jupyter-mcp-server/issues/183) for details.
+1. The MCP server POSTs to `/login` on the Jupyter server with the configured password
+2. Jupyter returns session cookies (including the `_xsrf` token)
+3. These cookies are injected into all HTTP requests (API calls, kernel operations) and WebSocket connections (notebook collaboration)
+4. The `X-XSRFToken` header is automatically included in requests that require XSRF protection
+
+### Configuration
+
+#### Simplified (Same Password for Both Servers)
+
+When document storage and runtime execution use the same Jupyter server:
+
+```json
+{
+  "env": {
+    "JUPYTER_URL": "http://localhost:8888",
+    "JUPYTER_PASSWORD": "my-jupyter-password"
+  }
+}
+```
+
+Or via CLI:
+
+```bash
+jupyter-mcp-server start \
+  --jupyter-url http://localhost:8888 \
+  --jupyter-password my-jupyter-password
+```
+
+#### Advanced (Separate Passwords)
+
+For deployments where document and runtime servers have different passwords:
+
+```json
+{
+  "env": {
+    "DOCUMENT_URL": "http://storage-server:8888",
+    "DOCUMENT_PASSWORD": "storage-password",
+    "RUNTIME_URL": "http://compute-server:8888",
+    "RUNTIME_PASSWORD": "compute-password"
+  }
+}
+```
+
+### Password vs Token
+
+| | Token Auth | Password Auth |
+|---|---|---|
+| **Mechanism** | Bearer token in `Authorization` header | Session cookies + XSRF token |
+| **Setup** | `--IdentityProvider.token MY_TOKEN` | `jupyter server password` |
+| **Best for** | API access, automation, JupyterHub | Local servers, password-protected deployments |
+| **XSRF handling** | Not needed (token bypasses XSRF) | Automatic (cookies include XSRF) |
+
+:::info Priority
+
+When both a password and a token are configured for the same server, **password authentication takes precedence**. The token is ignored and a warning is logged. This avoids ambiguity about which authentication method is active.
 
 :::
 
-### Workarounds for XSRF-only Environments
+### Setting a Jupyter Server Password
 
-Until automatic XSRF handling is implemented, you have these options:
+If your Jupyter server doesn't have a password configured yet:
 
-#### Option 1: Start Jupyter with a Token (Recommended)
+```bash
+# Interactive prompt to set a password
+jupyter server password
+```
+
+This stores a hashed password in `~/.jupyter/jupyter_server_config.json`. Then start Jupyter normally — the password is active immediately, so the MCP server can authenticate against it:
+
+```bash
+jupyter lab
+```
+
+:::warning Keep the token configured
+
+Do **not** blank out the server token (e.g. `--IdentityProvider.token ''`) just to enable password
+auth. Token and password are independent mechanisms — password auth works whether or not a token is
+set. Leaving a token in place keeps a working fallback: if password authentication ever fails, the
+server still requires *some* credential rather than being left open with no authentication at all.
+
+:::
+
+### Limitations
+
+:::info Partial Coverage of Issue #183
+
+Password authentication addresses the XSRF-protected scenario described in [issue #183](https://github.com/datalayer/jupyter-mcp-server/issues/183) for password-protected Jupyter servers. Other scenarios mentioned in that issue — SSO/OAuth, IAM-based auth in managed environments — are not yet supported.
+
+:::
+
+### Alternatives to Password Authentication
+
+If password auth doesn't fit your deployment, you can authenticate with a token instead (or, for development only, disable XSRF):
+
+#### Option 1: Token-based Authentication
 
 ```bash
 jupyter lab --IdentityProvider.token YOUR_SECURE_TOKEN

--- a/jupyter_mcp_server/auth.py
+++ b/jupyter_mcp_server/auth.py
@@ -1,0 +1,197 @@
+# Copyright (c) 2024- Datalayer, Inc.
+#
+# BSD 3-Clause License
+
+"""Authentication utilities for Jupyter server password login."""
+
+from typing import Optional
+
+import requests
+
+from jupyter_mcp_server.log import logger
+
+
+_BODY_PREVIEW_CHARS = 200
+
+
+def _truncate(text: str) -> str:
+    """Trim a response body for inclusion in an error message."""
+    if not text:
+        return "<empty>"
+    snippet = text.strip().replace("\n", " ")
+    if len(snippet) <= _BODY_PREVIEW_CHARS:
+        return repr(snippet)
+    return repr(snippet[:_BODY_PREVIEW_CHARS] + "…")
+
+
+class JupyterPasswordAuth:
+    """Handles password-based authentication with a Jupyter server.
+
+    Performs POST /login with the password, then keeps a `requests.Session`
+    alive so cookies refreshed by the server during subsequent requests are
+    visible via `live_headers()`. Use `inject_into_session()` to copy cookies
+    into another `Session` (e.g. the one inside `JupyterServerClient`).
+    """
+
+    def __init__(self, server_url: str, password: str):
+        self.server_url = server_url.rstrip("/")
+        self.password = password
+        self._session: Optional[requests.Session] = None
+        self._xsrf_token: Optional[str] = None
+        self._authenticated = False
+
+    def _do_request(self, method: str, url: str, stage: str, timeout: float, **kwargs):
+        """Wrap session.request with consistent error translation per stage."""
+        assert self._session is not None  # set by login() before calling
+        try:
+            return self._session.request(method, url, timeout=timeout, **kwargs)
+        except requests.exceptions.Timeout as error:
+            raise RuntimeError(
+                f"Timed out during {stage} ({method} {url}) after {timeout}s: {error}"
+            ) from error
+        except requests.exceptions.ConnectionError as error:
+            raise RuntimeError(
+                f"Connection error during {stage} ({method} {url}): {error}"
+            ) from error
+
+    def login(self, timeout: float = 10.0) -> None:
+        """Perform the /login POST to obtain session cookies.
+
+        Args:
+            timeout: Per-request timeout in seconds (applied to GET /login,
+                POST /login, and the verification GET /api/status).
+
+        Raises:
+            RuntimeError: If login fails (connection, timeout, bad credentials,
+                server error, or missing XSRF cookie).
+        """
+        # Build the session and only retain it on success — on failure, close
+        # it so we don't leak connections.
+        session = requests.Session()
+        self._session = session
+        try:
+            # GET /login to obtain the initial _xsrf cookie. Disable redirects
+            # so we don't silently follow to a different origin (e.g. JupyterHub).
+            self._do_request(
+                "GET", f"{self.server_url}/login",
+                stage="initial XSRF fetch", timeout=timeout,
+                allow_redirects=False,
+            )
+            xsrf = session.cookies.get("_xsrf", "")
+
+            # POST /login with password (and _xsrf if present).
+            post_data = {"password": self.password}
+            if xsrf:
+                post_data["_xsrf"] = xsrf
+            response = self._do_request(
+                "POST", f"{self.server_url}/login",
+                stage="login POST", timeout=timeout,
+                data=post_data, allow_redirects=False,
+            )
+            if response.status_code >= 500:
+                raise RuntimeError(
+                    f"Jupyter server returned {response.status_code} on /login — "
+                    f"the server is failing, not an auth problem. "
+                    f"Body: {_truncate(response.text)}"
+                )
+            if response.status_code not in (200, 302):
+                raise RuntimeError(
+                    f"Password login failed with status {response.status_code}. "
+                    f"Check that the Jupyter server is configured for password auth. "
+                    f"Body: {_truncate(response.text)}"
+                )
+
+            # Verify we actually got authenticated by testing the API.
+            # Distinguish 401/403 (bad credentials) from other failure modes.
+            verify = self._do_request(
+                "GET", f"{self.server_url}/api/status",
+                stage="session verification", timeout=timeout,
+            )
+            if verify.status_code in (401, 403):
+                raise RuntimeError(
+                    f"Password login did not produce a valid session "
+                    f"(GET /api/status returned {verify.status_code}). "
+                    f"The password may be incorrect. Body: {_truncate(verify.text)}"
+                )
+            if verify.status_code >= 500:
+                raise RuntimeError(
+                    f"Jupyter server returned {verify.status_code} on /api/status — "
+                    f"the server is failing, not an auth problem. "
+                    f"Body: {_truncate(verify.text)}"
+                )
+            if verify.status_code != 200:
+                raise RuntimeError(
+                    f"Unexpected status {verify.status_code} from /api/status "
+                    f"while verifying the login session. Body: {_truncate(verify.text)}"
+                )
+
+            self._xsrf_token = session.cookies.get("_xsrf", "")
+            if not self._xsrf_token:
+                raise RuntimeError(
+                    "Login succeeded but no _xsrf cookie was set. "
+                    "XSRF-protected POST requests would deterministically fail; "
+                    "refusing to proceed. Check the Jupyter server's XSRF configuration."
+                )
+            self._authenticated = True
+            logger.info(f"Password authentication successful for {self.server_url}")
+        except BaseException:
+            session.close()
+            self._session = None
+            raise
+
+    def close(self) -> None:
+        """Close the underlying session. Safe to call multiple times."""
+        if self._session is not None:
+            self._session.close()
+            self._session = None
+        self._authenticated = False
+
+    def _live_cookies(self) -> dict[str, str]:
+        """Snapshot the current cookie jar (post-login, may include refreshes)."""
+        if self._session is None:
+            return {}
+        return dict(self._session.cookies)
+
+    @property
+    def cookie_header(self) -> str:
+        """Cookie header value built from the current (live) cookie jar."""
+        return "; ".join(f"{name}={value}" for name, value in self._live_cookies().items())
+
+    def get_headers(self) -> dict[str, str]:
+        """Return headers dict with Cookie and X-XSRFToken for injection.
+
+        Reads the live cookie jar so a refreshed `_xsrf` is picked up.
+        Returns an empty dict if `login()` has not been called or has failed.
+        """
+        if not self._authenticated:
+            return {}
+        cookies = self._live_cookies()
+        if not cookies:
+            return {}
+        headers = {"Cookie": "; ".join(f"{name}={value}" for name, value in cookies.items())}
+        xsrf = cookies.get("_xsrf", "")
+        if xsrf:
+            headers["X-XSRFToken"] = xsrf
+        return headers
+
+    def relogin(self, timeout: float = 10.0) -> None:
+        """Re-authenticate after session expiry. Closes the current session and logs in again.
+
+        Raises the same errors as `login()` if the new login fails.
+        """
+        self.close()
+        self.login(timeout=timeout)
+
+    def inject_into_session(self, session: requests.Session) -> None:
+        """Copy current cookies into another session.
+
+        Deliberately does NOT set `X-XSRFToken` as a default header — if the
+        server ever rotates the `_xsrf` cookie, a frozen header value would go
+        stale. Callers that need the XSRF token per-request must read it from
+        the live cookie jar (see `ServerContext.runtime_auth_headers`) or call
+        `get_headers()` on this auth.
+        """
+        if not self._authenticated:
+            return
+        for name, value in self._live_cookies().items():
+            session.cookies.set(name, value)

--- a/jupyter_mcp_server/cli/commands/serve.py
+++ b/jupyter_mcp_server/cli/commands/serve.py
@@ -30,13 +30,16 @@ def _resolve_and_start(
     runtime_url: str | None,
     runtime_id: str | None,
     runtime_token: str | None,
+    runtime_password: str | None,
     mcp_token: str | None,
     insecure_mcp_noauth: bool,
     document_url: str | None,
     document_id: str | None,
     document_token: str | None,
+    document_password: str | None,
     jupyter_url: str | None,
     jupyter_token: str | None,
+    jupyter_password: str | None,
     port: int,
     provider: str,
     jupyterlab: str,
@@ -66,15 +69,23 @@ def _resolve_and_start(
         runtime_token=runtime_token,
     )
 
+    # Passwords mirror the token precedence: an individual --{runtime,document}-password
+    # wins, otherwise the shared --jupyter-password is used as the fallback. Passwords
+    # take precedence over tokens at the auth layer (see JupyterPasswordAuth).
+    resolved_document_password = document_password or jupyter_password
+    resolved_runtime_password = runtime_password or jupyter_password
+
     do_start(
         transport=transport,
         start_new_runtime=parse_bool_option(start_new_runtime, "--start-new-runtime"),
         runtime_url=resolved_runtime_url,
         runtime_id=runtime_id,
         runtime_token=resolved_runtime_token,
+        runtime_password=resolved_runtime_password,
         document_url=resolved_document_url,
         document_id=document_id,
         document_token=resolved_document_token,
+        document_password=resolved_document_password,
         port=port,
         provider=provider,
         jupyterlab=parse_bool_option(jupyterlab, "--jupyterlab"),
@@ -176,6 +187,14 @@ def server_callback(
             help="The runtime token to use for authentication with the provider. If not provided, the provider should accept anonymous requests.",
         ),
     ] = None,
+    runtime_password: Annotated[
+        str | None,
+        typer.Option(
+            "--runtime-password",
+            envvar="RUNTIME_PASSWORD",
+            help="Password for runtime Jupyter server authentication. Takes precedence over --runtime-token if both are set.",
+        ),
+    ] = None,
     mcp_token: Annotated[
         str | None,
         typer.Option(
@@ -216,6 +235,14 @@ def server_callback(
             help="The document token to use for authentication with the provider. If not provided, the provider should accept anonymous requests.",
         ),
     ] = None,
+    document_password: Annotated[
+        str | None,
+        typer.Option(
+            "--document-password",
+            envvar="DOCUMENT_PASSWORD",
+            help="Password for document Jupyter server authentication. Takes precedence over --document-token if both are set.",
+        ),
+    ] = None,
     jupyter_url: Annotated[
         str | None,
         typer.Option(
@@ -230,6 +257,14 @@ def server_callback(
             "--jupyter-token",
             envvar="JUPYTER_TOKEN",
             help="The Jupyter token to use as default for both document and runtime tokens. If not provided, individual token settings take precedence.",
+        ),
+    ] = None,
+    jupyter_password: Annotated[
+        str | None,
+        typer.Option(
+            "--jupyter-password",
+            envvar="JUPYTER_PASSWORD",
+            help="Shared password for both runtime and document servers (fallback if individual passwords not set). Takes precedence over --jupyter-token if both are set.",
         ),
     ] = None,
     allowed_jupyter_mcp_tools: Annotated[
@@ -322,13 +357,16 @@ def server_callback(
         runtime_url=runtime_url,
         runtime_id=runtime_id,
         runtime_token=runtime_token,
+        runtime_password=runtime_password,
         mcp_token=mcp_token,
         insecure_mcp_noauth=insecure_mcp_noauth,
         document_url=document_url,
         document_id=document_id,
         document_token=document_token,
+        document_password=document_password,
         jupyter_url=jupyter_url,
         jupyter_token=jupyter_token,
+        jupyter_password=jupyter_password,
         port=port,
         provider=provider.value,
         jupyterlab=jupyterlab,
@@ -427,6 +465,14 @@ def start_command(
             help="The runtime token to use for authentication with the provider. If not provided, the provider should accept anonymous requests.",
         ),
     ] = None,
+    runtime_password: Annotated[
+        str | None,
+        typer.Option(
+            "--runtime-password",
+            envvar="RUNTIME_PASSWORD",
+            help="Password for runtime Jupyter server authentication. Takes precedence over --runtime-token if both are set.",
+        ),
+    ] = None,
     mcp_token: Annotated[
         str | None,
         typer.Option(
@@ -467,6 +513,14 @@ def start_command(
             help="The document token to use for authentication with the provider. If not provided, the provider should accept anonymous requests.",
         ),
     ] = None,
+    document_password: Annotated[
+        str | None,
+        typer.Option(
+            "--document-password",
+            envvar="DOCUMENT_PASSWORD",
+            help="Password for document Jupyter server authentication. Takes precedence over --document-token if both are set.",
+        ),
+    ] = None,
     jupyter_url: Annotated[
         str | None,
         typer.Option(
@@ -481,6 +535,14 @@ def start_command(
             "--jupyter-token",
             envvar="JUPYTER_TOKEN",
             help="The Jupyter token to use as default for both document and runtime tokens. If not provided, individual token settings take precedence.",
+        ),
+    ] = None,
+    jupyter_password: Annotated[
+        str | None,
+        typer.Option(
+            "--jupyter-password",
+            envvar="JUPYTER_PASSWORD",
+            help="Shared password for both runtime and document servers (fallback if individual passwords not set). Takes precedence over --jupyter-token if both are set.",
         ),
     ] = None,
     allowed_jupyter_mcp_tools: Annotated[
@@ -570,13 +632,16 @@ def start_command(
         runtime_url=runtime_url,
         runtime_id=runtime_id,
         runtime_token=runtime_token,
+        runtime_password=runtime_password,
         mcp_token=mcp_token,
         insecure_mcp_noauth=insecure_mcp_noauth,
         document_url=document_url,
         document_id=document_id,
         document_token=document_token,
+        document_password=document_password,
         jupyter_url=jupyter_url,
         jupyter_token=jupyter_token,
+        jupyter_password=jupyter_password,
         port=port,
         provider=provider.value,
         jupyterlab=jupyterlab,

--- a/jupyter_mcp_server/config.py
+++ b/jupyter_mcp_server/config.py
@@ -30,6 +30,10 @@ class JupyterMCPConfig(BaseModel):
     runtime_token: str | None = Field(
         default=None, description="The runtime token to use for authentication"
     )
+    runtime_password: str | None = Field(
+        default=None,
+        description="Password for Jupyter server authentication (alternative to token)",
+    )
 
     # Sandbox variant configuration
     sandbox_variant: str = Field(
@@ -76,6 +80,10 @@ class JupyterMCPConfig(BaseModel):
     )
     document_token: str | None = Field(
         default=None, description="The document token to use for authentication"
+    )
+    document_password: str | None = Field(
+        default=None,
+        description="Password for Jupyter document server authentication (alternative to token)",
     )
 
     # Server configuration
@@ -194,7 +202,7 @@ def set_config(**kwargs) -> JupyterMCPConfig:
     for key, value in kwargs.items():
         if should_skip(value):
             # For optional fields, set to None; for required fields, skip (use default)
-            if key in ("runtime_token", "document_token", "runtime_id", "document_id"):
+            if key in ("runtime_token", "document_token", "runtime_id", "document_id", "runtime_password", "document_password"):
                 normalized_kwargs[key] = None
             # For required string fields like runtime_url, document_url, skip the key
             # to let the default value be used

--- a/jupyter_mcp_server/enroll.py
+++ b/jupyter_mcp_server/enroll.py
@@ -94,6 +94,7 @@ async def auto_enroll_document(
             notebook_manager=notebook_manager,
             runtime_url=config.runtime_url if config.runtime_url != "local" else None,
             runtime_token=config.runtime_token,
+            auth_headers=server_context.runtime_auth_headers or None,
         )
         logger.info(f"Auto-enrollment result: {result}")
     except Exception as e:

--- a/jupyter_mcp_server/notebook_manager.py
+++ b/jupyter_mcp_server/notebook_manager.py
@@ -17,6 +17,8 @@ import logging
 from types import TracebackType
 from typing import Any, Dict, Optional, TYPE_CHECKING, Union
 
+import requests
+
 from jupyter_nbmodel_client import NbModelClient, get_notebook_websocket_url
 
 from .config import get_config
@@ -57,15 +59,59 @@ class NotebookConnection:
             )
 
         config = get_config()
-        ws_url = get_notebook_websocket_url(
-            server_url=self.notebook_info.get("server_url", config.document_url),
-            token=self.notebook_info.get("token", config.document_token),
-            path=self.notebook_info.get("path", config.document_id),
-            provider=config.provider,
+        server_url = self.notebook_info.get("server_url", config.document_url)
+        token = self.notebook_info.get("token", config.document_token)
+        path = self.notebook_info.get("path", config.document_id)
+
+        from jupyter_mcp_server.server_context import ServerContext
+        server_context = ServerContext.get_instance()
+        auth_headers = server_context.document_auth_headers
+
+        ws_url = self._get_ws_url(server_url, token, path, config, auth_headers)
+        # _get_ws_url may have re-authenticated on an expired cookie; re-read the
+        # (possibly rotated) cookie so the WebSocket handshake uses a fresh one
+        # rather than the snapshot captured before any relogin.
+        auth_headers = server_context.document_auth_headers
+        websocket_headers = (
+            {"Cookie": auth_headers["Cookie"]}
+            if auth_headers and "Cookie" in auth_headers
+            else None
         )
-        self._notebook = NbModelClient(ws_url)
+        self._notebook = NbModelClient(ws_url, additional_headers=websocket_headers)
         await self._notebook.__aenter__()
         return self._notebook
+
+    def _get_ws_url(self, server_url, token, path, config, auth_headers):
+        """Fetch the collaboration WebSocket URL, retrying once after a re-login
+        if the session cookie has expired (HTTP 401 or 403 on the session PUT).
+        """
+        from jupyter_mcp_server.server_context import ServerContext
+
+        try:
+            return get_notebook_websocket_url(
+                server_url=server_url,
+                token=token,
+                path=path,
+                provider=config.provider,
+                headers=auth_headers or None,
+            )
+        except requests.HTTPError as error:
+            if error.response is None or error.response.status_code not in (401, 403):
+                raise
+            logger.warning(
+                "Collaboration session request returned %s — session cookie likely "
+                "expired. Re-authenticating and retrying.",
+                error.response.status_code,
+            )
+            ServerContext.get_instance().relogin_document()
+            fresh_headers = ServerContext.get_instance().document_auth_headers
+            return get_notebook_websocket_url(
+                server_url=server_url,
+                token=token,
+                path=path,
+                provider=config.provider,
+                headers=fresh_headers or None,
+            )
 
     async def __aexit__(
         self, exc_type: type | None, exc_val: BaseException | None, exc_tb: TracebackType | None

--- a/jupyter_mcp_server/sandbox_client.py
+++ b/jupyter_mcp_server/sandbox_client.py
@@ -63,12 +63,18 @@ def create_jupyter_sandbox_client(
     path: str | None = None,
     timeout: float | None = None,
     reconnect_interval: int = 0,
+    headers: dict[str, str] | None = None,
     logger: logging.Logger | None = None,
 ) -> ISandboxClient:
     """Build and start a jupyter sandbox, then return its plain kernel client.
 
     When ``kernel_id`` is provided, the client connects to that specific
     existing kernel; otherwise a new kernel is created.
+
+    ``headers`` carries extra HTTP headers for every request the sandbox makes,
+    used by password auth to pass the session Cookie and the matching
+    X-XSRFToken. A password-authenticated server has no token, so callers pass
+    ``token=None`` alongside and let the headers authenticate.
     """
     from code_sandboxes import Sandbox
 
@@ -91,6 +97,8 @@ def create_jupyter_sandbox_client(
         create_kwargs["timeout"] = float(timeout)
     if client_kwargs:
         create_kwargs["client_kwargs"] = client_kwargs
+    if headers:
+        create_kwargs["headers"] = dict(headers)
 
     sandbox = Sandbox.create(**create_kwargs)
     try:

--- a/jupyter_mcp_server/server.py
+++ b/jupyter_mcp_server/server.py
@@ -444,6 +444,7 @@ async def use_notebook(
             notebook_manager=notebook_manager,
             runtime_url=config.runtime_url if config.runtime_url != "local" else None,
             runtime_token=config.runtime_token,
+            auth_headers=server_context.runtime_auth_headers or None,
         )
     )
     kid = notebook_manager.get_kernel_id(notebook_name) or "unknown"

--- a/jupyter_mcp_server/server_context.py
+++ b/jupyter_mcp_server/server_context.py
@@ -23,6 +23,9 @@ class ServerContext:
     _kernel_spec_manager = None
     _session_manager = None
     _server_client = None
+    _kernel_client = None
+    _runtime_password_auth = None
+    _document_password_auth = None
     _initialized = False
 
     @classmethod
@@ -33,8 +36,13 @@ class ServerContext:
 
     @classmethod
     def reset(cls):
-        """Reset the singleton instance. Use this when config changes."""
+        """Reset the singleton instance. Use this when config changes.
+
+        Closes any active password-auth sessions so their connection pools
+        are released rather than waiting for GC.
+        """
         if cls._instance is not None:
+            cls._instance._close_auth()
             cls._instance._initialized = False
             cls._instance._mode = None
             cls._instance._contents_manager = None
@@ -43,16 +51,105 @@ class ServerContext:
             cls._instance._session_manager = None
             cls._instance._server_client = None
 
+    def _close_auth(self):
+        """Close auth sessions if present; safe to call multiple times.
+
+        Document auth may be the same instance as runtime auth (shared session
+        when URLs match), so guard against double-close.
+        """
+        runtime = self._runtime_password_auth
+        document = self._document_password_auth
+        self._runtime_password_auth = None
+        self._document_password_auth = None
+        if runtime is not None:
+            runtime.close()
+        if document is not None and document is not runtime:
+            document.close()
+
+    def _init_mcp_server_mode(self):
+        """Initialize MCP_SERVER mode with HTTP client and optional password auth.
+
+        Sets up up to two password-auth sessions:
+        - `_runtime_password_auth` for the runtime server (kernel ops).
+        - `_document_password_auth` for the document server (collaboration API).
+        When runtime and document URLs point to the same server, the runtime
+        auth is reused for document operations to avoid a redundant login.
+
+        On any failure partway through, closes whatever auth sessions were
+        created so we don't leak.
+        """
+        self._mode = ServerMode.MCP_SERVER
+        config = get_config()
+
+        runtime_url = config.runtime_url
+        if not runtime_url or runtime_url in ("None", "none", "null", ""):
+            raise ValueError(
+                f"runtime_url is not configured (current value: {repr(runtime_url)}). "
+                "Please check:\n"
+                "1. RUNTIME_URL environment variable is set correctly (not the string 'None')\n"
+                "2. --runtime-url argument is provided when starting the server\n"
+                "3. The MCP client configuration passes runtime_url correctly"
+            )
+
+        logger.info(f"Initializing MCP_SERVER mode with runtime_url: {runtime_url}")
+
+        from jupyter_mcp_server.auth import JupyterPasswordAuth
+
+        try:
+            # Runtime auth — password takes precedence over token
+            if config.runtime_password:
+                self._runtime_password_auth = JupyterPasswordAuth(runtime_url, config.runtime_password)
+                self._runtime_password_auth.login()
+                if config.runtime_token:
+                    logger.warning("Both runtime_password and runtime_token are set. Password auth takes precedence.")
+                self._server_client = JupyterServerClient(base_url=runtime_url, token=None)
+                self._runtime_password_auth.inject_into_session(self._server_client.http_client.session)
+            else:
+                self._server_client = JupyterServerClient(base_url=runtime_url, token=config.runtime_token)
+
+            # Document auth — only needed when the document server is explicitly
+            # different from the runtime server. When URLs match (or document_url
+            # is unset/falsy and would default to runtime), reuse the runtime auth.
+            document_url = config.document_url
+            urls_match = (not document_url) or (document_url == runtime_url)
+            if urls_match:
+                self._document_password_auth = self._runtime_password_auth
+            elif config.document_password:
+                self._document_password_auth = JupyterPasswordAuth(document_url, config.document_password)
+                self._document_password_auth.login()
+                if config.document_token:
+                    logger.warning("Both document_password and document_token are set. Password auth takes precedence.")
+            elif config.runtime_password and not config.document_token:
+                # Document server is genuinely different but only runtime_password is set —
+                # the runtime cookies won't authenticate there.
+                logger.warning(
+                    "document_url (%s) differs from runtime_url (%s) but no document_password "
+                    "is configured. Collaboration API requests will not be authenticated. "
+                    "Set --document-password (or DOCUMENT_PASSWORD), or --document-token.",
+                    document_url, runtime_url,
+                )
+        except BaseException:
+            self._close_auth()
+            raise
+
     def initialize(self):
-        """Initialize context once."""
+        """Initialize context once.
+
+        Tries to detect a Jupyter-extension context (JUPYTER_SERVER mode).
+        Falls back to MCP_SERVER mode ONLY when the extension's context module
+        cannot be imported — any other exception during mode setup (config
+        errors, login failures, etc.) propagates to the caller.
+        """
         if self._initialized:
             return
 
         try:
             from jupyter_mcp_server.jupyter_extension.context import get_server_context
-
+        except ImportError:
+            # Not running under jupyter-extension — fall back to MCP_SERVER mode.
+            self._init_mcp_server_mode()
+        else:
             context = get_server_context()
-
             if context.is_local_document() and context.get_contents_manager() is not None:
                 self._mode = ServerMode.JUPYTER_SERVER
                 self._contents_manager = context.get_contents_manager()
@@ -68,51 +165,7 @@ class ServerContext:
                     else None
                 )
             else:
-                self._mode = ServerMode.MCP_SERVER
-                # Initialize HTTP clients for MCP_SERVER mode
-                config = get_config()
-
-                # Validate that runtime_url is set and not None/empty
-                # Note: String "None" values should have been normalized by start_command()
-                runtime_url = config.runtime_url
-                if not runtime_url or runtime_url in ("None", "none", "null", ""):
-                    raise ValueError(
-                        f"runtime_url is not configured (current value: {runtime_url!r}). "
-                        "Please check:\n"
-                        "1. RUNTIME_URL environment variable is set correctly (not the string 'None')\n"
-                        "2. --runtime-url argument is provided when starting the server\n"
-                        "3. The MCP client configuration passes runtime_url correctly"
-                    )
-
-                logger.info(f"Initializing MCP_SERVER mode with runtime_url: {runtime_url}")
-                self._server_client = JupyterServerClient(
-                    base_url=runtime_url, token=config.runtime_token
-                )
-        except (ImportError, Exception) as e:
-            # If not in Jupyter context, use MCP_SERVER mode
-            if not isinstance(e, ValueError):
-                self._mode = ServerMode.MCP_SERVER
-                # Initialize HTTP clients for MCP_SERVER mode
-                config = get_config()
-
-                # Validate that runtime_url is set and not None/empty
-                # Note: String "None" values should have been normalized by start_command()
-                runtime_url = config.runtime_url
-                if not runtime_url or runtime_url in ("None", "none", "null", ""):
-                    raise ValueError(
-                        f"runtime_url is not configured (current value: {runtime_url!r}). "
-                        "Please check:\n"
-                        "1. RUNTIME_URL environment variable is set correctly (not the string 'None')\n"
-                        "2. --runtime-url argument is provided when starting the server\n"
-                        "3. The MCP client configuration passes runtime_url correctly"
-                    )
-
-                logger.info(f"Initializing MCP_SERVER mode with runtime_url: {runtime_url}")
-                self._server_client = JupyterServerClient(
-                    base_url=runtime_url, token=config.runtime_token
-                )
-            else:
-                raise
+                self._init_mcp_server_mode()
 
         self._initialized = True
         logger.info(f"Server mode initialized: {self._mode}")
@@ -152,6 +205,99 @@ class ServerContext:
         if not self._initialized:
             self.initialize()
         return self._server_client
+
+    @property
+    def kernel_client(self):
+        if not self._initialized:
+            self.initialize()
+        return self._kernel_client
+
+    @property
+    def runtime_auth_headers(self) -> dict[str, str]:
+        """Auth headers for the runtime server (kernel operations).
+
+        Empty dict when no runtime password auth is configured. When password
+        auth is active, reads the latest cookies from the JupyterServerClient
+        session (which the server may have refreshed) rather than the stale
+        login-time snapshot.
+        """
+        if not self._initialized:
+            self.initialize()
+        if self._runtime_password_auth is None:
+            return {}
+        if self._server_client is not None:
+            session = self._server_client.http_client.session
+            cookies = dict(session.cookies)
+            if cookies:
+                cookie_header = "; ".join(f"{name}={value}" for name, value in cookies.items())
+                headers = {"Cookie": cookie_header}
+                xsrf = cookies.get("_xsrf", "")
+                if xsrf:
+                    headers["X-XSRFToken"] = xsrf
+                return headers
+        # Fall back to login-time headers
+        return self._runtime_password_auth.get_headers()
+
+    @property
+    def document_auth_headers(self) -> dict[str, str]:
+        """Auth headers for the document server (collaboration API).
+
+        When runtime_url == document_url, this returns the same fresh headers
+        as `runtime_auth_headers` (single shared session). When the document
+        server is separate, returns the login-time headers from the dedicated
+        document auth.
+        """
+        if not self._initialized:
+            self.initialize()
+        if self._document_password_auth is None:
+            return {}
+        # Shared session with runtime — read fresh cookies from the runtime client
+        if self._document_password_auth is self._runtime_password_auth:
+            return self.runtime_auth_headers
+        return self._document_password_auth.get_headers()
+
+    def relogin_runtime(self, timeout: float = 10.0) -> None:
+        """Re-authenticate the runtime server session after cookie expiry.
+
+        Calls `relogin()` on the runtime auth instance and re-injects the fresh
+        cookies into the JupyterServerClient session so subsequent HTTP requests
+        (kernel management, etc.) carry valid credentials.
+
+        No-op when no runtime password auth is configured.
+        """
+        if self._runtime_password_auth is None:
+            return
+        self._runtime_password_auth.relogin(timeout=timeout)
+        if self._server_client is not None:
+            self._runtime_password_auth.inject_into_session(
+                self._server_client.http_client.session
+            )
+        logger.info("Runtime session re-authenticated after cookie expiry.")
+
+    def relogin_document(self, timeout: float = 10.0) -> None:
+        """Re-authenticate the document server session after cookie expiry.
+
+        When runtime and document auth are shared (same URL), delegates to
+        `relogin_runtime()` so the shared session is only re-established once.
+        For a separate document auth instance, re-logins independently.
+
+        No-op when no document password auth is configured.
+        """
+        if self._document_password_auth is None:
+            return
+        if self._document_password_auth is self._runtime_password_auth:
+            self.relogin_runtime(timeout=timeout)
+            return
+        self._document_password_auth.relogin(timeout=timeout)
+        logger.info("Document session re-authenticated after cookie expiry.")
+
+    @property
+    def auth_headers(self) -> dict[str, str]:
+        """Backwards-compatible alias for runtime_auth_headers.
+
+        Prefer `runtime_auth_headers` or `document_auth_headers` explicitly.
+        """
+        return self.runtime_auth_headers
 
     def is_jupyterlab_mode(self) -> bool:
         """Check if JupyterLab mode is enabled."""

--- a/jupyter_mcp_server/tools/execute_code_tool.py
+++ b/jupyter_mcp_server/tools/execute_code_tool.py
@@ -59,6 +59,7 @@ class ExecuteCodeTool(BaseTool):
         """
         from jupyter_mcp_server.config import get_config
         from jupyter_mcp_server.sandbox_client import create_jupyter_sandbox_client
+        from jupyter_mcp_server.server_context import ServerContext
 
         if server_client is not None:
             kernels = server_client.kernels.list_kernels()
@@ -69,12 +70,19 @@ class ExecuteCodeTool(BaseTool):
                 )
 
         config = get_config()
+        # Password auth carries credentials via cookie/XSRF headers; when present,
+        # drop the token so it can't override them (mirrors create_kernel and
+        # use_notebook). Without this, a borrowed cross-kernel connection under
+        # password auth would be unauthenticated, since runtime_token is typically
+        # None in that mode.
+        auth_headers = ServerContext.get_instance().runtime_auth_headers
         sandbox_client = create_jupyter_sandbox_client(
             server_url=config.runtime_url,
-            token=config.runtime_token,
+            token=None if auth_headers else config.runtime_token,
             kernel_id=kernel_id,
             timeout=getattr(config, "execution_timeout", None),
             reconnect_interval=getattr(config, "reconnect_interval", 0) or 0,
+            headers=auth_headers or None,
             logger=logger,
         )
         return cast(ISandboxClient, sandbox_client), None

--- a/jupyter_mcp_server/tools/use_notebook_tool.py
+++ b/jupyter_mcp_server/tools/use_notebook_tool.py
@@ -139,6 +139,7 @@ class UseNotebookTool(BaseTool):
         kernel_id: str | None = None,
         runtime_url: str | None = None,
         runtime_token: str | None = None,
+        auth_headers: dict[str, str] | None = None,
         **kwargs,
     ) -> str:
         """Execute the use_notebook tool.
@@ -231,6 +232,18 @@ class UseNotebookTool(BaseTool):
                         )
                     )
                 elif mode == ServerMode.MCP_SERVER and server_client is not None:
+                    # Creating a notebook is a state-changing PUT to /api/contents,
+                    # which Jupyter's XSRF protection guards. Under password auth the
+                    # injected session carries the _xsrf cookie but not the matching
+                    # X-XSRFToken header, and the cookie alone fails the check
+                    # ("'_xsrf' argument missing from POST"). Echo the token the
+                    # caller just read from the live cookie jar, so a rotated cookie
+                    # cannot go stale. Token auth has no _xsrf cookie and satisfies
+                    # XSRF via its own header, so nothing happens there.
+                    xsrf_token = (auth_headers or {}).get("X-XSRFToken")
+                    session = getattr(getattr(server_client, "http_client", None), "session", None)
+                    if xsrf_token and session is not None:
+                        session.headers["X-XSRFToken"] = xsrf_token
                     server_client.contents.create_notebook(notebook_path, content=content)
 
             # # Create/connect to kernel based on mode
@@ -248,12 +261,15 @@ class UseNotebookTool(BaseTool):
                 config = get_config()
                 kernel = create_jupyter_sandbox_client(
                     server_url=runtime_url,
-                    token=runtime_token,
+                    # Password auth authenticates via the cookie/XSRF headers, so
+                    # the token is dropped when they are present.
+                    token=None if auth_headers else runtime_token,
                     kernel_id=kernel_id,
                     path=notebook_path,
                     logger=logger,
                     timeout=getattr(config, "execution_timeout", None),
                     reconnect_interval=getattr(config, "reconnect_interval", 0) or 0,
+                    headers=auth_headers or None,
                 )
 
                 info_list.append(f"[INFO] Connected to kernel '{kernel.id}'.")

--- a/jupyter_mcp_server/utils.py
+++ b/jupyter_mcp_server/utils.py
@@ -236,6 +236,8 @@ def do_start(
     runtime_channels_url: str | None = None,
     sandbox_environment: str | None = None,
     sandbox_gpu: str | None = None,
+    runtime_password: str | None = None,
+    document_password: str | None = None,
 ):
     """Shared startup routine used by Typer CLI surfaces."""
 
@@ -268,9 +270,11 @@ def do_start(
         start_new_runtime=start_new_runtime,
         runtime_id=runtime_id,
         runtime_token=runtime_token,
+        runtime_password=runtime_password,
         document_url=document_url,
         document_id=document_id,
         document_token=document_token,
+        document_password=document_password,
         port=port,
         jupyterlab=jupyterlab,
         open_notebook_in_ui=open_notebook_in_ui,
@@ -585,13 +589,20 @@ def create_kernel(config, logger) -> ISandboxClient:
     if extension_kernel is not None:
         return extension_kernel
 
+    from jupyter_mcp_server.server_context import ServerContext
+
+    # Password auth carries credentials as cookie/XSRF headers; drop the token
+    # when they are present so it cannot override them.
+    auth_headers = ServerContext.get_instance().runtime_auth_headers
+
     try:
         kernel = create_jupyter_sandbox_client(
             server_url=config.runtime_url,
-            token=config.runtime_token,
+            token=None if auth_headers else config.runtime_token,
             kernel_id=config.runtime_id,
             timeout=getattr(config, "execution_timeout", None),
             reconnect_interval=getattr(config, "reconnect_interval", 0) or 0,
+            headers=auth_headers or None,
             logger=logger,
         )
         logger.info("Kernel created and started successfully")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,10 +21,13 @@ classifiers = [
   "Programming Language :: Python :: 3",
 ]
 dependencies = [
-    "code-sandboxes",
+    # 0.17.0 adds the `headers` passthrough and stops overwriting an explicit
+    # `token=None` in JupyterSandbox. Password auth needs both: its credentials are
+    # a session Cookie plus X-XSRFToken rather than a token.
+    "code-sandboxes>=0.17.0",
     "datalayer_reactor",
     "jupyter-mcp-tools",
-    "jupyter-nbmodel-client",
+    "jupyter-nbmodel-client>=0.14.8",
     "jupyter-server-nbmodel",
     "jupyter-server-client",
     "jupyter_server>=1.6,<3",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -19,8 +19,10 @@ import os
 import socket
 import subprocess
 import time
+import uuid
 from http import HTTPStatus
 
+import nbformat
 import pytest
 import pytest_asyncio
 import requests
@@ -458,3 +460,158 @@ def mcp_client_otel(mcp_server_url_otel):
     from .test_common import MCPClient
 
     return MCPClient(mcp_server_url_otel, token=JUPYTER_TOKEN)
+
+
+###############################################################################
+# Password-auth fixtures (e2e tests for password-based authentication)
+###############################################################################
+
+JUPYTER_PASSWORD = "test-password-e2e"
+
+
+@pytest.fixture(scope="session")
+def jupyter_password_root_dir(tmp_path_factory):
+    """Isolated root directory for the password-auth Jupyter server.
+
+    Tests write their own scratch notebooks here instead of into the repo's
+    ``./dev/content`` (which holds notebooks that ship with the repo).
+    """
+    return tmp_path_factory.mktemp("jupyter_password_content")
+
+
+@pytest.fixture(scope="session")
+def jupyter_server_password(jupyter_password_root_dir):
+    """Start a Jupyter server with both a password and a token configured.
+
+    The password is set via ``jupyter server password`` hashing. A token is also
+    configured on purpose: token and password are independent mechanisms, so this
+    verifies the MCP server authenticates via password (the only credential it is
+    given) even when the server still accepts a token — the real-world scenario,
+    and it avoids leaving the server with no authentication at all.
+    """
+    if not TEST_MCP_SERVER:
+        pytest.skip("TEST_MCP_SERVER is disabled — password e2e tests only run in MCP_SERVER mode")
+
+    from jupyter_server.auth import passwd
+    password_hash = passwd(JUPYTER_PASSWORD)
+
+    host = "localhost"
+    port = _find_free_port()
+    yield from _start_server(
+        name="JupyterLab (password)",
+        host=host,
+        port=port,
+        command=[
+            "jupyter", "lab",
+            "--port", str(port),
+            "--IdentityProvider.token", JUPYTER_TOKEN,
+            "--ServerApp.password", password_hash,
+            "--ip", host,
+            "--ServerApp.root_dir", str(jupyter_password_root_dir),
+            "--no-browser",
+        ],
+        readiness_endpoint="/login",
+        max_retries=10,
+    )
+
+
+@pytest.fixture(scope="function")
+def password_notebook(jupyter_password_root_dir):
+    """Create a uniquely-named empty notebook in the password server's root dir.
+
+    Yields the notebook filename (relative to the server root). A unique name per
+    test avoids cross-test collisions on a shared hardcoded notebook path.
+    """
+    notebook_name = f"password_test_{uuid.uuid4().hex[:8]}.ipynb"
+    notebook_path = jupyter_password_root_dir / notebook_name
+    nbformat.write(nbformat.v4.new_notebook(), str(notebook_path))
+    yield notebook_name
+    notebook_path.unlink(missing_ok=True)
+
+
+@pytest.fixture(scope="function")
+def jupyter_mcp_server_password(jupyter_server_password, password_notebook):
+    """Start a standalone MCP server that authenticates to Jupyter via password."""
+    host = "localhost"
+    port = _find_free_port()
+    yield from _start_server(
+        name="Jupyter MCP (password)",
+        host=host,
+        port=port,
+        command=[
+            "python", "-m", "jupyter_mcp_server",
+            "--transport", "streamable-http",
+            "--document-url", jupyter_server_password,
+            "--document-id", password_notebook,
+            "--runtime-url", jupyter_server_password,
+            "--start-new-runtime", "True",
+            "--jupyter-password", JUPYTER_PASSWORD,
+            "--insecure-mcp-noauth",
+            "--port", str(port),
+        ],
+        readiness_endpoint="/api/healthz",
+    )
+
+
+@pytest.fixture(scope="function")
+def mcp_client_password(jupyter_mcp_server_password):
+    """MCPClient connected to the password-auth MCP server (no Bearer token needed)."""
+    from .test_common import MCPClient
+    return MCPClient(jupyter_mcp_server_password, token=None)
+
+
+###############################################################################
+# Short-cookie fixtures (session-expiry / re-login tests)
+###############################################################################
+
+_COOKIE_TTL_SECONDS = 2
+
+
+@pytest.fixture(scope="session")
+def jupyter_short_cookie_root_dir(tmp_path_factory):
+    """Isolated root directory for the short-cookie Jupyter server."""
+    return tmp_path_factory.mktemp("jupyter_short_cookie_content")
+
+
+@pytest.fixture(scope="session")
+def jupyter_server_short_cookie(jupyter_short_cookie_root_dir, tmp_path_factory):
+    """Jupyter server whose session cookie expires after a few seconds.
+
+    Writes a ``jupyter_server_config.py`` that sets
+    ``IdentityProvider.cookie_options = {"expires_days": N}`` where N is a
+    tiny fraction of a day, then passes ``JUPYTER_CONFIG_DIR`` so Jupyter
+    picks it up.  Used to exercise the re-login path without waiting 30 days.
+    """
+    if not TEST_MCP_SERVER:
+        pytest.skip("TEST_MCP_SERVER is disabled")
+
+    config_dir = tmp_path_factory.mktemp("jupyter_short_cookie_config")
+
+    expires_days = _COOKIE_TTL_SECONDS / (24 * 60 * 60)
+    config_py = config_dir / "jupyter_server_config.py"
+    config_py.write_text(
+        f"c.IdentityProvider.cookie_options = {{'expires_days': {expires_days}}}\n"
+    )
+
+    from jupyter_server.auth import passwd
+    password_hash = passwd(JUPYTER_PASSWORD)
+
+    host = "localhost"
+    port = _find_free_port()
+    yield from _start_server(
+        name="JupyterLab (short-cookie)",
+        host=host,
+        port=port,
+        command=[
+            "jupyter", "lab",
+            "--port", str(port),
+            "--IdentityProvider.token", JUPYTER_TOKEN,
+            "--ServerApp.password", password_hash,
+            "--ip", host,
+            "--ServerApp.root_dir", str(jupyter_short_cookie_root_dir),
+            "--no-browser",
+        ],
+        readiness_endpoint="/login",
+        max_retries=10,
+        extra_env={"JUPYTER_CONFIG_DIR": str(config_dir)},
+    )

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -1,0 +1,978 @@
+# Copyright (c) 2024- Datalayer, Inc.
+#
+# BSD 3-Clause License
+
+"""Tests for password-based authentication support."""
+
+import asyncio
+import time
+import uuid
+from unittest.mock import patch, MagicMock
+
+import pytest
+import requests
+from requests.cookies import RequestsCookieJar
+
+from jupyter_mcp_server.auth import JupyterPasswordAuth
+from jupyter_mcp_server.config import reset_config, set_config, get_config
+from jupyter_mcp_server.server_context import ServerContext
+
+
+def _patch_session(mock_session_cls):
+    """Wire mock_session_cls so `requests.Session()` returns a controllable mock.
+
+    The auth module now uses `session.request(method, url, ...)` for all HTTP
+    calls (via `_do_request`), so configure `session.request` rather than
+    `session.get` / `session.post`. Returns the mock session.
+    """
+    session = MagicMock()
+    mock_session_cls.return_value = session
+    return session
+
+
+def _make_response(status_code: int = 200, text: str = "") -> MagicMock:
+    """Build a MagicMock response with a real `.text` attribute.
+
+    `auth._truncate` reads `response.text`; we set it explicitly so error-path
+    tests don't accidentally feed a MagicMock into string ops.
+    """
+    response = MagicMock(spec_set=["status_code", "text"])
+    response.status_code = status_code
+    response.text = text
+    return response
+
+
+def _request_responses(*responses):
+    """Build a side_effect that yields the given responses in order.
+
+    Mix of HTTP responses (MagicMock-like) and exceptions.
+    """
+    iterator = iter(responses)
+
+    def side_effect(method, url, **kwargs):
+        value = next(iterator)
+        if isinstance(value, BaseException):
+            raise value
+        return value
+
+    return side_effect
+
+
+# ---------------------------------------------------------------------------
+# JupyterPasswordAuth unit tests
+# ---------------------------------------------------------------------------
+
+
+class TestJupyterPasswordAuth:
+    """Tests for the JupyterPasswordAuth login flow."""
+
+    def _make_auth(self, url="http://localhost:8888", password="secret"):
+        return JupyterPasswordAuth(url, password)
+
+    # -- login success -------------------------------------------------------
+
+    @patch("jupyter_mcp_server.auth.requests.Session")
+    def test_login_success(self, mock_session_cls):
+        """Successful login keeps the session alive and exposes live cookies."""
+        session = _patch_session(mock_session_cls)
+        jar = RequestsCookieJar()
+        jar.set("_xsrf", "2|abc123")
+        jar.set("username-localhost", "user123")
+        session.cookies = jar
+
+        # GET /login, POST /login (302), GET /api/status (200)
+        session.request.side_effect = _request_responses(
+            MagicMock(),                      # GET /login
+            MagicMock(status_code=302),       # POST /login
+            MagicMock(status_code=200),       # GET /api/status
+        )
+
+        auth = self._make_auth()
+        auth.login()
+
+        assert auth._authenticated is True
+        assert auth._session is session  # session kept alive
+        assert auth._xsrf_token == "2|abc123"
+
+        # POST /login must include the _xsrf token and disable redirects
+        post_call = session.request.call_args_list[1]
+        assert post_call.args[0] == "POST"
+        assert post_call.kwargs["data"]["password"] == "secret"
+        assert post_call.kwargs["data"]["_xsrf"] == "2|abc123"
+        assert post_call.kwargs["allow_redirects"] is False
+        # Initial GET /login must also disable redirects (cross-origin guard)
+        get_call = session.request.call_args_list[0]
+        assert get_call.args[0] == "GET"
+        assert get_call.kwargs["allow_redirects"] is False
+
+        headers = auth.get_headers()
+        assert headers["X-XSRFToken"] == "2|abc123"
+        assert "_xsrf=2|abc123" in headers["Cookie"]
+        assert "username-localhost=user123" in headers["Cookie"]
+
+    @patch("jupyter_mcp_server.auth.requests.Session")
+    def test_get_headers_returns_live_cookies(self, mock_session_cls):
+        """get_headers reflects cookies set on the session AFTER login."""
+        session = _patch_session(mock_session_cls)
+        jar = RequestsCookieJar()
+        jar.set("_xsrf", "initial")
+        session.cookies = jar
+        session.request.side_effect = _request_responses(
+            MagicMock(),
+            MagicMock(status_code=302),
+            MagicMock(status_code=200),
+        )
+
+        auth = self._make_auth()
+        auth.login()
+
+        # Simulate the server rotating a cookie post-login
+        jar.set("_xsrf", "rotated")
+        jar.set("new", "value")
+
+        headers = auth.get_headers()
+        assert headers["X-XSRFToken"] == "rotated"
+        assert "new=value" in headers["Cookie"]
+
+    # -- get_headers ---------------------------------------------------------
+
+    def test_get_headers_not_authenticated(self):
+        """get_headers returns empty dict when not authenticated."""
+        auth = self._make_auth()
+        assert auth.get_headers() == {}
+
+    def test_get_headers_without_xsrf_in_jar(self):
+        """get_headers omits X-XSRFToken when no _xsrf cookie is present."""
+        auth = self._make_auth()
+        auth._authenticated = True
+        session = requests.Session()
+        session.cookies.set("session", "abc")
+        auth._session = session
+
+        headers = auth.get_headers()
+        assert "Cookie" in headers
+        assert "session=abc" in headers["Cookie"]
+        assert "X-XSRFToken" not in headers
+
+    # -- inject_into_session -------------------------------------------------
+
+    def test_inject_into_session(self):
+        """inject_into_session copies live cookies but NOT a stale XSRF header."""
+        auth = self._make_auth()
+        auth._authenticated = True
+        src_session = requests.Session()
+        src_session.cookies.set("_xsrf", "token123")
+        src_session.cookies.set("session", "abc")
+        auth._session = src_session
+
+        target = requests.Session()
+        auth.inject_into_session(target)
+
+        assert target.cookies.get("_xsrf") == "token123"
+        assert target.cookies.get("session") == "abc"
+        # X-XSRFToken is deliberately NOT injected as a default header; it must
+        # be set per-request from the live cookie jar so cookie rotation works.
+        assert "X-XSRFToken" not in target.headers
+
+    def test_inject_into_session_not_authenticated(self):
+        """inject_into_session is a no-op when not authenticated."""
+        auth = self._make_auth()
+        target = requests.Session()
+        original_cookies = dict(target.cookies)
+
+        auth.inject_into_session(target)
+
+        assert dict(target.cookies) == original_cookies
+
+    # -- close ---------------------------------------------------------------
+
+    @patch("jupyter_mcp_server.auth.requests.Session")
+    def test_close_clears_state(self, mock_session_cls):
+        session = _patch_session(mock_session_cls)
+        jar = RequestsCookieJar()
+        jar.set("_xsrf", "x")
+        session.cookies = jar
+        session.request.side_effect = _request_responses(
+            MagicMock(), MagicMock(status_code=302), MagicMock(status_code=200),
+        )
+
+        auth = self._make_auth()
+        auth.login()
+        auth.close()
+        session.close.assert_called_once()
+        assert auth._session is None
+        assert auth._authenticated is False
+
+    # -- login error cases ---------------------------------------------------
+
+    @patch("jupyter_mcp_server.auth.requests.Session")
+    def test_login_connection_error_on_initial_get(self, mock_session_cls):
+        """ConnectionError on initial GET surfaces as RuntimeError."""
+        session = _patch_session(mock_session_cls)
+        session.cookies = RequestsCookieJar()
+        session.request.side_effect = requests.exceptions.ConnectionError("refused")
+
+        auth = self._make_auth()
+        with pytest.raises(RuntimeError, match="Connection error"):
+            auth.login()
+        # Session must be closed on failure
+        session.close.assert_called_once()
+
+    @patch("jupyter_mcp_server.auth.requests.Session")
+    def test_login_connection_error_on_post(self, mock_session_cls):
+        """ConnectionError on POST /login also surfaces as RuntimeError."""
+        session = _patch_session(mock_session_cls)
+        session.cookies = RequestsCookieJar()
+        session.request.side_effect = _request_responses(
+            MagicMock(),
+            requests.exceptions.ConnectionError("reset"),
+        )
+
+        auth = self._make_auth()
+        with pytest.raises(RuntimeError, match="Connection error.*POST"):
+            auth.login()
+
+    @patch("jupyter_mcp_server.auth.requests.Session")
+    def test_login_connection_error_on_verify(self, mock_session_cls):
+        """ConnectionError on /api/status verify also surfaces as RuntimeError."""
+        session = _patch_session(mock_session_cls)
+        session.cookies = RequestsCookieJar()
+        session.request.side_effect = _request_responses(
+            MagicMock(),
+            MagicMock(status_code=302),
+            requests.exceptions.ConnectionError("reset during verify"),
+        )
+
+        auth = self._make_auth()
+        with pytest.raises(RuntimeError, match="Connection error.*api/status"):
+            auth.login()
+
+    @patch("jupyter_mcp_server.auth.requests.Session")
+    def test_login_connection_timeout(self, mock_session_cls):
+        """Timeout on GET /login surfaces as RuntimeError."""
+        session = _patch_session(mock_session_cls)
+        session.cookies = RequestsCookieJar()
+        session.request.side_effect = requests.exceptions.Timeout("slow")
+
+        auth = self._make_auth()
+        with pytest.raises(RuntimeError, match="Timed out"):
+            auth.login(timeout=0.5)
+
+    @patch("jupyter_mcp_server.auth.requests.Session")
+    def test_login_server_error_5xx_on_login(self, mock_session_cls):
+        """5xx from /login surfaces a 'server is failing' message."""
+        session = _patch_session(mock_session_cls)
+        session.cookies = RequestsCookieJar()
+        session.request.side_effect = _request_responses(
+            MagicMock(),
+            MagicMock(status_code=503),
+        )
+
+        auth = self._make_auth()
+        with pytest.raises(RuntimeError, match=r"503.*server is failing"):
+            auth.login()
+
+    @patch("jupyter_mcp_server.auth.requests.Session")
+    def test_login_server_error_5xx_on_verify(self, mock_session_cls):
+        """5xx from /api/status is also classified as server failure, not auth."""
+        session = _patch_session(mock_session_cls)
+        session.cookies = RequestsCookieJar()
+        session.request.side_effect = _request_responses(
+            MagicMock(),
+            MagicMock(status_code=302),
+            MagicMock(status_code=502),
+        )
+
+        auth = self._make_auth()
+        with pytest.raises(RuntimeError, match=r"502.*server is failing"):
+            auth.login()
+
+    @patch("jupyter_mcp_server.auth.requests.Session")
+    def test_login_bad_status(self, mock_session_cls):
+        """Non-200/302 status from /login is treated as a login failure."""
+        session = _patch_session(mock_session_cls)
+        session.cookies = RequestsCookieJar()
+        session.request.side_effect = _request_responses(
+            MagicMock(),
+            MagicMock(status_code=400),
+        )
+
+        auth = self._make_auth()
+        with pytest.raises(RuntimeError, match="login failed with status 400"):
+            auth.login()
+
+    @patch("jupyter_mcp_server.auth.requests.Session")
+    def test_login_wrong_password_403(self, mock_session_cls):
+        """403 from /api/status verify means cookies didn't authenticate."""
+        session = _patch_session(mock_session_cls)
+        session.cookies = RequestsCookieJar()
+        session.request.side_effect = _request_responses(
+            MagicMock(),
+            MagicMock(status_code=302),
+            MagicMock(status_code=403),
+        )
+
+        auth = self._make_auth()
+        with pytest.raises(RuntimeError, match="password may be incorrect"):
+            auth.login()
+
+    @patch("jupyter_mcp_server.auth.requests.Session")
+    def test_login_wrong_password_401(self, mock_session_cls):
+        """401 from /api/status verify is also treated as auth failure (not just 403)."""
+        session = _patch_session(mock_session_cls)
+        session.cookies = RequestsCookieJar()
+        session.request.side_effect = _request_responses(
+            MagicMock(),
+            MagicMock(status_code=302),
+            MagicMock(status_code=401),
+        )
+
+        auth = self._make_auth()
+        with pytest.raises(RuntimeError, match="password may be incorrect"):
+            auth.login()
+
+    @patch("jupyter_mcp_server.auth.requests.Session")
+    def test_login_unexpected_verify_status(self, mock_session_cls):
+        """Non-200/4xx/5xx from /api/status (e.g. 3xx redirect) is its own error."""
+        session = _patch_session(mock_session_cls)
+        session.cookies = RequestsCookieJar()
+        session.cookies.set("_xsrf", "tok")  # set so we don't hit the missing-xsrf raise
+        session.request.side_effect = _request_responses(
+            MagicMock(),
+            MagicMock(status_code=302),
+            MagicMock(status_code=302),  # /api/status redirect (unexpected)
+        )
+
+        auth = self._make_auth()
+        with pytest.raises(RuntimeError, match=r"Unexpected status 302"):
+            auth.login()
+
+    @patch("jupyter_mcp_server.auth.requests.Session")
+    def test_login_error_includes_response_body(self, mock_session_cls):
+        """Login failures surface a (truncated) response body for debuggability."""
+        session = _patch_session(mock_session_cls)
+        session.cookies = RequestsCookieJar()
+        session.request.side_effect = _request_responses(
+            _make_response(),
+            _make_response(status_code=400, text="<html>Bad password!</html>"),
+        )
+
+        auth = self._make_auth()
+        with pytest.raises(RuntimeError, match="Bad password"):
+            auth.login()
+
+    @patch("jupyter_mcp_server.auth.requests.Session")
+    def test_login_fails_when_no_xsrf_cookie(self, mock_session_cls):
+        """Login that succeeds at HTTP level but leaves no _xsrf cookie must fail fast."""
+        session = _patch_session(mock_session_cls)
+        session.cookies = RequestsCookieJar()  # never sets _xsrf
+        session.request.side_effect = _request_responses(
+            MagicMock(),
+            MagicMock(status_code=302),
+            MagicMock(status_code=200),
+        )
+
+        auth = self._make_auth()
+        with pytest.raises(RuntimeError, match="no _xsrf cookie"):
+            auth.login()
+        # Session is closed on failure
+        session.close.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# Config password fields
+# ---------------------------------------------------------------------------
+
+
+class TestPasswordConfig:
+    """Tests for password fields in JupyterMCPConfig."""
+
+    def setup_method(self):
+        reset_config()
+
+    def teardown_method(self):
+        reset_config()
+
+    def test_password_fields_default_none(self):
+        config = get_config()
+        assert config.runtime_password is None
+        assert config.document_password is None
+
+    def test_set_password(self):
+        config = set_config(runtime_password="secret", document_password="other")
+        assert config.runtime_password == "secret"
+        assert config.document_password == "other"
+
+    def test_password_normalization_none_string(self):
+        """String 'None' is normalized to actual None."""
+        config = set_config(runtime_password="None", document_password="null")
+        assert config.runtime_password is None
+        assert config.document_password is None
+
+    def test_password_normalization_empty_string(self):
+        """Empty string is normalized to actual None."""
+        config = set_config(runtime_password="", document_password="")
+        assert config.runtime_password is None
+        assert config.document_password is None
+
+
+# ---------------------------------------------------------------------------
+# ServerContext auth_headers tests
+# ---------------------------------------------------------------------------
+
+
+class TestServerContextAuthHeaders:
+    """Tests for ServerContext.auth_headers property."""
+
+    def setup_method(self):
+        reset_config()
+        ServerContext.reset()
+        # Ensure a fresh singleton
+        ServerContext._instance = None
+
+    def teardown_method(self):
+        reset_config()
+        ServerContext.reset()
+        ServerContext._instance = None
+
+    def test_auth_headers_empty_without_password(self):
+        """auth_headers returns {} when no password is configured."""
+        set_config(runtime_url="http://localhost:8888", runtime_token="mytoken")
+        context = ServerContext.get_instance()
+        # Manually set up MCP_SERVER mode without password
+        from jupyter_mcp_server.tools import ServerMode
+        context._mode = ServerMode.MCP_SERVER
+        context._runtime_password_auth = None
+        context._server_client = MagicMock()
+        context._initialized = True
+
+        assert context.auth_headers == {}
+
+    def test_auth_headers_reads_from_session_cookies(self):
+        """auth_headers reads fresh cookies from JupyterServerClient session."""
+        from jupyter_mcp_server.tools import ServerMode
+
+        context = ServerContext.get_instance()
+        context._mode = ServerMode.MCP_SERVER
+        context._initialized = True
+
+        # Set up a mock password auth and server client
+        mock_auth = MagicMock()
+        mock_auth.get_headers.return_value = {"Cookie": "old=stale", "X-XSRFToken": "old"}
+        context._runtime_password_auth = mock_auth
+
+        mock_client = MagicMock()
+        mock_session = MagicMock()
+        mock_session.cookies = RequestsCookieJar()
+        mock_session.cookies.set("_xsrf", "fresh_token")
+        mock_session.cookies.set("username-localhost", "user1")
+        mock_client.http_client.session = mock_session
+        context._server_client = mock_client
+
+        headers = context.auth_headers
+        assert "X-XSRFToken" in headers
+        assert headers["X-XSRFToken"] == "fresh_token"
+        assert "_xsrf=fresh_token" in headers["Cookie"]
+        assert "username-localhost=user1" in headers["Cookie"]
+
+    def test_auth_headers_falls_back_to_login_headers(self):
+        """auth_headers falls back to login-time headers if session has no cookies."""
+        from jupyter_mcp_server.tools import ServerMode
+
+        context = ServerContext.get_instance()
+        context._mode = ServerMode.MCP_SERVER
+        context._initialized = True
+
+        mock_auth = MagicMock()
+        mock_auth.get_headers.return_value = {"Cookie": "login=cookie", "X-XSRFToken": "login_xsrf"}
+        context._runtime_password_auth = mock_auth
+
+        mock_client = MagicMock()
+        mock_session = MagicMock()
+        mock_session.cookies = RequestsCookieJar()  # empty jar
+        mock_client.http_client.session = mock_session
+        context._server_client = mock_client
+
+        headers = context.auth_headers
+        assert headers == {"Cookie": "login=cookie", "X-XSRFToken": "login_xsrf"}
+
+    def test_auth_headers_triggers_initialize(self):
+        """auth_headers triggers initialize() when not yet initialized (the bug we fixed)."""
+        set_config(runtime_url="http://localhost:8888")
+        context = ServerContext.get_instance()
+        assert context._initialized is False
+
+        # Patch _init_mcp_server_mode to avoid real HTTP calls
+        with patch.object(context, "_init_mcp_server_mode") as mock_init:
+            _ = context.auth_headers
+            mock_init.assert_called_once()
+
+    def test_reset_clears_password_auth(self):
+        """ServerContext.reset() clears both runtime and document password auth."""
+        context = ServerContext.get_instance()
+        context._runtime_password_auth = MagicMock()
+        context._document_password_auth = MagicMock()
+        context._initialized = True
+
+        ServerContext.reset()
+
+        assert context._runtime_password_auth is None
+        assert context._document_password_auth is None
+        assert context._initialized is False
+
+    def test_document_auth_headers_shares_runtime_when_urls_match(self):
+        """When document and runtime URLs match, document auth reuses runtime session."""
+        from jupyter_mcp_server.tools import ServerMode
+
+        context = ServerContext.get_instance()
+        context._mode = ServerMode.MCP_SERVER
+        context._initialized = True
+
+        shared_auth = MagicMock()
+        shared_auth.get_headers.return_value = {"Cookie": "stale", "X-XSRFToken": "stale"}
+        context._runtime_password_auth = shared_auth
+        context._document_password_auth = shared_auth  # same instance → shared
+
+        mock_client = MagicMock()
+        jar = RequestsCookieJar()
+        jar.set("_xsrf", "fresh")
+        jar.set("session", "fresh-session")
+        mock_client.http_client.session.cookies = jar
+        context._server_client = mock_client
+
+        # document_auth_headers should return the FRESH runtime cookies,
+        # not the stale login-time snapshot
+        headers = context.document_auth_headers
+        assert headers["X-XSRFToken"] == "fresh"
+        assert "_xsrf=fresh" in headers["Cookie"]
+
+    def test_document_auth_headers_separate_when_urls_differ(self):
+        """When document and runtime URLs differ, document auth uses its own session."""
+        from jupyter_mcp_server.tools import ServerMode
+
+        context = ServerContext.get_instance()
+        context._mode = ServerMode.MCP_SERVER
+        context._initialized = True
+
+        runtime_auth = MagicMock()
+        runtime_auth.get_headers.return_value = {"Cookie": "runtime=cookie"}
+        document_auth = MagicMock()
+        document_auth.get_headers.return_value = {"Cookie": "doc=cookie", "X-XSRFToken": "doc-xsrf"}
+
+        context._runtime_password_auth = runtime_auth
+        context._document_password_auth = document_auth  # different instance
+
+        mock_client = MagicMock()
+        mock_client.http_client.session.cookies = RequestsCookieJar()
+        context._server_client = mock_client
+
+        # document_auth_headers should come from document_auth, not runtime
+        headers = context.document_auth_headers
+        assert headers == {"Cookie": "doc=cookie", "X-XSRFToken": "doc-xsrf"}
+
+    def test_document_auth_headers_empty_without_password(self):
+        """document_auth_headers returns {} when no document password configured."""
+        from jupyter_mcp_server.tools import ServerMode
+
+        context = ServerContext.get_instance()
+        context._mode = ServerMode.MCP_SERVER
+        context._initialized = True
+        context._runtime_password_auth = None
+        context._document_password_auth = None
+
+        assert context.document_auth_headers == {}
+
+
+# ---------------------------------------------------------------------------
+# NotebookConnection auth headers tests
+# ---------------------------------------------------------------------------
+
+
+class TestNotebookConnectionAuth:
+    """Tests for auth header injection in NotebookConnection."""
+
+    def setup_method(self):
+        reset_config()
+        ServerContext.reset()
+        ServerContext._instance = None
+
+    def teardown_method(self):
+        reset_config()
+        ServerContext.reset()
+        ServerContext._instance = None
+
+    def _make_password_auth_connection(self):
+        """Set up MCP_SERVER mode with shared runtime/document password auth and
+        return a NotebookConnection whose document_auth_headers resolve to the
+        fresh session cookies (Cookie: ``_xsrf=tok; session=abc``)."""
+        from jupyter_mcp_server.notebook_manager import NotebookConnection
+
+        set_config(
+            runtime_url="http://localhost:8888",
+            document_url="http://localhost:8888",
+            runtime_password="secret",
+            provider="jupyter",
+        )
+
+        from jupyter_mcp_server.tools import ServerMode
+        context = ServerContext.get_instance()
+        context._mode = ServerMode.MCP_SERVER
+        context._initialized = True
+        mock_auth = MagicMock()
+        context._runtime_password_auth = mock_auth
+        # Share runtime auth with document since URLs match in this test
+        context._document_password_auth = mock_auth
+        context._server_client = MagicMock()
+        mock_session = MagicMock()
+        mock_session.cookies = RequestsCookieJar()
+        mock_session.cookies.set("_xsrf", "tok")
+        mock_session.cookies.set("session", "abc")
+        context._server_client.http_client.session = mock_session
+
+        return NotebookConnection(
+            notebook_info={
+                "server_url": "http://localhost:8888",
+                "token": None,
+                "path": "test.ipynb",
+            }
+        )
+
+    @pytest.mark.asyncio
+    async def test_nbmodel_client_receives_cookie_in_additional_headers(self):
+        """When auth_headers present, NbModelClient is constructed with the Cookie
+        header so the WebSocket handshake carries the password session cookie."""
+        connection = self._make_password_auth_connection()
+
+        async def fake_aenter(self_):
+            return self_
+
+        async def fake_aexit(self_, *args):
+            return None
+
+        with patch(
+            "jupyter_mcp_server.notebook_manager.get_notebook_websocket_url",
+            return_value="ws://localhost:8888/api/collaboration/room/abc",
+        ), patch(
+            "jupyter_mcp_server.notebook_manager.NbModelClient"
+        ) as MockClient:
+            mock_notebook = MagicMock()
+            mock_notebook.__aenter__ = fake_aenter
+            mock_notebook.__aexit__ = fake_aexit
+            MockClient.return_value = mock_notebook
+
+            await connection.__aenter__()
+
+        # The WebSocket handshake carries only the Cookie, not the XSRF token.
+        assert MockClient.call_args.kwargs["additional_headers"] == {
+            "Cookie": "_xsrf=tok; session=abc"
+        }
+
+    @pytest.mark.asyncio
+    async def test_collaboration_session_url_called_with_auth_headers(self):
+        """The collaboration-session URL request carries Cookie and X-XSRFToken,
+        forwarded to get_notebook_websocket_url via the headers kwarg."""
+        connection = self._make_password_auth_connection()
+
+        async def fake_aenter(self_):
+            return self_
+
+        async def fake_aexit(self_, *args):
+            return None
+
+        with patch(
+            "jupyter_mcp_server.notebook_manager.get_notebook_websocket_url",
+            return_value="ws://localhost:8888/api/collaboration/room/abc",
+        ) as mock_ws_url, patch(
+            "jupyter_mcp_server.notebook_manager.NbModelClient"
+        ) as MockClient:
+            mock_notebook = MagicMock()
+            mock_notebook.__aenter__ = fake_aenter
+            mock_notebook.__aexit__ = fake_aexit
+            MockClient.return_value = mock_notebook
+
+            await connection.__aenter__()
+
+        assert mock_ws_url.call_args.kwargs["headers"] == {
+            "Cookie": "_xsrf=tok; session=abc",
+            "X-XSRFToken": "tok",
+        }
+        assert mock_ws_url.call_args.kwargs["provider"] == "jupyter"
+
+
+# ---------------------------------------------------------------------------
+# End-to-end tests against a real password-protected Jupyter server
+# ---------------------------------------------------------------------------
+
+
+async def _read_cell_until(mcp_client, cell_index, expected_substring, timeout=30.0, interval=0.5):
+    """Read a cell repeatedly until ``expected_substring`` appears, or timeout.
+
+    In MCP_SERVER mode both execute and read go through the collaboration YDoc,
+    which is eventually consistent: a kernel's outputs are applied to the shared
+    document slightly *after* insert_execute_code_cell returns. A single read can
+    therefore race ahead of the sync and see the cell with no output yet
+    ("execution count: N/A"). Poll the read-back so the round-trip assertion is
+    robust to that lag under load, while still failing if the output never syncs.
+    """
+    deadline = time.monotonic() + timeout
+    cell = await mcp_client.read_cell(cell_index=cell_index)
+    while expected_substring not in str(cell) and time.monotonic() < deadline:
+        await asyncio.sleep(interval)
+        cell = await mcp_client.read_cell(cell_index=cell_index)
+    return cell
+
+
+class TestPasswordAuthE2E:
+    """E2E tests that spin up a real Jupyter server with password auth
+    and verify the full MCP flow works end-to-end.
+
+    These tests use the ``mcp_client_password`` fixture which starts:
+    1. A JupyterLab server with password auth (no token)
+    2. A standalone MCP server configured with --jupyter-password
+    3. An MCPClient connected to the MCP server
+    """
+
+    @pytest.mark.asyncio
+    async def test_password_auth_health(self, jupyter_mcp_server_password):
+        """MCP server health endpoint works when authenticated via password."""
+        import requests
+        response = requests.get(f"{jupyter_mcp_server_password}/api/healthz")
+        assert response.status_code == 200
+        data = response.json()
+        assert data["status"] == "healthy"
+
+    @pytest.mark.asyncio
+    async def test_password_auth_list_tools(self, mcp_client_password):
+        """MCP protocol list_tools works with password auth."""
+        async with mcp_client_password:
+            tools = await mcp_client_password.list_tools()
+        tool_names = [tool.name for tool in tools.tools]
+        assert "execute_code" in tool_names
+        assert "use_notebook" in tool_names
+
+    @pytest.mark.asyncio
+    async def test_password_auth_execute_code(self, mcp_client_password):
+        """KernelClient works with password cookie/XSRF auth."""
+        # Multiply two large ints so the expected value can't appear incidentally
+        # in an error message or unrelated output (a bare "4" easily could).
+        factor_a, factor_b = 98765, 43210
+        expected_product = str(factor_a * factor_b)
+        async with mcp_client_password:
+            result = await mcp_client_password.execute_code(f"{factor_a} * {factor_b}")
+        assert result is not None
+        assert "result" in result
+        outputs = result["result"]
+        assert any(expected_product in str(output) for output in outputs), (
+            f"expected product {expected_product} not found in outputs: {outputs}"
+        )
+
+    @pytest.mark.asyncio
+    async def test_password_auth_create_notebook(
+        self, mcp_client_password, jupyter_password_root_dir
+    ):
+        """Creating a notebook via mode="create" works under password auth.
+
+        Creating a notebook is a state-changing PUT to /api/contents, which
+        Jupyter's XSRF protection guards. The injected session carries the
+        _xsrf cookie but not the matching X-XSRFToken header; without the header
+        the create POST fails with "403: '_xsrf' argument missing from POST".
+        This exercises the header-echo fix and is the create-mode counterpart to
+        test_password_auth_notebook_operations (which only covers connect).
+        """
+        notebook_name = f"created_{uuid.uuid4().hex[:8]}.ipynb"
+        notebook_path = jupyter_password_root_dir / notebook_name
+        try:
+            async with mcp_client_password:
+                create_result = await mcp_client_password.use_notebook(
+                    notebook_name="created_test",
+                    notebook_path=notebook_name,
+                    mode="create",
+                )
+                assert isinstance(create_result, str)
+                assert "error" not in create_result.lower(), (
+                    f"use_notebook(mode='create') returned an error: {create_result}"
+                )
+                assert "_xsrf" not in create_result, (
+                    f"create hit the XSRF check: {create_result}"
+                )
+                # The file must actually exist on the server's disk.
+                assert notebook_path.exists(), (
+                    f"notebook was not created on disk at {notebook_path}"
+                )
+
+                # A round-trip over the freshly-created notebook should work too.
+                factor_a, factor_b = 31337, 71993
+                expected_product = str(factor_a * factor_b)
+                await mcp_client_password.insert_execute_code_cell(
+                    0, f"{factor_a} * {factor_b}"
+                )
+                cell = await _read_cell_until(mcp_client_password, 0, expected_product)
+                assert expected_product in str(cell), (
+                    f"expected product {expected_product} not found in cell: {cell}"
+                )
+        finally:
+            notebook_path.unlink(missing_ok=True)
+
+    @pytest.mark.asyncio
+    async def test_password_auth_notebook_operations(self, mcp_client_password, password_notebook):
+        """WebSocket collaboration path works with password auth.
+
+        This is the most critical test — it exercises the Cookie header that
+        NbModelClient injects into the WebSocket handshake via additional_headers.
+        It drives a full round-trip over the collaboration WebSocket: insert and
+        execute a cell, then read its output back, verifying actual content
+        rather than merely a non-null read.
+        """
+        factor_a, factor_b = 13577, 24683
+        expected_product = str(factor_a * factor_b)
+        async with mcp_client_password:
+            # Connect to the notebook (triggers WebSocket collaboration)
+            use_result = await mcp_client_password.use_notebook(
+                notebook_name="password_test",
+                notebook_path=password_notebook,
+                mode="connect",
+            )
+            assert isinstance(use_result, str)
+            assert "error" not in use_result.lower(), f"use_notebook returned an error: {use_result}"
+
+            # Insert + execute a cell over the WebSocket collaboration path...
+            await mcp_client_password.insert_execute_code_cell(0, f"{factor_a} * {factor_b}")
+
+            # ...and read it back to confirm the round-trip produced the right output.
+            cell = await _read_cell_until(mcp_client_password, 0, expected_product)
+            assert cell is not None
+            assert expected_product in str(cell), (
+                f"expected product {expected_product} not found in cell: {cell}"
+            )
+
+
+# ---------------------------------------------------------------------------
+# Session-expiry / re-login tests
+# ---------------------------------------------------------------------------
+
+
+class TestSessionExpiry:
+    """Tests that verify behaviour when a password-auth session cookie expires.
+
+    ``jupyter_server_short_cookie`` starts a Jupyter server whose session cookie
+    is configured to expire after a very short TTL (``_COOKIE_TTL_SECONDS``).
+    """
+
+    def test_expired_cookie_causes_auth_failure(self, jupyter_server_short_cookie):
+        """After the cookie TTL elapses, GET /api/status returns 401 or 403.
+
+        This is the red test that proves expiry actually breaks the session —
+        a prerequisite for any re-login logic being meaningful.
+        """
+        import time
+        from tests.conftest import JUPYTER_PASSWORD, _COOKIE_TTL_SECONDS
+
+        auth = JupyterPasswordAuth(jupyter_server_short_cookie, JUPYTER_PASSWORD)
+        auth.login()
+
+        # Sanity-check: session works immediately after login.
+        initial = auth._session.get(f"{jupyter_server_short_cookie}/api/status")
+        assert initial.status_code == 200, (
+            f"Expected 200 right after login, got {initial.status_code}"
+        )
+
+        # Wait for the cookie to expire.
+        time.sleep(_COOKIE_TTL_SECONDS + 1)
+
+        # The session cookie has expired; the request should now be rejected.
+        expired = auth._session.get(f"{jupyter_server_short_cookie}/api/status")
+        assert expired.status_code in (401, 403), (
+            f"Expected 401/403 after cookie expiry, got {expired.status_code}"
+        )
+
+        auth.close()
+
+    def test_relogin_restores_session_after_expiry(self, jupyter_server_short_cookie):
+        """relogin() obtains a fresh session and subsequent requests succeed."""
+        import time
+        from tests.conftest import JUPYTER_PASSWORD, _COOKIE_TTL_SECONDS
+
+        auth = JupyterPasswordAuth(jupyter_server_short_cookie, JUPYTER_PASSWORD)
+        auth.login()
+
+        time.sleep(_COOKIE_TTL_SECONDS + 1)
+
+        # Confirm the session is stale.
+        assert auth._session.get(
+            f"{jupyter_server_short_cookie}/api/status"
+        ).status_code in (401, 403)
+
+        # Re-login and verify the session is working again.
+        auth.relogin()
+        restored = auth._session.get(f"{jupyter_server_short_cookie}/api/status")
+        assert restored.status_code == 200, (
+            f"Expected 200 after relogin, got {restored.status_code}"
+        )
+
+        auth.close()
+
+    @pytest.mark.asyncio
+    async def test_notebook_operations_recover_after_session_expiry(
+        self, jupyter_server_short_cookie, jupyter_short_cookie_root_dir
+    ):
+        """Notebook collaboration operations succeed even after the session cookie
+        expires, because NotebookConnection auto-relogs on 401/403.
+
+        The MCP server is started fresh against the short-cookie Jupyter server so
+        it logs in at startup, then the test waits for the cookie to expire before
+        attempting a notebook operation.
+        """
+        import time
+        import uuid
+        import nbformat
+        from tests.conftest import (
+            _find_free_port,
+            _start_server,
+            JUPYTER_PASSWORD,
+            _COOKIE_TTL_SECONDS,
+        )
+        from tests.test_common import MCPClient
+
+        factor_a, factor_b = 47293, 81637
+        expected_product = str(factor_a * factor_b)
+        notebook_name = f"relogin_test_{uuid.uuid4().hex[:8]}.ipynb"
+        notebook_path = jupyter_short_cookie_root_dir / notebook_name
+        nbformat.write(nbformat.v4.new_notebook(), str(notebook_path))
+
+        host = "localhost"
+        port = _find_free_port()
+        for mcp_url in _start_server(
+            name="MCP (relogin test)",
+            host=host,
+            port=port,
+            command=[
+                "python", "-m", "jupyter_mcp_server",
+                "--transport", "streamable-http",
+                "--document-url", jupyter_server_short_cookie,
+                "--document-id", notebook_name,
+                "--runtime-url", jupyter_server_short_cookie,
+                "--start-new-runtime", "True",
+                "--jupyter-password", JUPYTER_PASSWORD,
+                "--insecure-mcp-noauth",
+                "--port", str(port),
+            ],
+            readiness_endpoint="/api/healthz",
+        ):
+            # Wait for the session cookie to expire before making notebook calls.
+            time.sleep(_COOKIE_TTL_SECONDS + 1)
+
+            async with MCPClient(mcp_url, token=None) as client:
+                use_result = await client.use_notebook(
+                    notebook_name="relogin_test",
+                    notebook_path=notebook_name,
+                    mode="connect",
+                )
+                assert "error" not in str(use_result).lower(), (
+                    f"use_notebook failed after session expiry: {use_result}"
+                )
+                await client.insert_execute_code_cell(0, f"{factor_a} * {factor_b}")
+                cell = await client.read_cell(cell_index=0)
+                assert expected_product in str(cell), (
+                    f"Expected product {expected_product} not found in cell: {cell}"
+                )
+        notebook_path.unlink(missing_ok=True)


### PR DESCRIPTION
## Summary

Adds password-based authentication as an alternative to token auth, enabling the MCP server to work with Jupyter deployments that use password login and XSRF protection.

**Related issues:** Partially addresses #183 (XSRF-protected Jupyter deployments without Bearer tokens), related to #61 (WebSocket authentication failures)

### Changes

- New `JupyterPasswordAuth` class (`auth.py`) handles the `/login` flow: obtains XSRF cookie, POSTs credentials, verifies the session, and keeps a `requests.Session` alive so subsequent callers see live cookie values rather than a login-time snapshot.
- CLI options `--runtime-password`, `--document-password`, `--jupyter-password` (with corresponding env vars `RUNTIME_PASSWORD`, `DOCUMENT_PASSWORD`, `JUPYTER_PASSWORD`) follow the same priority/fallback pattern as existing token options. Password takes precedence over token when both are set for the same server.
- Auth cookies are injected into `JupyterServerClient`, `KernelClient`, and the collaboration WebSocket connection. The fresh `X-XSRFToken` header is read per-request from the live cookie jar, so cookie rotation is handled correctly.
- Two separate auth instances: `_runtime_password_auth` for kernel operations and `_document_password_auth` for collaboration. When `runtime_url == document_url` the runtime auth is reused; when URLs differ and `--document-password` is set, a second login is performed. A warning is logged when the document server is genuinely different and only `--runtime-password` is set.
- The collaboration WebSocket now uses `jupyter-nbmodel-client`'s native `additional_headers` (NbModelClient) and `headers` (`get_notebook_websocket_url`) parameters to inject the Cookie/XSRF auth — see "Removed monkey-patch" below.
- **Automatic re-login on session expiry**: Jupyter session cookies expire (30 days by default), so long-running sessions could go stale. `NotebookConnection` now catches `401/403` on the collaboration-session request, re-authenticates (`ServerContext.relogin_document()` → `JupyterPasswordAuth.relogin()`), re-injects the fresh cookies, and retries once.
- Refactored duplicated `_init_mcp_server_mode` logic in `server_context.py` into a single method with proper resource cleanup on partial failure. `ServerContext.reset()` now closes auth sessions to release connection pools.
- The CLI decorator was split into `_remote_connection_options` (the subset that `connect` can forward over `/api/connect`) and `_connection_options` (adds local-only password options used by `start`). This also fixed a pre-existing `TypeError` in `connect_command` on `main`.
- Comprehensive test suite (`test_auth.py`) covering the login flow (success, timeout, connection error at each stage, 5xx, 401/403, missing-xsrf, unexpected-status, response-body propagation), header generation, session injection, config normalization, dual runtime/document auth scenarios, session expiry / re-login, and e2e tests against a real password-protected Jupyter server.

### How it works

1. On startup, if a password is configured, `ServerContext` creates a `JupyterPasswordAuth` instance and calls `.login()` to authenticate.
2. The resulting session cookies are injected into `JupyterServerClient`'s HTTP session, and the auth's own `requests.Session` is kept alive so cookies remain readable for the document side.
3. For `KernelClient` and collaboration API requests, auth headers (`Cookie` + `X-XSRFToken`) are passed via the `headers` kwarg and computed per-request from the live cookie jar.
4. The `runtime_auth_headers` and `document_auth_headers` properties on `ServerContext` always read the latest cookies from the active session (not the stale login-time snapshot).
5. If a collaboration request returns `401/403` (expired cookie), the connection re-authenticates and retries once with the fresh cookies.

### Removed monkey-patch

Earlier revisions of this PR monkey-patched the module-level `connect` imported in `jupyter_nbmodel_client.client` to inject the Cookie header during the WebSocket handshake, because `NbModelClient` exposed no way to pass extra headers. That patch was not concurrency-safe.

This is now resolved upstream: [jupyter-nbmodel-client#61](https://github.com/datalayer/jupyter-nbmodel-client/pull/61) added `additional_headers=` to `NbModelClient` and `headers=` to `get_notebook_websocket_url` (released in `jupyter-nbmodel-client 0.14.8`). The monkey-patch and the re-implemented URL helper have been removed; the minimum dependency is bumped to `>=0.14.8`.

### Known limitation

The automatic re-login currently covers the **collaboration / document path** (`NotebookConnection`). Kernel-management HTTP requests that go through `jupyter_server_client` internals are not yet wrapped in the same retry; this can be a follow-up.

## Test plan

- [x] `uv run --extra test pytest tests/test_auth.py` passes (unit + e2e, including session-expiry/re-login tests against a real password-protected Jupyter server)
- [x] Test with a password-protected Jupyter server: `jupyter lab --IdentityProvider.token='' --ServerApp.password='argon2:...'`
- [x] Verify token-based auth still works unchanged (backward compatible)
- [x] Verify that `--jupyter-password` falls back correctly when individual passwords are not set
- [x] Verify that `jupyter-mcp-server connect --help` shows no `--*-password` options (passwords are local-only; not forwardable over `/api/connect`)