### PR TITLE
feat: make the execution timeout configurable from the CLI and environment (fixes #264)

### DIFF
--- a/docs/docs/reference/configuration/index.mdx
+++ b/docs/docs/reference/configuration/index.mdx
@@ -90,6 +90,8 @@ For deployments requiring granular control over document storage and runtime exe
 | `TRANSPORT` | Transport method for MCP | `stdio` / `streamable-http` | `stdio` |
 | `PORT` | Port for streamable HTTP transport | `4040` | `4040` |
 | `RECONNECT_INTERVAL` | Seconds before retrying a dropped kernel WebSocket connection. `0` disables auto-reconnect. | `5` | `0` |
+| `JUPYTER_MCP_EXECUTION_TIMEOUT` | Default timeout in seconds for code execution, used when a tool call does not pass its own timeout. Must be greater than `0`. | `300` | `120` |
+| `JUPYTER_MCP_MAX_EXECUTION_TIMEOUT` | Maximum timeout in seconds a tool call may request for code execution. Must be greater than `0`. | `7200` | `3600` |
 | `JUPYTERLAB` | Enable JupyterLab mode | `true` / `false` | `true` |
 | `OPEN_NOTEBOOK_IN_UI` | Open the notebook in the JupyterLab UI on `use_notebook`, activating its tab | `true` / `false` | `false` |
 | `JUPYTER_MCP_OTEL_FILE` | Path for OpenTelemetry span export (JSONL) | `/tmp/spans.jsonl` | `None` |
@@ -163,6 +165,9 @@ Options:
   --jupyter-token TEXT                Jupyter token as default for both document and runtime tokens (default: None)
   --allowed-jupyter-mcp-tools TEXT    Comma-separated list of jupyter-mcp-tools to enable (default: notebook_run-all-cells,notebook_get-selected-cell)
   --reconnect-interval INTEGER         Seconds before retrying a dropped kernel WebSocket connection (default: 0)
+  --execution-timeout INTEGER RANGE   Default timeout in seconds for code execution when a tool call passes no timeout (default: 120)
+  --max-execution-timeout INTEGER RANGE
+                                      Maximum timeout in seconds a tool call may request (default: 3600)
   --otel-file TEXT                    Path for OpenTelemetry span export as JSONL (default: None)
   --port INTEGER                      Port for streamable-http transport (default: 4040)
 ```
@@ -192,6 +197,9 @@ Options:
   --jupyter-url TEXT                  Jupyter URL as default for both document and runtime URLs (default: None)
   --jupyter-token TEXT                Jupyter token as default for both document and runtime tokens (default: None)
   --reconnect-interval INTEGER        Seconds before retrying a dropped kernel WebSocket connection (default: 0)
+  --execution-timeout INTEGER RANGE   Default timeout in seconds for code execution when a tool call passes no timeout (default: 120)
+  --max-execution-timeout INTEGER RANGE
+                                      Maximum timeout in seconds a tool call may request (default: 3600)
   --jupyter-mcp-server-url TEXT       URL of the Jupyter MCP Server to connect to (default: http://localhost:4040)
 ```
 

--- a/jupyter_mcp_server/CLI.py
+++ b/jupyter_mcp_server/CLI.py
@@ -131,6 +131,20 @@ def _common_options(f):
             default=0,
             help="Seconds to wait before reconnecting a dropped WebSocket connection to the kernel. Defaults to 0 (disabled).",
         ),
+        click.option(
+            "--execution-timeout",
+            envvar="JUPYTER_MCP_EXECUTION_TIMEOUT",
+            type=click.IntRange(min=1),
+            default=120,
+            help="Default timeout in seconds for code execution, used when a tool call does not pass its own timeout. Defaults to 120.",
+        ),
+        click.option(
+            "--max-execution-timeout",
+            envvar="JUPYTER_MCP_MAX_EXECUTION_TIMEOUT",
+            type=click.IntRange(min=1),
+            default=3600,
+            help="Maximum timeout in seconds a tool call may request for code execution. Defaults to 3600.",
+        ),
     ]
     # Apply decorators in reverse order
     for option in reversed(options):
@@ -211,6 +225,8 @@ def _do_start(
     mcp_token: str = None,
     insecure_mcp_noauth: bool = False,
     reconnect_interval: int = 0,
+    execution_timeout: int = 120,
+    max_execution_timeout: int = 3600,
 ):
     """Internal function to execute the start logic."""
 
@@ -247,6 +263,8 @@ def _do_start(
         open_notebook_in_ui=open_notebook_in_ui,
         allowed_jupyter_mcp_tools=allowed_jupyter_mcp_tools,
         reconnect_interval=reconnect_interval,
+        execution_timeout=execution_timeout,
+        max_execution_timeout=max_execution_timeout,
     )
 
     # Reset ServerContext to pick up new configuration
@@ -373,6 +391,8 @@ def server(
     allowed_jupyter_mcp_tools: str,
     otel_file: str,
     reconnect_interval: int,
+    execution_timeout: int,
+    max_execution_timeout: int,
 ):
     """Manages Jupyter MCP Server.
 
@@ -414,6 +434,8 @@ def server(
         mcp_token=mcp_token,
         insecure_mcp_noauth=insecure_mcp_noauth,
         reconnect_interval=reconnect_interval,
+        execution_timeout=execution_timeout,
+        max_execution_timeout=max_execution_timeout,
     )
 
 
@@ -443,6 +465,8 @@ def connect_command(
     jupyter_token: str,
     allowed_jupyter_mcp_tools: str,
     reconnect_interval: int,
+    execution_timeout: int,
+    max_execution_timeout: int,
 ):
     """Command to connect a Jupyter MCP Server to a document and a runtime."""
 
@@ -581,6 +605,8 @@ def start_command(
     allowed_jupyter_mcp_tools: str,
     otel_file: str,
     reconnect_interval: int,
+    execution_timeout: int,
+    max_execution_timeout: int,
 ):
     """Start the Jupyter MCP server with a transport."""
     # Resolve URL and token variables based on priority logic
@@ -611,6 +637,8 @@ def start_command(
         mcp_token=mcp_token,
         insecure_mcp_noauth=insecure_mcp_noauth,
         reconnect_interval=reconnect_interval,
+        execution_timeout=execution_timeout,
+        max_execution_timeout=max_execution_timeout,
     )
 
 

--- a/jupyter_mcp_server/config.py
+++ b/jupyter_mcp_server/config.py
@@ -35,8 +35,8 @@ class JupyterMCPConfig(BaseModel):
     reconnect_interval: int = Field(default=0, description="Seconds to wait before reconnecting a dropped WebSocket connection to the kernel. 0 disables auto-reconnect.")
 
     # Execution timeout configuration
-    execution_timeout: int = Field(default=120, description="Default timeout in seconds for code execution. Set to 0 for unlimited (use with caution).")
-    max_execution_timeout: int = Field(default=3600, description="Maximum allowed timeout in seconds for code execution.")
+    execution_timeout: int = Field(default=120, gt=0, description="Default timeout in seconds for code execution.")
+    max_execution_timeout: int = Field(default=3600, gt=0, description="Maximum allowed timeout in seconds for code execution.")
     
     class Config:
         """Pydantic configuration."""

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -10,6 +10,12 @@ Simple test script to verify the configuration system works correctly.
 import os
 from unittest.mock import MagicMock, patch
 
+import click
+import pytest
+from click.testing import CliRunner
+from pydantic import ValidationError
+
+from jupyter_mcp_server.CLI import _common_options
 from jupyter_mcp_server.config import JupyterMCPConfig, get_config, reset_config, set_config
 
 
@@ -265,8 +271,114 @@ def test_reconnect_interval_config():
     print("✅ reconnect_interval configuration test completed successfully!")
 
 
+def test_execution_timeout_env_var_is_read():
+    """The documented JUPYTER_MCP_EXECUTION_TIMEOUT env var reaches the CLI option."""
+    seen = {}
+
+    @click.command()
+    @_common_options
+    def _probe(**kwargs):
+        seen.update(kwargs)
+
+    result = CliRunner().invoke(
+        _probe, [], env={"JUPYTER_MCP_EXECUTION_TIMEOUT": "300"}
+    )
+
+    assert result.exit_code == 0, result.output
+    assert seen["execution_timeout"] == 300
+
+
+def test_max_execution_timeout_env_var_is_read():
+    """JUPYTER_MCP_MAX_EXECUTION_TIMEOUT reaches the CLI option."""
+    seen = {}
+
+    @click.command()
+    @_common_options
+    def _probe(**kwargs):
+        seen.update(kwargs)
+
+    result = CliRunner().invoke(
+        _probe, [], env={"JUPYTER_MCP_MAX_EXECUTION_TIMEOUT": "7200"}
+    )
+
+    assert result.exit_code == 0, result.output
+    assert seen["max_execution_timeout"] == 7200
+
+
+def test_execution_timeout_defaults_when_env_var_unset():
+    """Without the env var, the CLI default matches the config default."""
+    seen = {}
+
+    @click.command()
+    @_common_options
+    def _probe(**kwargs):
+        seen.update(kwargs)
+
+    result = CliRunner().invoke(_probe, [], env={})
+
+    assert result.exit_code == 0, result.output
+    assert seen["execution_timeout"] == 120
+    assert seen["max_execution_timeout"] == 3600
+
+
+def test_execution_timeout_zero_is_rejected_at_startup():
+    """A timeout of 0 fails at startup rather than expiring every execution."""
+    ran = []
+
+    @click.command()
+    @_common_options
+    def _probe(**kwargs):
+        ran.append(True)
+
+    result = CliRunner().invoke(
+        _probe, [], env={"JUPYTER_MCP_EXECUTION_TIMEOUT": "0"}
+    )
+
+    assert result.exit_code != 0
+    assert not ran, "startup continued with a timeout that expires immediately"
+
+
+def test_execution_timeout_config_rejects_non_positive():
+    """The config object itself refuses a non-positive execution timeout."""
+    reset_config()
+
+    with pytest.raises(ValidationError):
+        JupyterMCPConfig(execution_timeout=0)
+
+    with pytest.raises(ValidationError):
+        JupyterMCPConfig(max_execution_timeout=0)
+
+    # validate_assignment=True means the singleton rejects it too
+    with pytest.raises(ValidationError):
+        set_config(execution_timeout=0)
+
+    reset_config()
+
+
+def test_execution_timeout_config():
+    """Test the execution_timeout configuration field."""
+    reset_config()
+
+    config = get_config()
+    assert config.execution_timeout == 120
+    assert config.max_execution_timeout == 3600
+
+    new_config = set_config(execution_timeout=300)
+    assert new_config.execution_timeout == 300
+
+    # Singleton reflects the update
+    assert get_config().execution_timeout == 300
+
+    # Reset restores the default
+    reset_config()
+    assert get_config().execution_timeout == 120
+
+    print("✅ execution_timeout configuration test completed successfully!")
+
+
 if __name__ == "__main__":
     test_config()
     test_allowed_jupyter_mcp_tools_config()
     test_jupyter_extension_trait()
     test_reconnect_interval_config()
+    test_execution_timeout_config()


### PR DESCRIPTION
Opening this as you suggested in #264, so the naming question has something concrete to sit on.

## Root cause

#266 added `execution_timeout` / `max_execution_timeout` to `JupyterMCPConfig`, and README.md:32 plus docs/docs/reference/tools/index.mdx:133,145 document `JUPYTER_MCP_EXECUTION_TIMEOUT` as the way to set it. That env var does not exist in the code. It appears in those two files and nowhere else: `grep -rn JUPYTER_MCP_EXECUTION_TIMEOUT --include='*.py' .` returns nothing. `JupyterMCPConfig` is a plain `BaseModel`, not `BaseSettings`, so it reads no environment, and there was no `--execution-timeout` option feeding `set_config`. Anyone who followed the README set that variable and silently kept getting 120s.

Separately, config.py:38 advertised `Set to 0 for unlimited (use with caution)`. 0 is not unlimited. It flows straight into `asyncio.wait_for` (server.py:624) and into `execute_code_local`, where `timeout_ms = timeout * 1000` makes `remaining_ms = max(0, timeout_ms - elapsed_ms)` already 0 on the first loop iteration (utils.py:654-668), so the execution expires before the kernel can answer.

That second defect is unreachable today, which is why it is in this PR rather than its own: the only way to get `execution_timeout=0` into the config is a programmatic `set_config`, and no entrypoint does that. It goes live the moment the wiring below lands.

## Invariant

A timeout that reaches the execution seam is a positive number of seconds the operator actually chose.

## The fix

Per your call in the issue ("0 or None should be discarded and fail fast, unlimited should not be possible - a real number is needed"), unlimited is not implemented: both fields get `gt=0`, and the "0 for unlimited" claim is deleted rather than made true. The model sets `validate_assignment = True`, so this also rejects a later `set_config(execution_timeout=0)`, not just construction.

The options mirror `--reconnect-interval` (CLI.py:127), the runtime knob this one sits next to: an entry in `_common_options` with an `envvar`, threaded into the existing `set_config` call in `_do_start`. `click.IntRange(min=1)` turns a rejected value into a clean startup error instead of a traceback.

On the name, I used the prefixed `JUPYTER_MCP_EXECUTION_TIMEOUT`, on the one argument that is not about style: README.md:32 already publishes it, so people are setting that exact name today and getting nothing, and honoring it makes their existing config work. You were right that my `JUPYTER_MCP_OTEL_FILE` comparison was irrelevant, and the neighbours here really are unprefixed. If you prefer `EXECUTION_TIMEOUT`, it is a one-line change in each option and I will push it. Your call.

## How I verified

Docker `python:3.11-slim`, installed from a clean checkout, provenance printed on both sides (`/src/jupyter_mcp_server/CLI.py`) so I was exercising this source and not an installed copy.

End to end through the real `start` command with only the blocking `mcp.run` patched out, same script both sides:

- on `5ce3fc1`: `JUPYTER_MCP_EXECUTION_TIMEOUT=1800` gives `get_config().execution_timeout == 120`, and `=0` starts the server anyway.
- on this branch: `1800` gives `1800`, and `=0` exits 2 with `Error: Invalid value for '--execution-timeout': 0 is not in the range x>=1.`

The 0-expires-instantly behaviour, against a real ipykernel through `execute_code_local` on `5ce3fc1`: `timeout=30` returns `['hello from a real kernel']` in 0.223s, `timeout=0` returns `['[TIMEOUT ERROR: Code execution exceeded 0 seconds]']` in 0.115s with 0 outputs.

Five of the six added tests fail on `5ce3fc1` and pass here. The sixth (`test_execution_timeout_config`) passes on both; it mirrors `test_reconnect_interval_config` as field coverage.

```
TEST_MCP_SERVER=true TEST_JUPYTER_SERVER=false pytest
```

gives `99 passed, 1 failed, 7 skipped, 54 errors` on this branch, against `94 passed, 6 failed, 7 skipped, 54 errors` for the same test files on a clean `5ce3fc1` in the same container: an identical failure profile, plus the tests added here. The 54 errors and the `test_otel_integration.py::test_span_log_summary` failure need a live JupyterLab that my container does not start, and are unrelated to this change. I also ran the CI smoke check: all 44 modules import, and `--help` lists both flags.

## What I did not verify

I did not run this against a live JupyterLab or Datalayer runtime, so the wiring is proven at `get_config()` and at the execution seam, not by watching a long cell survive to 1800s.

## Left out on purpose

`execute_code` (server.py:779) still hardcodes `timeout: int = 30` with `le=3600` and never reads the config, so a lowered `--max-execution-timeout` is not enforced there and the new default does not reach it. It is the same surface, but fixing it changes a tool's public default, which is your decision rather than mine, and #264 is about `execute_cell`. Happy to follow up separately if you want it.

Fixes #264
