### PR TITLE
feat: increase execute_code timeout maximum from 60s to 3600s

### DIFF
--- a/jupyter_mcp_server/server.py
+++ b/jupyter_mcp_server/server.py
@@ -694,7 +694,7 @@ async def move_cell(
 @with_hooks("execute_code")
 async def execute_code(
     code: Annotated[str, Field(description="Code to execute (supports magic commands with %, shell commands with !)")],
-    timeout: Annotated[int, Field(description="Execution timeout in seconds",le=60)] = 30,
+    timeout: Annotated[int, Field(description="Execution timeout in seconds",le=3600)] = 30,
     kernel_id: Annotated[str | None, Field(description="Target an existing kernel by ID (e.g. a raw kernel with no notebook). If omitted, uses the current notebook's kernel.")] = None,
 ) -> Annotated[list[str | ImageContent], Field(description="List of outputs from the executed code")]:
     """Execute code directly in a kernel (not saved to notebook).


### PR DESCRIPTION
## Summary

- The `timeout` parameter in `execute_code` had a hard cap of 60 seconds (`le=60`), which is too restrictive for long-running kernel tasks (e.g. processing large files, training models, running simulations).
- This PR raises the maximum to 3600s (1 hour) while keeping the **default unchanged at 30s**.
- Callers who do not specify `timeout` see no behavior change. The change only unlocks the ability to opt in to a longer timeout when needed.

## Tested locally

- `execute_code` still defaults to 30s timeout when `timeout` is not specified ✅
- Specifying `timeout=90` is accepted by the tool schema ✅
- `time.sleep(65)` with `timeout=120` completes successfully (previously would have been interrupted at 60s) ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)