### PR TITLE
Protect management routes

### DIFF
--- a/jupyter_mcp_server/CLI.py
+++ b/jupyter_mcp_server/CLI.py
@@ -180,6 +180,12 @@ def _resolve_url_and_token_variables(
     return resolved_document_url, resolved_document_token, resolved_runtime_url, resolved_runtime_token
 
 
+def _mcp_auth_headers(mcp_token: str | None) -> dict[str, str]:
+    if not mcp_token:
+        return {}
+    return {"Authorization": f"Bearer {mcp_token}"}
+
+
 def _do_start(
     transport: str,
     start_new_runtime: bool,
@@ -424,18 +430,28 @@ def connect_command(
     jupyter_url: str,
     jupyter_token: str,
     allowed_jupyter_mcp_tools: str,
+    reconnect_interval: int,
 ):
     """Command to connect a Jupyter MCP Server to a document and a runtime."""
+
+    resolved_document_url, resolved_document_token, resolved_runtime_url, resolved_runtime_token = _resolve_url_and_token_variables(
+        jupyter_url=jupyter_url,
+        jupyter_token=jupyter_token,
+        document_url=document_url,
+        document_token=document_token,
+        runtime_url=runtime_url,
+        runtime_token=runtime_token,
+    )
 
     # Set configuration using the singleton
     config = set_config(
         provider=provider,
-        runtime_url=runtime_url,
+        runtime_url=resolved_runtime_url,
         runtime_id=runtime_id,
-        runtime_token=runtime_token,
-        document_url=document_url,
+        runtime_token=resolved_runtime_token,
+        document_url=resolved_document_url,
         document_id=document_id,
-        document_token=document_token,
+        document_token=resolved_document_token,
         jupyterlab=jupyterlab
     )
     
@@ -472,6 +488,7 @@ def connect_command(
         headers={
             "Content-Type": "application/json",
             "Accept": "application/json",
+            **_mcp_auth_headers(mcp_token),
         },
         content=document_runtime.model_dump_json(),
     )
@@ -486,9 +503,17 @@ def connect_command(
     default="http://localhost:4040",
     help="The URL of the Jupyter MCP Server to stop. Defaults to 'http://localhost:4040'.",
 )
-def stop_command(jupyter_mcp_server_url: str):
+@click.option(
+    "--mcp-token",
+    envvar="MCP_TOKEN",
+    type=click.STRING,
+    default=None,
+    help="Token for authenticating to the Jupyter MCP Server management route.",
+)
+def stop_command(jupyter_mcp_server_url: str, mcp_token: str):
     r = httpx.delete(
         f"{jupyter_mcp_server_url}/api/stop",
+        headers=_mcp_auth_headers(mcp_token),
     )
     r.raise_for_status()
 

--- a/jupyter_mcp_server/server.py
+++ b/jupyter_mcp_server/server.py
@@ -7,15 +7,17 @@ Jupyter MCP Server Layer
 """
 
 from typing import Annotated, Literal, Optional
-from pydantic import Field
+from urllib.parse import urlsplit
+
 from fastapi import Request
 from jupyter_kernel_client import KernelClient
-
 from mcp.server import FastMCP
-from mcp.server.auth.provider import AccessToken, TokenVerifier
+from mcp.server.auth.provider import AccessToken
 from mcp.types import ImageContent, ToolAnnotations
-from starlette.middleware.cors import CORSMiddleware
+from pydantic import Field
 from starlette.applications import Starlette
+from starlette.middleware.base import BaseHTTPMiddleware
+from starlette.middleware.cors import CORSMiddleware
 from starlette.responses import JSONResponse
 
 from jupyter_mcp_server.log import logger
@@ -77,6 +79,74 @@ class RuntimeTokenVerifier:
         return AccessToken(token=token, client_id="mcp-client", scopes=[])
 
 
+MANAGEMENT_ROUTE_PATHS = {"/api/connect", "/api/stop", "/api/healthz"}
+AUTHENTICATED_MANAGEMENT_ROUTE_PATHS = {"/api/connect", "/api/stop"}
+LOCAL_HOSTNAMES = {"localhost", "127.0.0.1", "::1"}
+
+
+def _is_local_hostname(hostname: str | None) -> bool:
+    return bool(hostname and hostname.lower() in LOCAL_HOSTNAMES)
+
+
+def _is_management_route(path: str) -> bool:
+    return path.rstrip("/") in MANAGEMENT_ROUTE_PATHS
+
+
+def _is_authenticated_management_route(path: str) -> bool:
+    return path.rstrip("/") in AUTHENTICATED_MANAGEMENT_ROUTE_PATHS
+
+
+class ManagementRouteSecurityMiddleware(BaseHTTPMiddleware):
+    """Apply authentication and browser-origin checks to management routes."""
+
+    def __init__(self, app, token_verifier=None):
+        super().__init__(app)
+        self._token_verifier = token_verifier
+
+    async def dispatch(self, request: Request, call_next):
+        if not _is_management_route(request.url.path):
+            return await call_next(request)
+
+        if not _is_local_hostname(request.url.hostname):
+            return JSONResponse({"error": "Invalid Host header"}, status_code=421)
+
+        origin = request.headers.get("origin")
+        if origin:
+            origin_hostname = urlsplit(origin).hostname
+            if not _is_local_hostname(origin_hostname):
+                return JSONResponse({"error": "Invalid Origin header"}, status_code=403)
+
+        if self._token_verifier and _is_authenticated_management_route(request.url.path):
+            auth_header = request.headers.get("authorization", "")
+            scheme, _, token = auth_header.partition(" ")
+            if scheme.lower() != "bearer" or not token:
+                return JSONResponse(
+                    {"error": "invalid_token", "error_description": "Authentication required"},
+                    status_code=401,
+                    headers={
+                        "WWW-Authenticate": (
+                            'Bearer error="invalid_token", '
+                            'error_description="Authentication required"'
+                        )
+                    },
+                )
+
+            access_token = await self._token_verifier.verify_token(token)
+            if not access_token:
+                return JSONResponse(
+                    {"error": "invalid_token", "error_description": "Invalid token"},
+                    status_code=401,
+                    headers={
+                        "WWW-Authenticate": (
+                            'Bearer error="invalid_token", '
+                            'error_description="Invalid token"'
+                        )
+                    },
+                )
+
+        return await call_next(request)
+
+
 class FastMCPWithCORS(FastMCP):
     def streamable_http_app(self) -> Starlette:
         """Return StreamableHTTP server app with CORS and auth middleware.
@@ -88,6 +158,11 @@ class FastMCPWithCORS(FastMCP):
         # that actually validates Bearer tokens — that requires settings.auth
         # which we don't use). Add it here directly.
         app = super().streamable_http_app()
+
+        app.add_middleware(
+            ManagementRouteSecurityMiddleware,
+            token_verifier=self._token_verifier,
+        )
 
         if self._token_verifier:
             from starlette.middleware.authentication import AuthenticationMiddleware

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -12,6 +12,84 @@ from unittest.mock import MagicMock, patch
 
 from jupyter_mcp_server.config import JupyterMCPConfig, get_config, reset_config, set_config
 
+
+def test_mcp_auth_headers_include_bearer_token():
+    """Management CLI requests include the MCP bearer token when configured."""
+    from jupyter_mcp_server.CLI import _mcp_auth_headers
+
+    assert _mcp_auth_headers("client-token") == {
+        "Authorization": "Bearer client-token",
+    }
+
+
+def test_mcp_auth_headers_empty_without_token():
+    """Management CLI requests stay unauthenticated in explicit no-auth mode."""
+    from jupyter_mcp_server.CLI import _mcp_auth_headers
+
+    assert _mcp_auth_headers(None) == {}
+
+
+def test_connect_command_sends_mcp_token():
+    """The first-party connect command remains compatible with protected routes."""
+    from click.testing import CliRunner
+
+    from jupyter_mcp_server.CLI import server
+
+    class Response:
+        def raise_for_status(self):
+            pass
+
+    seen = {}
+
+    def fake_put(url, headers=None, content=None):
+        seen["headers"] = headers
+        return Response()
+
+    with patch("jupyter_mcp_server.CLI.httpx.put", fake_put):
+        result = CliRunner().invoke(
+            server,
+            [
+                "connect",
+                "--jupyter-url",
+                "http://localhost:8888",
+                "--jupyter-token",
+                "jupyter-token",
+                "--runtime-id",
+                "kernel-id",
+                "--document-id",
+                "notebook.ipynb",
+                "--mcp-token",
+                "client-token",
+            ],
+        )
+
+    assert result.exit_code == 0
+    assert seen["headers"]["Authorization"] == "Bearer client-token"
+
+
+def test_stop_command_sends_mcp_token():
+    """The first-party stop command remains compatible with protected routes."""
+    from click.testing import CliRunner
+
+    from jupyter_mcp_server.CLI import server
+
+    class Response:
+        def raise_for_status(self):
+            pass
+
+    seen = {}
+
+    def fake_delete(url, headers=None):
+        seen["headers"] = headers
+        return Response()
+
+    with patch("jupyter_mcp_server.CLI.httpx.delete", fake_delete):
+        result = CliRunner().invoke(server, ["stop", "--mcp-token", "client-token"])
+
+    assert result.exit_code == 0
+    assert seen["headers"]["Authorization"] == "Bearer client-token"
+
+
 def test_config():
     """Test the configuration singleton."""
     print("Testing Jupyter MCP Configuration System")

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -174,6 +174,84 @@ def test_mcp_token_rejects_runtime_token(mcp_server_with_mcp_token):
     assert r.status_code in (HTTPStatus.FORBIDDEN, HTTPStatus.UNAUTHORIZED)
 
 
+@pytest.mark.skipif(not TEST_MCP_SERVER, reason="TEST_MCP_SERVER disabled")
+def test_management_routes_reject_forged_host(mcp_server_with_mcp_token):
+    """Management routes reject DNS-rebinding Host headers."""
+    import httpx
+
+    r = httpx.put(
+        f"{mcp_server_with_mcp_token}/api/connect",
+        headers={
+            "Host": "attacker.example",
+            "Origin": "http://attacker.example",
+            "Content-Type": "application/json",
+        },
+        json={},
+    )
+    assert r.status_code == HTTPStatus.MISDIRECTED_REQUEST
+
+
+@pytest.mark.skipif(not TEST_MCP_SERVER, reason="TEST_MCP_SERVER disabled")
+def test_management_routes_reject_forged_origin(mcp_server_with_mcp_token):
+    """Management routes reject browser requests from non-local origins."""
+    import httpx
+
+    r = httpx.delete(
+        f"{mcp_server_with_mcp_token}/api/stop",
+        headers={
+            "Host": "localhost",
+            "Origin": "http://attacker.example",
+        },
+    )
+    assert r.status_code == HTTPStatus.FORBIDDEN
+
+
+@pytest.mark.skipif(not TEST_MCP_SERVER, reason="TEST_MCP_SERVER disabled")
+def test_management_routes_require_mcp_token(mcp_server_with_mcp_token):
+    """State-changing management routes require MCP_TOKEN."""
+    import httpx
+
+    r = httpx.put(
+        f"{mcp_server_with_mcp_token}/api/connect",
+        headers={"Content-Type": "application/json"},
+        json={},
+    )
+    assert r.status_code == HTTPStatus.UNAUTHORIZED
+
+
+@pytest.mark.skipif(not TEST_MCP_SERVER, reason="TEST_MCP_SERVER disabled")
+def test_management_routes_reject_runtime_token(mcp_server_with_mcp_token):
+    """State-changing management routes reject the Jupyter runtime token."""
+    import httpx
+
+    r = httpx.delete(
+        f"{mcp_server_with_mcp_token}/api/stop",
+        headers={"Authorization": f"Bearer {JUPYTER_TOKEN}"},
+    )
+    assert r.status_code == HTTPStatus.UNAUTHORIZED
+
+
+@pytest.mark.skipif(not TEST_MCP_SERVER, reason="TEST_MCP_SERVER disabled")
+def test_management_routes_accept_mcp_token(mcp_server_with_mcp_token):
+    """State-changing management routes accept MCP_TOKEN."""
+    import httpx
+
+    r = httpx.delete(
+        f"{mcp_server_with_mcp_token}/api/stop",
+        headers={"Authorization": f"Bearer {MCP_TOKEN}"},
+    )
+    assert r.status_code == HTTPStatus.OK
+
+
+@pytest.mark.skipif(not TEST_MCP_SERVER, reason="TEST_MCP_SERVER disabled")
+def test_management_routes_allow_local_non_browser_request(mcp_server_with_mcp_token):
+    """Local health requests without Origin remain accepted."""
+    import httpx
+
+    r = httpx.get(f"{mcp_server_with_mcp_token}/api/healthz")
+    assert r.status_code == HTTPStatus.OK
+
+
 def _mcp_server_command_insecure_noauth(jupyter_url, port):
     """Build standalone MCP server command with --insecure-mcp-noauth (no --mcp-token)."""
     return [


### PR DESCRIPTION
## Summary

This PR protects the custom management routes used by standalone `streamable-http` mode.

It covers both reported issues:

- `MCP-SEC-005-1`: unauthenticated access to state-changing `/api/*` routes
- `MCP-SEC-012-1`: DNS rebinding against custom management routes

The patch adds a management-route security middleware that:

- rejects non-local `Host` values on `/api/connect`, `/api/stop`, and `/api/healthz`
- rejects non-local browser `Origin` values on those routes
- requires the configured `MCP_TOKEN` for state-changing `/api/connect` and `/api/stop`
- keeps `/api/healthz` available for local readiness checks
- updates the first-party `connect` and `stop` CLI commands to send `Authorization: Bearer $MCP_TOKEN`

## Security impact

Before this change, `/mcp` enforced MCP client authentication and rejected forged browser-origin headers, but the adjacent custom management routes did not consistently share those controls.

The sensitive route is `PUT /api/connect`. It lets the caller replace the active Jupyter backend URL and token fields, reset server context, and start a kernel client against the selected backend. That operation now requires the MCP bearer token and must arrive through a local Host/Origin boundary.

After this change:

- forged `Host: attacker.example` on `/api/connect` returns `421 Misdirected Request`
- forged `Origin: http://attacker.example` on `/api/stop` returns `403 Forbidden`
- unauthenticated `PUT /api/connect` returns `401 Unauthorized`
- `DELETE /api/stop` with the Jupyter runtime token returns `401 Unauthorized`
- `DELETE /api/stop` with the configured `MCP_TOKEN` returns `200 OK`
- local `/api/healthz` requests without an `Origin` remain accepted

## Tests

```bash
UV_CACHE_DIR=/Users/agonen/Projects/jupyter-mcp-server-dns-fix/.uv-cache \
UV_PROJECT_ENVIRONMENT=/Users/agonen/Projects/jupyter-mcp-server-dns-fix/.venv-test \
JUPYTER_RUNTIME_DIR=/Users/agonen/Projects/jupyter-mcp-server-dns-fix/.jupyter-runtime \
JUPYTER_CONFIG_DIR=/Users/agonen/Projects/jupyter-mcp-server-dns-fix/.jupyter-config \
JUPYTER_DATA_DIR=/Users/agonen/Projects/jupyter-mcp-server-dns-fix/.jupyter-data \
uv run --extra test --python 3.12 pytest \
  tests/test_tools.py::test_management_routes_reject_forged_host \
  tests/test_tools.py::test_management_routes_reject_forged_origin \
  tests/test_tools.py::test_management_routes_require_mcp_token \
  tests/test_tools.py::test_management_routes_reject_runtime_token \
  tests/test_tools.py::test_management_routes_accept_mcp_token \
  tests/test_tools.py::test_management_routes_allow_local_non_browser_request \
  tests/test_tools.py::test_mcp_token_accepted \
  tests/test_tools.py::test_mcp_token_rejects_runtime_token \
  tests/test_config.py::test_mcp_auth_headers_include_bearer_token \
  tests/test_config.py::test_mcp_auth_headers_empty_without_token \
  tests/test_config.py::test_connect_command_sends_mcp_token \
  tests/test_config.py::test_stop_command_sends_mcp_token -q
```

Result: `12 passed`.

Broader compatibility run:

```bash
uv run --extra test --python 3.12 pytest tests/test_tools.py -q
```

Result: `39 passed`.