### PR TITLE
fix: self-heal restart_notebook when the kernel was culled (JUPYTER_SERVER mode)

### DIFF
--- a/jupyter_mcp_server/tools/restart_notebook_tool.py
+++ b/jupyter_mcp_server/tools/restart_notebook_tool.py
@@ -15,7 +15,41 @@ logger = logging.getLogger(__name__)
 
 class RestartNotebookTool(BaseTool):
     """Tool to restart the kernel for a specific notebook."""
-    
+
+    async def _reprovision_kernel(
+        self,
+        kernel_manager: Any,
+        notebook_manager: NotebookManager,
+        notebook_name: str,
+    ) -> str:
+        """Start a fresh kernel and rebind it to the notebook (JUPYTER_SERVER mode).
+
+        Used when the notebook's recorded kernel has been culled or lost, so the
+        agent can self-heal instead of being stuck with a dead kernel binding.
+        """
+        try:
+            notebook_path = notebook_manager.get_notebook_path(notebook_name)
+            new_kernel_id = await kernel_manager.start_kernel(path=notebook_path)
+            notebook_manager.add_notebook(
+                notebook_name,
+                {"id": new_kernel_id},
+                server_url="local",
+                token=None,
+                path=notebook_path,
+            )
+            logger.info(f"Provisioned fresh kernel {new_kernel_id} for notebook '{notebook_name}'")
+            return (
+                f"Notebook '{notebook_name}' kernel was no longer available and has been "
+                f"reprovisioned (new kernel '{new_kernel_id}'). Memory state and imported "
+                f"packages have been cleared."
+            )
+        except Exception as e:
+            logger.error(f"Failed to reprovision kernel for notebook '{notebook_name}': {e}")
+            return (
+                f"Failed to restart notebook '{notebook_name}': the kernel was no longer "
+                f"available and reprovisioning failed: {e}"
+            )
+
     async def execute(
         self,
         mode: ServerMode,
@@ -53,12 +87,30 @@ class RestartNotebookTool(BaseTool):
             kernel_id = notebook_manager.get_kernel_id(notebook_name)
             if not kernel_id:
                 return f"Failed to restart notebook '{notebook_name}': kernel ID not found."
-            
+
+            # Self-heal a stale binding: if the recorded kernel no longer exists
+            # (idle-culled on JupyterHub, or the single-user server was restarted),
+            # provision a fresh kernel and rebind it instead of failing on a 404.
+            if kernel_id not in kernel_manager:
+                logger.info(
+                    f"Kernel {kernel_id} for notebook '{notebook_name}' no longer exists; "
+                    f"provisioning a fresh kernel."
+                )
+                return await self._reprovision_kernel(kernel_manager, notebook_manager, notebook_name)
+
             try:
                 logger.info(f"Restarting kernel {kernel_id} for notebook '{notebook_name}' in JUPYTER_SERVER mode")
                 await kernel_manager.restart_kernel(kernel_id)
                 return f"Notebook '{notebook_name}' kernel restarted successfully. Memory state and imported packages have been cleared."
             except Exception as e:
+                # The kernel may have been culled between the liveness check and the
+                # restart call; treat a now-missing kernel as a reprovision, not a failure.
+                if kernel_id not in kernel_manager:
+                    logger.info(
+                        f"Kernel {kernel_id} for notebook '{notebook_name}' disappeared during "
+                        f"restart; provisioning a fresh kernel."
+                    )
+                    return await self._reprovision_kernel(kernel_manager, notebook_manager, notebook_name)
                 logger.error(f"Failed to restart kernel {kernel_id}: {e}")
                 return f"Failed to restart notebook '{notebook_name}': {e}"
         

--- a/tests/test_restart_notebook_tool.py
+++ b/tests/test_restart_notebook_tool.py
@@ -1,0 +1,121 @@
+# Copyright (c) 2024- Datalayer, Inc.
+#
+# BSD 3-Clause License
+
+"""Unit tests for RestartNotebookTool self-healing in JUPYTER_SERVER mode.
+
+These tests exercise the tool's kernel-liveness handling with a minimal
+in-memory stand-in for jupyter_server's MappingKernelManager, so no running
+Jupyter server is required.
+"""
+
+import pytest
+
+from jupyter_mcp_server.notebook_manager import NotebookManager
+from jupyter_mcp_server.tools._base import ServerMode
+from jupyter_mcp_server.tools.restart_notebook_tool import RestartNotebookTool
+
+
+class FakeKernelManager:
+    """Minimal stand-in for MappingKernelManager covering the surface
+    restart_notebook uses: membership, restart, and start_kernel."""
+
+    def __init__(self, existing_ids=()):
+        self._kernels = set(existing_ids)
+        self._counter = 0
+        self.started_paths = []
+
+    def __contains__(self, kernel_id):
+        return kernel_id in self._kernels
+
+    async def restart_kernel(self, kernel_id):
+        if kernel_id not in self._kernels:
+            # Mirror MappingKernelManager, which 404s on a missing kernel.
+            raise Exception(f"HTTP 404: Not Found (Kernel does not exist: {kernel_id})")
+        return None
+
+    async def start_kernel(self, path=None, **kwargs):
+        self._counter += 1
+        new_id = f"kernel-new-{self._counter}"
+        self._kernels.add(new_id)
+        self.started_paths.append(path)
+        return new_id
+
+
+class RacyKernelManager(FakeKernelManager):
+    """Kernel manager whose kernel is culled exactly during the restart call,
+    so the liveness check passes but restart_kernel then 404s."""
+
+    async def restart_kernel(self, kernel_id):
+        self._kernels.discard(kernel_id)
+        raise Exception(f"HTTP 404: Not Found (Kernel does not exist: {kernel_id})")
+
+
+def _manager_with_notebook(kernel_id, path="work/test.ipynb"):
+    nm = NotebookManager()
+    nm.add_notebook(
+        "nb",
+        {"id": kernel_id},
+        server_url="local",
+        token=None,
+        path=path,
+    )
+    return nm
+
+
+@pytest.mark.asyncio
+async def test_restart_reprovisions_when_kernel_culled():
+    """A restart on a notebook whose kernel was culled must self-heal:
+    provision a fresh kernel, rebind it, and report success."""
+    nm = _manager_with_notebook("dead-kernel")
+    km = FakeKernelManager(existing_ids=[])  # dead-kernel is gone
+
+    result = await RestartNotebookTool().execute(
+        mode=ServerMode.JUPYTER_SERVER,
+        kernel_manager=km,
+        notebook_manager=nm,
+        notebook_name="nb",
+    )
+
+    assert "reprovisioned" in result
+    assert "kernel-new-1" in result
+    # The binding was rebound to the fresh kernel, not left stale.
+    assert nm.get_kernel_id("nb") == "kernel-new-1"
+    # The new kernel was started with the notebook's path (cwd), matching use_notebook.
+    assert km.started_paths == ["work/test.ipynb"]
+
+
+@pytest.mark.asyncio
+async def test_restart_reprovisions_when_kernel_culled_during_restart():
+    """If the kernel is culled between the liveness check and restart_kernel,
+    the except branch must also self-heal rather than surface the 404."""
+    nm = _manager_with_notebook("live-then-gone")
+    km = RacyKernelManager(existing_ids=["live-then-gone"])
+
+    result = await RestartNotebookTool().execute(
+        mode=ServerMode.JUPYTER_SERVER,
+        kernel_manager=km,
+        notebook_manager=nm,
+        notebook_name="nb",
+    )
+
+    assert "reprovisioned" in result
+    assert nm.get_kernel_id("nb") == "kernel-new-1"
+
+
+@pytest.mark.asyncio
+async def test_restart_live_kernel_is_unchanged():
+    """The happy path (kernel alive) restarts in place and keeps the same id."""
+    nm = _manager_with_notebook("live")
+    km = FakeKernelManager(existing_ids=["live"])
+
+    result = await RestartNotebookTool().execute(
+        mode=ServerMode.JUPYTER_SERVER,
+        kernel_manager=km,
+        notebook_manager=nm,
+        notebook_name="nb",
+    )
+
+    assert "restarted successfully" in result
+    assert nm.get_kernel_id("nb") == "live"
+    assert km.started_paths == []  # no new kernel provisioned


### PR DESCRIPTION
## Root cause

In JUPYTER_SERVER mode, `restart_notebook` reads the kernel id recorded by `use_notebook` and calls `kernel_manager.restart_kernel(kernel_id)` directly. When that kernel has been idle-culled (standard on JupyterHub) or lost to a single-user server restart, `restart_kernel` raises `404: Not Found (Kernel does not exist: <id>)`. The tool catches it and returns "Failed to restart", so the notebook stays bound to a kernel that no longer exists and the agent cannot recover through the tool. The only working path today is `unuse_notebook` then `use_notebook`, which agents do not discover on their own. This is the `restart_notebook` part of #260.

## Invariant

A restart on a notebook whose kernel is gone must self-heal: provision a fresh kernel and rebind it, rather than fail on a 404. An agent should never be left with a dead binding it cannot recover through the restart tool.

## Fix

Before restarting, check kernel liveness with `kernel_id in kernel_manager`, the same idiom `use_notebook` already uses. If the kernel is gone, start a new kernel with the notebook's path (mirroring `local_backend`, which passes the path so the kernel's working directory matches the notebook) and rebind it via `notebook_manager.add_notebook`, then report success. An `except` branch covers the race where the kernel is culled between the liveness check and the `restart_kernel` call. The live-kernel path is unchanged, and after a rebind `notebook_manager.get_kernel_id` returns the new id, so the `restarted` lifecycle hook fires with the correct kernel.

Scope: this PR fixes only the `restart_notebook` self-heal (the second item under #260 "Expected"). The `execute_cell` liveness check and the `use_notebook` rebind suggestions are left out to keep one concern per PR.

## How I verified

Ran in a clean `python:3.10-slim` Docker container (editable install with `.[test]`):

- New offline unit test `tests/test_restart_notebook_tool.py` using a minimal in-memory kernel-manager stand-in (no running Jupyter server), covering three cases: a culled kernel reprovisions and rebinds to the new id and starts it with the notebook path; a kernel culled during restart (the race) reprovisions via the `except` branch; a live kernel restarts in place with the id unchanged and no new kernel started.
- Differential: the two self-heal tests FAIL on `origin/main`'s `restart_notebook_tool.py` (it returns "Failed to restart ... 404" and the binding stays stale) and PASS on this branch; the live-kernel test passes both ways, so the happy path does not regress. Provenance was checked by toggling the source file version.
- `tests/test_config.py` and `tests/test_hooks.py` still pass; `ruff check` on the changed file adds no rule categories beyond the file's existing style.

What I did not verify: I have no live JupyterHub with an idle-culler here, so I did not exercise a real culled kernel end to end. The 404 and the reprovision path are reproduced against an in-memory `MappingKernelManager` stand-in that mirrors its `__contains__`, `restart_kernel`, and `start_kernel` surface, not the real server. I also did not run the full parametrized integration suite (`tests/test_tools.py`), which needs a running Jupyter server.

Fixes #260

---

AI assistance: this change was prepared with the help of an AI agent (Claude). A human is accountable for it, and I am happy to adjust the approach.
