### PR TITLE
Working Directory Fix for #253

### DIFF
--- a/jupyter_mcp_server/jupyter_extension/backends/local_backend.py
+++ b/jupyter_mcp_server/jupyter_extension/backends/local_backend.py
@@ -351,8 +351,10 @@ class LocalBackend(Backend):
         if kernel_id and kernel_id in self.kernel_manager:
             return kernel_id
         
-        # Start new kernel
-        kernel_id = await self.kernel_manager.start_kernel()
+        # Pass path so MappingKernelManager.cwd_for_path() sets the kernel's
+        # working directory to the notebook's directory, matching JupyterLab's
+        # behavior for human users.
+        kernel_id = await self.kernel_manager.start_kernel(path=path)
         return kernel_id
     
     async def execute_cell(

--- a/jupyter_mcp_server/tools/use_notebook_tool.py
+++ b/jupyter_mcp_server/tools/use_notebook_tool.py
@@ -19,7 +19,7 @@ logger = logging.getLogger(__name__)
 class UseNotebookTool(BaseTool):
     """Tool to use (connect to or create) a notebook file."""
     
-    async def _start_kernel_local(self, kernel_manager: Any):
+    async def _start_kernel_local(self, kernel_manager: Any, path: Optional[str] = None):
         # Start a new kernel using local API
         kernel_id = await kernel_manager.start_kernel()
         logger.info(f"Started kernel '{kernel_id}', waiting for it to be ready...")
@@ -212,7 +212,7 @@ class UseNotebookTool(BaseTool):
                         return f"Kernel '{kernel_id}' not found in local kernel manager."
                     kernel = {"id": kernel_id}
                 else:
-                    kernel = await self._start_kernel_local(kernel_manager)
+                    kernel = await self._start_kernel_local(kernel_manager, path=notebook_path)
                     kernel_id = kernel['id']
 
                 info_list.append(f"[INFO] Connected to kernel '{kernel_id}'.")


### PR DESCRIPTION
This is the 2-line change mentioned in #253, passing a path to the Jupyter notebook kernel opening function so that the MCP behavior lines up with Jupyter Lab human user behavior (opening a notebook will have the working directory set to the folder that it is in)