### PR TITLE
Add beacon.json for Beacon discovery listing

### DIFF
--- a/README.md
+++ b/README.md
@@ -325,3 +325,9 @@ ______________________________________________________________________
 Made with ❤️ by [Datalayer](https://github.com/datalayer)
 
 </div>
+
+## Discovery
+
+[![Beacon Verified](https://registry-ruby.vercel.app/api/v1/agents/datalayer%2Fjupyter-mcp-server/badge.svg)](https://portal-five-phi-54.vercel.app/?q=datalayer%2Fjupyter-mcp-server)
+
+Listed on [Beacon](https://portal-five-phi-54.vercel.app) — searchable index of open-source MCP servers.

--- a/beacon.json
+++ b/beacon.json
@@ -1,0 +1,24 @@
+{
+  "beacon_manifest": "0.1",
+  "id": "datalayer/jupyter-mcp-server",
+  "name": "Jupyter Mcp Server",
+  "description": "Open-source AI agent \u2014 ai, jupyter, mcp, mcp-server.",
+  "capabilities": [
+    "ai",
+    "jupyter",
+    "mcp",
+    "mcp-server",
+    "model",
+    "context",
+    "protocol",
+    "server"
+  ],
+  "interfaces": [
+    {
+      "type": "mcp",
+      "endpoint": "https://github.com/datalayer/jupyter-mcp-server"
+    }
+  ],
+  "source": "https://github.com/datalayer/jupyter-mcp-server",
+  "homepage": "https://github.com/datalayer/jupyter-mcp-server"
+}


### PR DESCRIPTION
Adds Beacon Agent Manifest v0.1 for capability search on https://portal-five-phi-54.vercel.app — opt-in metadata, no runtime changes. Spec: https://github.com/enrichgateagent-png/beacon-agent-manifest

Made with [Cursor](https://cursor.com)