### PR TITLE
fix: create the notebook before the session that points at it (JUPYTER_SERVER mode)

### DIFF
--- a/jupyter_mcp_server/tools/use_notebook_tool.py
+++ b/jupyter_mcp_server/tools/use_notebook_tool.py
@@ -188,6 +188,28 @@ class UseNotebookTool(BaseTool):
                     return f"The path '{notebook_path}' is not the correct path for notebook '{notebook_name}'. Do you mean connect to '{notebook_manager.get_notebook_path(notebook_name)}'?"
         # add new notebook to notebook_manager
         else:
+            # Create notebook if needed
+            # This runs before the kernel and the Jupyter session below, which are
+            # both pointed at notebook_path and so need the file to exist already.
+            if use_mode == "create":
+                content = {
+                    "cells": [{
+                        "cell_type": "markdown",
+                        "metadata": {},
+                        "source": [
+                            "New Notebook Created by Jupyter MCP Server",
+                        ]
+                    }],
+                    "metadata": {},
+                    "nbformat": 4,
+                    "nbformat_minor": 4
+                }
+                if mode == ServerMode.JUPYTER_SERVER and contents_manager is not None:
+                    # Use local API to create notebook
+                    await contents_manager.new(model={'type': 'notebook', 'content': content, 'format': 'json'}, path=notebook_path)
+                elif mode == ServerMode.MCP_SERVER and server_client is not None:
+                    server_client.contents.create_notebook(notebook_path, content=content)
+
             # # Create/connect to kernel based on mode
             if mode == ServerMode.MCP_SERVER and server_client is not None:
                 if kernel_id is not None:
@@ -233,26 +255,6 @@ class UseNotebookTool(BaseTool):
                 else:
                     logger.warning("No session_manager available. Notebook may not be properly connected in JupyterLab UI.")
 
-            # Create notebook if needed
-            if use_mode == "create":
-                content = {
-                    "cells": [{
-                        "cell_type": "markdown",
-                        "metadata": {},
-                        "source": [
-                            "New Notebook Created by Jupyter MCP Server",
-                        ]
-                    }],
-                    "metadata": {},
-                    "nbformat": 4,
-                    "nbformat_minor": 4
-                }
-                if mode == ServerMode.JUPYTER_SERVER and contents_manager is not None:
-                    # Use local API to create notebook
-                    await contents_manager.new(model={'type': 'notebook'}, path=notebook_path)
-                elif mode == ServerMode.MCP_SERVER and server_client is not None:
-                    server_client.contents.create_notebook(notebook_path, content=content)
-            
             # Add notebook to notebook_manager
             if mode == ServerMode.MCP_SERVER and runtime_url:
                 notebook_manager.add_notebook(

--- a/tests/test_use_notebook_create_local.py
+++ b/tests/test_use_notebook_create_local.py
@@ -1,0 +1,105 @@
+# Copyright (c) 2024- Datalayer, Inc.
+#
+# BSD 3-Clause License
+
+"""Unit tests for use_notebook(use_mode="create") in JUPYTER_SERVER mode.
+
+These tests drive UseNotebookTool with in-memory stand-ins for the local
+contents/kernel/session managers, so no running Jupyter server is required.
+They cover what the tool asks those managers to do, and in which order, not the
+behaviour the managers themselves implement.
+"""
+
+import pytest
+
+from jupyter_mcp_server.notebook_manager import NotebookManager
+from jupyter_mcp_server.tools._base import ServerMode
+from jupyter_mcp_server.tools.use_notebook_tool import UseNotebookTool
+
+
+class RecordingContentsManager:
+    """Stand-in for jupyter_server's ContentsManager that records the model it
+    is asked to create instead of writing a file."""
+
+    def __init__(self, events):
+        self.events = events
+        self.new_calls = []
+
+    async def get(self, path, content=True, type=None):
+        return {"content": []}
+
+    async def new(self, model=None, path=""):
+        self.events.append("new")
+        self.new_calls.append((model, path))
+        return {"path": path}
+
+
+class RecordingKernelManager:
+    """Stand-in for the local MultiKernelManager surface use_notebook touches."""
+
+    def __init__(self, events):
+        self.events = events
+
+    async def start_kernel(self):
+        self.events.append("start_kernel")
+        return "kernel-1"
+
+    def get_kernel(self, kernel_id):
+        return object()
+
+    def get_connection_info(self, kernel_id):
+        return {"shell_port": 1}
+
+
+class RecordingSessionManager:
+    """Stand-in for jupyter_server's SessionManager."""
+
+    def __init__(self, events):
+        self.events = events
+
+    async def create_session(self, path=None, kernel_id=None, type=None, name=None):
+        self.events.append("create_session")
+        return {"id": "session-1"}
+
+
+async def _create_notebook():
+    """Create 'nb.ipynb' over the JUPYTER_SERVER path, returning the recorded
+    manager events and the contents_manager that saw the create call."""
+    events = []
+    contents_manager = RecordingContentsManager(events)
+    await UseNotebookTool().execute(
+        mode=ServerMode.JUPYTER_SERVER,
+        contents_manager=contents_manager,
+        kernel_manager=RecordingKernelManager(events),
+        session_manager=RecordingSessionManager(events),
+        notebook_manager=NotebookManager(),
+        notebook_name="nb",
+        notebook_path="nb.ipynb",
+        use_mode="create",
+    )
+    return events, contents_manager
+
+
+@pytest.mark.asyncio
+async def test_create_passes_the_skeleton_to_the_contents_manager():
+    """The notebook skeleton use_notebook builds must reach the local contents
+    manager, so that creating a notebook produces the same file in
+    JUPYTER_SERVER mode as it does over HTTP in MCP_SERVER mode."""
+    _events, contents_manager = await _create_notebook()
+
+    assert len(contents_manager.new_calls) == 1
+    model, path = contents_manager.new_calls[0]
+    assert path == "nb.ipynb"
+    assert model["type"] == "notebook"
+    assert model["content"]["cells"][0]["cell_type"] == "markdown"
+
+
+@pytest.mark.asyncio
+async def test_create_writes_the_notebook_before_starting_a_session_on_it():
+    """A Jupyter session must never be created for a notebook path that does
+    not exist yet, so the file is written before the kernel and session that
+    point at it."""
+    events, _contents_manager = await _create_notebook()
+
+    assert events.index("new") < events.index("create_session")
+    assert events.index("new") < events.index("start_kernel")


### PR DESCRIPTION
## Problem

In `use_notebook(use_mode="create")`, two things happen in the wrong order and one value is dropped, both in the `JUPYTER_SERVER` branch of `UseNotebookTool.execute`:

1. **The notebook skeleton is discarded.** The function builds a `content` dict holding a markdown cell ("New Notebook Created by Jupyter MCP Server"). The `MCP_SERVER` branch passes it (`server_client.contents.create_notebook(notebook_path, content=content)`), but the `JUPYTER_SERVER` branch called `await contents_manager.new(model={'type': 'notebook'}, path=notebook_path)`, which never referenced `content`. On that branch `content` was dead code, so the same tool call produced a different notebook depending on the mode.

2. **The file was created last.** The kernel (`_start_kernel_local(..., path=notebook_path)`) and then `session_manager.create_session(path=notebook_path, ...)` both ran *before* the file was written, so a Jupyter session briefly existed for a notebook path that did not exist yet.

## Invariant

In create mode the notebook file exists, with the intended skeleton content, before anything is pointed at its path.

## Fix

Move the `if use_mode == "create":` block above the kernel/session block, and pass the skeleton on the local branch via `model={'type': 'notebook', 'content': content, 'format': 'json'}`. The block is moved unchanged apart from that model argument.

## How I verified

All of this ran in a clean `python:3.12-slim` Docker container on current `main` (2113db0), with `print(module.__file__)` confirming the code under test was the checkout and not an installed copy.

Added `tests/test_use_notebook_create_local.py`: it drives `UseNotebookTool().execute(mode=ServerMode.JUPYTER_SERVER, ...)` with in-memory recording stand-ins for the contents/kernel/session managers, so it needs no live server. Both tests fail on `main` and pass here. On `main` the recorded call order is literally `['start_kernel', 'create_session', 'new']`, which is point 2 above.

I also checked the consequence of point 1 against real `jupyter_server` 2.20.0 `AsyncFileContentsManager` rather than reading its source:

- `new(model={'type': 'notebook'})` writes a 72-byte notebook with **0 cells**
- `new(model={'type': 'notebook', 'content': ..., 'format': 'json'})` writes a 198-byte notebook with the **1** skeleton cell

Existing suites that run without a live server are unchanged: 82 passed, 1 skipped. The 52 errors in that run are pre-existing fixture setup failures that need a live server, identical on `main` and on this branch.

## What I did NOT verify

I could not reproduce the JupyterLab hang reported in #246: it needs JupyterHub plus `jupyter_server_documents` and jupyter-ai 3.0, which I do not have. **So I am not claiming this fixes that hang.** Note that under standard `jupyter_server` the old code writes a valid (if empty) notebook, not the 0-byte file described in that thread, so the 0-byte observation there looks backend-specific and I could not confirm the causal chain. I am offering this as an ordering and mode-parity fix on its own merits, and referencing #246 only as the report that led me to the code. Happy to add `Fixes #246` if you judge it to cover the report.

Reordering also affects the `MCP_SERVER` branch, where the file is now created before `kernel.start(path=...)`. I did not exercise that branch against a live server. One consequence worth your call: if kernel startup now fails, the created file is left behind, where previously it would not have been created.

Disclosure: written with AI assistance. Every claim above was executed and checked by me.
