### PR TITLE
feat: add --reconnect-interval option for WebSocket auto-reconnect

### DIFF
--- a/jupyter_mcp_server/CLI.py
+++ b/jupyter_mcp_server/CLI.py
@@ -116,7 +116,14 @@ def _common_options(f):
             type=click.STRING,
             default="notebook_run-all-cells,notebook_get-selected-cell",
             help="Comma-separated list of jupyter-mcp-tools to enable. Defaults to 'notebook_run-all-cells,notebook_get-selected-cell' - Only applicable when run as jupyter server extension.",
-        )
+        ),
+        click.option(
+            "--reconnect-interval",
+            envvar="RECONNECT_INTERVAL",
+            type=click.INT,
+            default=0,
+            help="Seconds to wait before reconnecting a dropped WebSocket connection to the kernel. Defaults to 0 (disabled).",
+        ),
     ]
     # Apply decorators in reverse order
     for option in reversed(options):
@@ -189,6 +196,7 @@ def _do_start(
     otel_file: str = "",
     mcp_token: str = None,
     insecure_mcp_noauth: bool = False,
+    reconnect_interval: int = 0,
 ):
     """Internal function to execute the start logic."""
 
@@ -222,7 +230,8 @@ def _do_start(
         document_token=document_token,
         port=port,
         jupyterlab=jupyterlab,
-        allowed_jupyter_mcp_tools=allowed_jupyter_mcp_tools
+        allowed_jupyter_mcp_tools=allowed_jupyter_mcp_tools,
+        reconnect_interval=reconnect_interval,
     )
 
     # Reset ServerContext to pick up new configuration
@@ -347,6 +356,7 @@ def server(
     jupyterlab: bool,
     allowed_jupyter_mcp_tools: str,
     otel_file: str,
+    reconnect_interval: int,
 ):
     """Manages Jupyter MCP Server.
 
@@ -386,6 +396,7 @@ def server(
         otel_file=otel_file,
         mcp_token=mcp_token,
         insecure_mcp_noauth=insecure_mcp_noauth,
+        reconnect_interval=reconnect_interval,
     )
 
 
@@ -530,6 +541,7 @@ def start_command(
     jupyterlab: bool,
     allowed_jupyter_mcp_tools: str,
     otel_file: str,
+    reconnect_interval: int,
 ):
     """Start the Jupyter MCP server with a transport."""
     # Resolve URL and token variables based on priority logic
@@ -558,6 +570,7 @@ def start_command(
         otel_file=otel_file,
         mcp_token=mcp_token,
         insecure_mcp_noauth=insecure_mcp_noauth,
+        reconnect_interval=reconnect_interval,
     )
 
 

--- a/jupyter_mcp_server/config.py
+++ b/jupyter_mcp_server/config.py
@@ -31,6 +31,7 @@ class JupyterMCPConfig(BaseModel):
     port: int = Field(default=4040, description="The port to use for the Streamable HTTP transport")
     jupyterlab: bool = Field(default=True, description="Enable JupyterLab mode (defaults to True)")
     allowed_jupyter_mcp_tools: str = Field(default="notebook_run-all-cells,notebook_get-selected-cell", description="Comma-separated list of jupyter-mcp-tools to enable")
+    reconnect_interval: int = Field(default=0, description="Seconds to wait before reconnecting a dropped WebSocket connection to the kernel. 0 disables auto-reconnect.")
     
     class Config:
         """Pydantic configuration."""

--- a/jupyter_mcp_server/utils.py
+++ b/jupyter_mcp_server/utils.py
@@ -257,10 +257,14 @@ def create_kernel(config, logger):
     kernel = None
     try:
         # Initialize the kernel client with the provided parameters.
+        client_kwargs = {}
+        if getattr(config, "reconnect_interval", 0):
+            client_kwargs["reconnect_interval"] = config.reconnect_interval
         kernel = KernelClient(
-            server_url=config.runtime_url, 
-            token=config.runtime_token, 
-            kernel_id=config.runtime_id
+            server_url=config.runtime_url,
+            token=config.runtime_token,
+            kernel_id=config.runtime_id,
+            client_kwargs=client_kwargs if client_kwargs else None,
         )
         kernel.start()
         logger.info("Kernel created and started successfully")

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -8,8 +8,9 @@ Simple test script to verify the configuration system works correctly.
 """
 
 import os
+from unittest.mock import MagicMock, patch
 
-from jupyter_mcp_server.config import get_config, set_config, reset_config
+from jupyter_mcp_server.config import JupyterMCPConfig, get_config, reset_config, set_config
 
 def test_config():
     """Test the configuration singleton."""
@@ -109,7 +110,85 @@ def test_jupyter_extension_trait():
     print("✅ Jupyter extension trait test completed successfully!")
 
 
+def test_create_kernel_passes_reconnect_interval():
+    """Verify create_kernel passes reconnect_interval to KernelClient via client_kwargs."""
+    from jupyter_mcp_server.utils import create_kernel
+
+    config = JupyterMCPConfig(
+        runtime_url="http://localhost:8888",
+        runtime_token="test_token",
+        runtime_id="test-kernel-id",
+        reconnect_interval=5,
+    )
+
+    with patch("jupyter_kernel_client.KernelClient") as MockKernelClient:
+        mock_kernel = MagicMock()
+        MockKernelClient.return_value = mock_kernel
+
+        create_kernel(config, MagicMock())
+
+        MockKernelClient.assert_called_once_with(
+            server_url="http://localhost:8888",
+            token="test_token",
+            kernel_id="test-kernel-id",
+            client_kwargs={"reconnect_interval": 5},
+        )
+        mock_kernel.start.assert_called_once()
+
+    print("test create_kernel passes reconnect_interval: OK")
+
+
+def test_create_kernel_no_reconnect_by_default():
+    """Verify create_kernel does not pass client_kwargs when reconnect_interval=0."""
+    from jupyter_mcp_server.utils import create_kernel
+
+    config = JupyterMCPConfig(
+        runtime_url="http://localhost:8888",
+        runtime_token="test_token",
+        runtime_id="test-kernel-id",
+        reconnect_interval=0,
+    )
+
+    with patch("jupyter_kernel_client.KernelClient") as MockKernelClient:
+        mock_kernel = MagicMock()
+        MockKernelClient.return_value = mock_kernel
+
+        create_kernel(config, MagicMock())
+
+        MockKernelClient.assert_called_once_with(
+            server_url="http://localhost:8888",
+            token="test_token",
+            kernel_id="test-kernel-id",
+            client_kwargs=None,
+        )
+
+    print("test create_kernel no reconnect by default: OK")
+
+
+def test_reconnect_interval_config():
+    """Test the reconnect_interval configuration field."""
+    reset_config()
+
+    # Default should be 0 (disabled)
+    config = get_config()
+    assert config.reconnect_interval == 0
+
+    # Setting a positive value
+    new_config = set_config(reconnect_interval=5)
+    assert new_config.reconnect_interval == 5
+
+    # Singleton reflects the update
+    assert get_config().reconnect_interval == 5
+
+    # Reset restores to 0
+    reset_config()
+    assert get_config().reconnect_interval == 0
+
+    print("✅ reconnect_interval configuration test completed successfully!")
+
+
 if __name__ == "__main__":
     test_config()
     test_allowed_jupyter_mcp_tools_config()
     test_jupyter_extension_trait()
+    test_reconnect_interval_config()


### PR DESCRIPTION
## Problem

When the network connection to the Jupyter kernel drops, `KernelWebSocketClient` permanently tears down its WebSocket connection (default `reconnect=0` in `websocket-client`). This leaves the MCP server unable to execute code even after the network recovers — the only fix is a full MCP server restart.

## Solution

Add a `--reconnect-interval <seconds>` CLI flag (and `RECONNECT_INTERVAL` env var) that passes a non-zero reconnect delay through to `KernelWebSocketClient` via `KernelClient`'s `client_kwargs`. When set, the WebSocket layer retries indefinitely every N seconds until the kernel is reachable again.

## Changes

- **`config.py`**: add `reconnect_interval: int = 0` field to `JupyterMCPConfig`
- **`CLI.py`**: add `--reconnect-interval` / `RECONNECT_INTERVAL` option to `server` and `start` commands
- **`utils.py`**: pass `client_kwargs={"reconnect_interval": N}` to `KernelClient` when non-zero
- **`tests/test_config.py`**: unit tests with mocked `KernelClient` verifying kwargs are passed correctly

## Usage

```bash
jupyter-mcp-server --reconnect-interval 5
# or
RECONNECT_INTERVAL=5 jupyter-mcp-server
```

## Behaviour

- `--reconnect-interval 0` (default): unchanged behaviour — no reconnect on drop
- `--reconnect-interval N` (N > 0): WebSocket retries every N seconds until the kernel comes back; MCP server stays alive and recovers automatically

## Test

```
tests/test_config.py::test_create_kernel_passes_reconnect_interval  PASSED
tests/test_config.py::test_create_kernel_no_reconnect_by_default    PASSED
tests/test_config.py::test_reconnect_interval_config                PASSED
```