### PR TITLE
feat: add open_notebook_in_ui opt-in for use_notebook tab activation (fixes #218)

### DIFF
--- a/docs/docs/reference/configuration/index.mdx
+++ b/docs/docs/reference/configuration/index.mdx
@@ -16,8 +16,13 @@ The server automatically detects the appropriate mode based on deployment contex
 ### JupyterLab Mode
 **Environment Variable:** `JUPYTERLAB=true` (default)
 
-- **Enabled**: Automatic notebook opening, enhanced UI tools, `notebook_run-all-cells` tool
+- **Enabled**: Enhanced UI tools, `notebook_run-all-cells` tool
 - **Disabled**: Basic operations only, headless usage
+
+### Open Notebook in UI
+**Environment Variable:** `OPEN_NOTEBOOK_IN_UI=false` (default)
+
+When enabled together with JupyterLab mode, `use_notebook` also opens the notebook in the JupyterLab UI, which activates its tab. It is off by default so that notebooks used over MCP do not pull the focus away from the tab you are working in.
 
 ## Transport & Providers
 
@@ -86,6 +91,7 @@ For deployments requiring granular control over document storage and runtime exe
 | `PORT` | Port for streamable HTTP transport | `4040` | `4040` |
 | `RECONNECT_INTERVAL` | Seconds before retrying a dropped kernel WebSocket connection. `0` disables auto-reconnect. | `5` | `0` |
 | `JUPYTERLAB` | Enable JupyterLab mode | `true` / `false` | `true` |
+| `OPEN_NOTEBOOK_IN_UI` | Open the notebook in the JupyterLab UI on `use_notebook`, activating its tab | `true` / `false` | `false` |
 | `JUPYTER_MCP_OTEL_FILE` | Path for OpenTelemetry span export (JSONL) | `/tmp/spans.jsonl` | `None` |
 
 ### Configuration Priority

--- a/jupyter_mcp_server/CLI.py
+++ b/jupyter_mcp_server/CLI.py
@@ -41,6 +41,13 @@ def _common_options(f):
             help="Enable JupyterLab mode. Defaults to True.",
         ),
         click.option(
+            "--open-notebook-in-ui",
+            envvar="OPEN_NOTEBOOK_IN_UI",
+            type=click.BOOL,
+            default=False,
+            help="Open the notebook in the JupyterLab UI when using it, which activates its tab. Defaults to False.",
+        ),
+        click.option(
             "--runtime-url",
             envvar="RUNTIME_URL",
             type=click.STRING,
@@ -198,6 +205,7 @@ def _do_start(
     port: int,
     provider: str,
     jupyterlab: bool,
+    open_notebook_in_ui: bool,
     allowed_jupyter_mcp_tools: str,
     otel_file: str = "",
     mcp_token: str = None,
@@ -236,6 +244,7 @@ def _do_start(
         document_token=document_token,
         port=port,
         jupyterlab=jupyterlab,
+        open_notebook_in_ui=open_notebook_in_ui,
         allowed_jupyter_mcp_tools=allowed_jupyter_mcp_tools,
         reconnect_interval=reconnect_interval,
     )
@@ -360,6 +369,7 @@ def server(
     port: int,
     provider: str,
     jupyterlab: bool,
+    open_notebook_in_ui: bool,
     allowed_jupyter_mcp_tools: str,
     otel_file: str,
     reconnect_interval: int,
@@ -398,6 +408,7 @@ def server(
         port=port,
         provider=provider,
         jupyterlab=jupyterlab,
+        open_notebook_in_ui=open_notebook_in_ui,
         allowed_jupyter_mcp_tools=allowed_jupyter_mcp_tools,
         otel_file=otel_file,
         mcp_token=mcp_token,
@@ -427,6 +438,7 @@ def connect_command(
     document_token: str,
     provider: str,
     jupyterlab: bool,
+    open_notebook_in_ui: bool,
     jupyter_url: str,
     jupyter_token: str,
     allowed_jupyter_mcp_tools: str,
@@ -452,7 +464,8 @@ def connect_command(
         document_url=resolved_document_url,
         document_id=document_id,
         document_token=resolved_document_token,
-        jupyterlab=jupyterlab
+        jupyterlab=jupyterlab,
+        open_notebook_in_ui=open_notebook_in_ui
     )
     
     # Also update the jupyter_extension ServerContext with the jupyterlab flag
@@ -564,6 +577,7 @@ def start_command(
     port: int,
     provider: str,
     jupyterlab: bool,
+    open_notebook_in_ui: bool,
     allowed_jupyter_mcp_tools: str,
     otel_file: str,
     reconnect_interval: int,
@@ -591,6 +605,7 @@ def start_command(
         port=port,
         provider=provider,
         jupyterlab=jupyterlab,
+        open_notebook_in_ui=open_notebook_in_ui,
         allowed_jupyter_mcp_tools=allowed_jupyter_mcp_tools,
         otel_file=otel_file,
         mcp_token=mcp_token,

--- a/jupyter_mcp_server/config.py
+++ b/jupyter_mcp_server/config.py
@@ -30,6 +30,7 @@ class JupyterMCPConfig(BaseModel):
     # Server configuration
     port: int = Field(default=4040, description="The port to use for the Streamable HTTP transport")
     jupyterlab: bool = Field(default=True, description="Enable JupyterLab mode (defaults to True)")
+    open_notebook_in_ui: bool = Field(default=False, description="Open the notebook in the JupyterLab UI when using it, which activates its tab (defaults to False)")
     allowed_jupyter_mcp_tools: str = Field(default="notebook_run-all-cells,notebook_get-selected-cell", description="Comma-separated list of jupyter-mcp-tools to enable")
     reconnect_interval: int = Field(default=0, description="Seconds to wait before reconnecting a dropped WebSocket connection to the kernel. 0 disables auto-reconnect.")
 

--- a/jupyter_mcp_server/jupyter_extension/extension.py
+++ b/jupyter_mcp_server/jupyter_extension/extension.py
@@ -100,6 +100,12 @@ class JupyterMCPServerExtensionApp(ExtensionAppJinjaMixin, ExtensionApp):
         help='Enable JupyterLab mode (defaults to True)'
     )
     
+    open_notebook_in_ui = Bool(
+        False,
+        config=True,
+        help='Open the notebook in the JupyterLab UI when using it, which activates its tab (defaults to False)'
+    )
+    
     allowed_jupyter_mcp_tools = Unicode(
         "notebook_run-all-cells,notebook_get-selected-cell",
         config=True,
@@ -134,6 +140,7 @@ class JupyterMCPServerExtensionApp(ExtensionAppJinjaMixin, ExtensionApp):
         logger.info(f"  Document ID: {self.document_id}")
         logger.info(f"  Start New Runtime: {self.start_new_runtime}")
         logger.info(f"  JupyterLab Mode: {self.jupyterlab}")
+        logger.info(f"  Open Notebook in UI: {self.open_notebook_in_ui}")
         if self.runtime_id:
             logger.info(f"  Runtime ID: {self.runtime_id}")
         
@@ -159,6 +166,7 @@ class JupyterMCPServerExtensionApp(ExtensionAppJinjaMixin, ExtensionApp):
         config.runtime_id = self.runtime_id if self.runtime_id else None
         config.provider = self.provider
         config.jupyterlab = self.jupyterlab
+        config.open_notebook_in_ui = self.open_notebook_in_ui
         config.allowed_jupyter_mcp_tools = self.allowed_jupyter_mcp_tools
         
         # Store configuration in settings for handlers
@@ -172,6 +180,7 @@ class JupyterMCPServerExtensionApp(ExtensionAppJinjaMixin, ExtensionApp):
             "mcp_runtime_id": self.runtime_id,
             "mcp_provider": self.provider,
             "mcp_jupyterlab": self.jupyterlab,
+            "mcp_open_notebook_in_ui": self.open_notebook_in_ui,
             "mcp_allowed_jupyter_mcp_tools": self.allowed_jupyter_mcp_tools,
             "mcp_serverapp": self.serverapp,
         })

--- a/jupyter_mcp_server/tools/use_notebook_tool.py
+++ b/jupyter_mcp_server/tools/use_notebook_tool.py
@@ -297,12 +297,14 @@ class UseNotebookTool(BaseTool):
         except Exception as e:
             logger.debug(f"Failed to get notebook summary: {e}")
         
-        # Check if we should open in JupyterLab UI (when JupyterLab mode is enabled)
+        # Check if we should open in JupyterLab UI (when JupyterLab mode is
+        # enabled and the user opted in, since opening activates the tab)
         try:
+            from jupyter_mcp_server.config import get_config
             from jupyter_mcp_server.jupyter_extension.context import get_server_context
             context = get_server_context()
-            
-            if context.is_jupyterlab_mode():
+
+            if context.is_jupyterlab_mode() and get_config().open_notebook_in_ui:
                 logger.info(f"JupyterLab mode enabled, attempting to open notebook '{notebook_path}' in JupyterLab UI")
                 
                 # Determine base_url and token based on mode

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -236,9 +236,13 @@ def test_management_routes_accept_mcp_token(mcp_server_with_mcp_token):
     """State-changing management routes accept MCP_TOKEN."""
     import httpx
 
+    # /api/stop shuts the kernel down inline and KernelClient.stop() is allowed
+    # REQUEST_TIMEOUT (10s) to do it, so the client has to outwait the server's
+    # own budget. The httpx default is 5s.
     r = httpx.delete(
         f"{mcp_server_with_mcp_token}/api/stop",
         headers={"Authorization": f"Bearer {MCP_TOKEN}"},
+        timeout=30.0,
     )
     assert r.status_code == HTTPStatus.OK
 

--- a/tests/test_use_notebook_ui_open.py
+++ b/tests/test_use_notebook_ui_open.py
@@ -1,0 +1,162 @@
+# Copyright (c) 2024- Datalayer, Inc.
+#
+# BSD 3-Clause License
+
+"""Unit tests for the use_notebook JupyterLab UI opening gate.
+
+These tests drive UseNotebookTool with an in-memory stand-in for the
+jupyter-mcp-tools client, so no running JupyterLab is required. They cover the
+server-side decision to dispatch `docmanager_open`, not the browser behaviour
+that dispatch causes.
+"""
+
+import pytest
+
+from jupyter_mcp_server.config import get_config, reset_config
+from jupyter_mcp_server.jupyter_extension.context import get_server_context
+from jupyter_mcp_server.notebook_manager import NotebookManager
+from jupyter_mcp_server.tools._base import ServerMode
+from jupyter_mcp_server.tools.use_notebook_tool import UseNotebookTool
+
+
+class FakeFile:
+    """Minimal stand-in for a jupyter-server-client directory entry."""
+
+    def __init__(self, name):
+        self.name = name
+
+
+class FakeContents:
+    def __init__(self, names):
+        self._names = names
+
+    def list_directory(self, path):
+        return [FakeFile(name) for name in self._names]
+
+
+class FakeServerClient:
+    """Minimal stand-in for JupyterServerClient covering the surface
+    use_notebook touches on the switch path: status and a directory listing."""
+
+    def __init__(self, names):
+        self.contents = FakeContents(names)
+
+    def get_status(self):
+        return {"version": "2.0.0"}
+
+
+class FakeMCPToolsClient:
+    """Stand-in for jupyter_mcp_tools' MCPToolsClient that records the tools it
+    is asked to execute instead of calling a live JupyterLab."""
+
+    calls = []
+
+    def __init__(self, base_url=None, token=None):
+        self.base_url = base_url
+        self.token = token
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+    async def execute_tool(self, tool_id, parameters=None):
+        type(self).calls.append((tool_id, parameters))
+        return {"success": True}
+
+
+@pytest.fixture(autouse=True)
+def _reset_state(monkeypatch):
+    """Each test gets a clean config, context flag, and call recorder."""
+    reset_config()
+    FakeMCPToolsClient.calls = []
+    monkeypatch.setattr(
+        "jupyter_mcp_tools.client.MCPToolsClient", FakeMCPToolsClient
+    )
+    yield
+    reset_config()
+
+
+def _manager_with_two_notebooks():
+    """A manager holding two notebooks, with 'nb1' active, so that using 'nb2'
+    takes the switch path that activates a different notebook."""
+    nm = NotebookManager()
+    for name in ("nb1", "nb2"):
+        nm.add_notebook(
+            name,
+            {"id": f"kernel-{name}"},
+            server_url="http://localhost:8888",
+            token="token",
+            path=f"work/{name}.ipynb",
+        )
+    nm.set_current_notebook("nb1")
+    return nm
+
+
+async def _switch_to_nb2(notebook_manager):
+    """Switch the active notebook from nb1 to nb2 over the MCP_SERVER path."""
+    get_server_context().update(context_type="MCP_SERVER", jupyterlab=True)
+    return await UseNotebookTool().execute(
+        mode=ServerMode.MCP_SERVER,
+        server_client=FakeServerClient(["nb1.ipynb", "nb2.ipynb"]),
+        notebook_manager=notebook_manager,
+        notebook_name="nb2",
+        notebook_path="work/nb2.ipynb",
+        use_mode="connect",
+        runtime_url="http://localhost:8888",
+        runtime_token="token",
+    )
+
+
+@pytest.mark.asyncio
+async def test_switching_notebook_does_not_open_ui_by_default():
+    """Switching notebooks must not steal the JupyterLab tab focus unless the
+    user asked for it, so no docmanager_open is dispatched by default."""
+    nm = _manager_with_two_notebooks()
+
+    await _switch_to_nb2(nm)
+
+    assert nm.get_current_notebook() == "nb2"
+    assert FakeMCPToolsClient.calls == []
+
+
+@pytest.mark.asyncio
+async def test_switching_notebook_opens_ui_when_opted_in():
+    """With open_notebook_in_ui set, the previous behaviour is preserved: the
+    notebook is opened in the JupyterLab UI."""
+    get_config().open_notebook_in_ui = True
+    nm = _manager_with_two_notebooks()
+
+    await _switch_to_nb2(nm)
+
+    assert FakeMCPToolsClient.calls == [
+        ("docmanager_open", {"path": "work/nb2.ipynb"})
+    ]
+
+
+@pytest.mark.asyncio
+async def test_ui_open_stays_off_when_jupyterlab_mode_disabled():
+    """The opt-in does not re-enable UI opening outside JupyterLab mode."""
+    get_config().open_notebook_in_ui = True
+    nm = _manager_with_two_notebooks()
+
+    get_server_context().update(context_type="MCP_SERVER", jupyterlab=False)
+    await UseNotebookTool().execute(
+        mode=ServerMode.MCP_SERVER,
+        server_client=FakeServerClient(["nb1.ipynb", "nb2.ipynb"]),
+        notebook_manager=nm,
+        notebook_name="nb2",
+        notebook_path="work/nb2.ipynb",
+        use_mode="connect",
+        runtime_url="http://localhost:8888",
+        runtime_token="token",
+    )
+
+    assert FakeMCPToolsClient.calls == []
+
+
+def test_open_notebook_in_ui_defaults_to_off():
+    """The opt-in is off by default, leaving jupyter-mcp-tools loading (which
+    the separate `jupyterlab` flag gates) untouched."""
+    assert get_config().open_notebook_in_ui is False


### PR DESCRIPTION
Follows up on the design discussion in #218.

## Root cause

`use_notebook` dispatches the jupyter-mcp-tools `docmanager_open` command whenever JupyterLab mode is on (`use_notebook_tool.py`, the block around lines 300-343). Opening the document activates its tab, so an agent that connects to or switches notebooks in the background pulls the UI focus away from the tab the user is working in. There is currently no way to opt out.

As @abbbe found in the issue, `JUPYTERLAB=false` is not that opt-out. The same flag also gates loading the jupyter-mcp-tools tool set (`get_tools()` in `server.py`, and `handlers.py`), so turning it off to stop the tab switch drops those tools as well. The two behaviours are coupled under one flag.

## Invariant

Switching notebooks over MCP must not activate a JupyterLab tab unless the user opted in.

## The fix

A dedicated `open_notebook_in_ui` option, defaulting to `False`, gating only the `use_notebook` UI-open block:

```python
if context.is_jupyterlab_mode() and get_config().open_notebook_in_ui:
    ... docmanager_open ...
```

It is wired like the existing `jupyterlab` flag: config field, CLI option (`--open-notebook-in-ui`), `OPEN_NOTEBOOK_IN_UI` env var, and extension trait. jupyter-mcp-tools loading is untouched, so anyone who wants the current behaviour sets the flag and gets it back.

This does change the default: background notebook switches no longer activate the tab. That matches your "I am open to set by default to false based on your feedbacks" in the issue, but it is your call, and flipping the default to `True` here is a one-line change if you would rather keep today's behaviour and let people opt out instead.

## How I verified

Docker `python:3.12-slim`, editable install at `a116ed6`, module resolved to `/src/jupyter_mcp_server/tools/use_notebook_tool.py`.

The regression tests drive `UseNotebookTool.execute` on the notebook-switch path with an in-memory stand-in for `MCPToolsClient` that records the tools it is asked to execute (the same stand-in approach as `tests/test_restart_notebook_tool.py`):

- Against unfixed source at `a116ed6`, `test_switching_notebook_does_not_open_ui_by_default` fails, recording `('docmanager_open', {'path': 'work/nb2.ipynb'})`. That is the focus-steal, reproduced offline.
- On this branch the same four tests pass: no dispatch by default, dispatch when `open_notebook_in_ui` is set, still no dispatch when JupyterLab mode is off, and the default is off.

```
TEST_MCP_SERVER=true TEST_JUPYTER_SERVER=false pytest
```

gives `93 passed, 1 failed, 7 skipped, 54 errors` on this branch and `89 passed, 1 failed, 7 skipped, 54 errors` on a clean checkout of `a116ed6` in the same container: an identical failure profile, plus the 4 tests added here. The 54 errors and the `test_otel_integration.py::test_span_log_summary` failure are the tests that need a live JupyterLab, which my container does not start; they are not related to this change. I also ran the CI smoke check (every module imports, `start --help` lists the new flag).

## What I did not verify

I have not exercised this against a live JupyterLab UI, so the tests cover the server-side decision to dispatch `docmanager_open`, not the browser behaviour that dispatch causes. @abbbe also reported that `JUPYTERLAB=false` did not suppress the activation, which you attributed to the jupyter-mcp-tools extension; that entrypoint-wiring question is out of scope here and this change does not address it.

I did not run `.pre-commit-config.yaml` over the changed files: `ruff` and `ruff-format` there fail on the repo's current files as well, so running them would have reformatted five files and buried this change in unrelated churn. I checked instead that the change adds no new lint errors of any class beyond the long `Field`/`help` lines that match their neighbours, and the new test file reports the same ruff findings as the existing `tests/test_restart_notebook_tool.py`.

Happy to rename the flag or adjust the default if you prefer something else.

Fixes #218

Written with AI assistance; I reproduced and verified the behaviour above myself.
