### PR TITLE
feat: add configurable execution timeout (fixes #249)

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@
 >   - local `Host` is required for all management routes
 >   - non-local browser `Origin` is rejected
 >   - `MCP_TOKEN` (Bearer) is required for state-changing routes (`/api/connect`, `/api/stop`)
-> - **Timeout configuration update:** `execute_code` now supports up to **3600s** timeout (default remains **30s**).
+> - **Configurable timeout:** `execute_cell` timeout is now configurable via `JUPYTER_MCP_EXECUTION_TIMEOUT` env var or `execution_timeout` config (default: 120s, max: 3600s). Per-call `timeout=0` uses the config default.
 > 
 > **Update in v1.0.2:** `pycrdt` is now supported, so installing `datalayer_pycrdt` is no longer required.
 > 

--- a/docs/docs/reference/tools/index.mdx
+++ b/docs/docs/reference/tools/index.mdx
@@ -130,7 +130,7 @@ When `use_notebook` starts a new kernel for a notebook, the kernel is started wi
 - Execute a cell from the currently activated notebook with timeout and return it's outputs
 - Input:
   - `cell_index`(int): Index of the cell to execute (0-based)
-  - `timeout`(int, optional): Maximum seconds to wait for execution (default: 90)
+  - `timeout`(int, optional): Maximum seconds to wait for execution (0 = use config default, default: 0). Configurable via `JUPYTER_MCP_EXECUTION_TIMEOUT` env var (default: 120s, max: 3600s)
   - `stream`(bool, optional): Enable streaming progress updates for long-running cells (default: false)
   - `progress_interval`(int, optional): Seconds between progress updates when stream=true (default: 5)
 - Returns: `list[Union[str, ImageContent]]` - List of outputs from the executed cell including text, HTML, and images. Supports streaming mode with progress updates for long-running cells.
@@ -142,7 +142,7 @@ When `use_notebook` starts a new kernel for a notebook, the kernel is started wi
 - Input:
   - `cell_index`(int): Index of the cell to insert and execute (0-based)
   - `cell_source`(string): Code source for the cell
-  - `timeout`(int, optional): Maximum seconds to wait for execution (default: 90)
+  - `timeout`(int, optional): Maximum seconds to wait for execution (0 = use config default, default: 0). Configurable via `JUPYTER_MCP_EXECUTION_TIMEOUT` env var (default: 120s, max: 3600s)
 - Returns: `list[Union[str, ImageContent]]` - List of outputs from the executed cell including text, HTML, and images. Returns both insertion confirmation and execution results.
 
 #### 13. `read_cell`

--- a/jupyter_mcp_server/config.py
+++ b/jupyter_mcp_server/config.py
@@ -32,6 +32,10 @@ class JupyterMCPConfig(BaseModel):
     jupyterlab: bool = Field(default=True, description="Enable JupyterLab mode (defaults to True)")
     allowed_jupyter_mcp_tools: str = Field(default="notebook_run-all-cells,notebook_get-selected-cell", description="Comma-separated list of jupyter-mcp-tools to enable")
     reconnect_interval: int = Field(default=0, description="Seconds to wait before reconnecting a dropped WebSocket connection to the kernel. 0 disables auto-reconnect.")
+
+    # Execution timeout configuration
+    execution_timeout: int = Field(default=120, description="Default timeout in seconds for code execution. Set to 0 for unlimited (use with caution).")
+    max_execution_timeout: int = Field(default=3600, description="Maximum allowed timeout in seconds for code execution.")
     
     class Config:
         """Pydantic configuration."""

--- a/jupyter_mcp_server/server.py
+++ b/jupyter_mcp_server/server.py
@@ -614,11 +614,15 @@ async def edit_cell_source(
 @with_hooks("execute_cell")
 async def execute_cell(
     cell_index: Annotated[int, Field(description="Index of the cell to execute (0-based)", ge=0)],
-    timeout: Annotated[int, Field(description="Maximum seconds to wait for execution")] = 90,
+    timeout: Annotated[int, Field(description="Maximum seconds to wait for execution (0 = use config default)")] = 0,
     stream: Annotated[bool, Field(description="Enable streaming progress (including time indicator) updates for long-running cells")] = False,
     progress_interval: Annotated[int, Field(description="Seconds between progress updates when stream=True")] = 5,
 ) -> Annotated[list[str | ImageContent], Field(description="List of outputs from the executed cell")]:
     """Execute a cell from the currently activated notebook with timeout and return it's outputs"""
+    config = get_config()
+    # Use config default if timeout is 0, otherwise clamp to max
+    effective_timeout = config.execution_timeout if timeout == 0 else min(timeout, config.max_execution_timeout)
+
     return await safe_notebook_operation(
         lambda: ExecuteCellTool().execute(
             mode=server_context.mode,
@@ -627,7 +631,7 @@ async def execute_cell(
             kernel_manager=server_context.kernel_manager,
             notebook_manager=notebook_manager,
             cell_index=cell_index,
-            timeout_seconds=timeout,
+            timeout_seconds=effective_timeout,
             stream=stream,
             progress_interval=progress_interval,
             ensure_kernel_alive_fn=__ensure_kernel_alive
@@ -646,10 +650,13 @@ async def execute_cell(
 async def insert_execute_code_cell(
     cell_index: Annotated[int, Field(description="Index of the cell to insert and execute (0-based)", ge=-1)],
     cell_source: Annotated[str, Field(description="Code source for the cell")],
-    timeout: Annotated[int, Field(description="Maximum seconds to wait for execution")] = 90,
+    timeout: Annotated[int, Field(description="Maximum seconds to wait for execution (0 = use config default)")] = 0,
 ) -> Annotated[list[str | ImageContent], Field(description="List of outputs from the executed cell")]:
     """Insert a cell at specified index from the currently activated notebook and then execute it with timeout and return it's outputs
     It is a shortcut tool for insert_cell and execute_cell tools, recommended to use if you want to insert a cell and execute it at the same time"""
+    config = get_config()
+    effective_timeout = config.execution_timeout if timeout == 0 else min(timeout, config.max_execution_timeout)
+
     await safe_notebook_operation(
         lambda: InsertCellTool().execute(
             mode=server_context.mode,
@@ -671,7 +678,7 @@ async def insert_execute_code_cell(
             kernel_manager=server_context.kernel_manager,
             notebook_manager=notebook_manager,
             cell_index=cell_index,
-            timeout_seconds=timeout,
+            timeout_seconds=effective_timeout,
             stream=False,
             progress_interval=0,
             ensure_kernel_alive_fn=__ensure_kernel_alive


### PR DESCRIPTION
## Summary

Make execution timeout configurable instead of hardcoded 90s (Issue #249).

### Changes

1. **config.py**: Add `execution_timeout` (default 120s) and `max_execution_timeout` (default 3600s)
2. **server.py**: Use config timeout in `execute_cell` and `insert_execute_code_cell`

### Configuration

```python
# Via config
config.execution_timeout = 600  # 10 minutes

# Via environment variable
JUPYTER_MCP_EXECUTION_TIMEOUT=600

# Per-call override (clamped to max)
execute_cell(cell_index=0, timeout=300)
```

### Behavior
- `timeout=0` (default): Uses config `execution_timeout`
- `timeout=N`: Uses N, clamped to `max_execution_timeout`
- Config defaults: 120s execution, 3600s max

### Why
ML model training can take 10+ minutes. The hardcoded 90s timeout makes the tool unusable for long-running cells.

Closes #249

/claim #249