### PR TITLE
fix: preserve outputs, execution_count and metadata when moving a cell

### DIFF
--- a/jupyter_mcp_server/tools/move_cell_tool.py
+++ b/jupyter_mcp_server/tools/move_cell_tool.py
@@ -83,12 +83,12 @@ class MoveCellTool(BaseTool):
                 cell_type = nb_dict["cells"][source_index].get("cell_type", "code")
                 return Notebook(**nb_dict), {"cell_type": cell_type, "source": cell_source}
 
-            deleted = nb.delete_cell(source_index)
+            deleted = dict(nb.delete_cell(source_index))
             cell_type = deleted.get("cell_type", "code")
             cell_source = deleted.get("source", "")
             if isinstance(cell_source, list):
                 cell_source = "".join(cell_source)
-            nb.insert_cell(target_index, cell_source, cell_type)
+            nb.insert(target_index, deleted)
             return Notebook(**nb.as_dict()), {"cell_type": cell_type, "source": cell_source}
         else:
             return await self._move_cell_file(notebook_path, source_index, target_index)
@@ -144,12 +144,12 @@ class MoveCellTool(BaseTool):
                 cell_type = nb_dict["cells"][source_index].get("cell_type", "code")
                 return Notebook(**nb_dict), {"cell_type": cell_type, "source": cell_source}
 
-            deleted = notebook.delete_cell(source_index)
+            deleted = dict(notebook.delete_cell(source_index))
             cell_type = deleted.get("cell_type", "code")
             cell_source = deleted.get("source", "")
             if isinstance(cell_source, list):
                 cell_source = "".join(cell_source)
-            notebook.insert_cell(target_index, cell_source, cell_type)
+            notebook.insert(target_index, deleted)
             return Notebook(**notebook.as_dict()), {"cell_type": cell_type, "source": cell_source}
 
     async def execute(

--- a/tests/test_move_cell.py
+++ b/tests/test_move_cell.py
@@ -24,6 +24,8 @@ $ pytest tests/test_move_cell.py -v
 ```
 """
 
+import contextlib
+
 import pytest
 
 from .test_common import MCPClient, timeout_wrapper
@@ -110,6 +112,56 @@ class TestMoveCellApply:
         assert cells == ["A", "B", "C"]
 
 
+class TestMoveCellPreservesPayload:
+    """A move is a reorder: the moved cell keeps everything but its position."""
+
+    def setup_method(self):
+        self.tool = MoveCellTool()
+
+    @staticmethod
+    def _notebook_model():
+        """A three-cell notebook whose middle cell has been executed."""
+        from jupyter_nbmodel_client import NotebookModel
+        from jupyter_ydoc import YNotebook
+
+        nb = NotebookModel()
+        nb._doc = YNotebook()
+        nb._doc.set({
+            "cells": [
+                {"cell_type": "code", "source": "a = 1", "metadata": {},
+                 "outputs": [], "execution_count": None},
+                {"cell_type": "code", "source": "print('hello')",
+                 "metadata": {"tags": ["keep-me"]}, "execution_count": 7,
+                 "outputs": [{"output_type": "stream", "name": "stdout",
+                              "text": "hello\n"}]},
+                {"cell_type": "code", "source": "b = 2", "metadata": {},
+                 "outputs": [], "execution_count": None},
+            ],
+            "metadata": {}, "nbformat": 4, "nbformat_minor": 5,
+        })
+        return nb
+
+    @pytest.mark.asyncio
+    async def test_websocket_move_preserves_cell_payload(self):
+        """_move_cell_websocket must not rebuild the cell from its source."""
+        nb = self._notebook_model()
+        before = nb.as_dict()["cells"][1]
+
+        class _Manager:
+            @contextlib.asynccontextmanager
+            async def get_current_connection(_self):
+                yield nb
+
+        await self.tool._move_cell_websocket(_Manager(), 1, 2)
+
+        after = nb.as_dict()["cells"][2]
+        assert after["source"] == "print('hello')"
+        assert after["outputs"] == before["outputs"]
+        assert after["execution_count"] == 7
+        assert after["metadata"]["tags"] == ["keep-me"]
+        assert after["id"] == before["id"]
+
+
 ###############################################################################
 # Section B — Integration Tests (MCP_SERVER and JUPYTER_SERVER modes)
 ###############################################################################
@@ -119,6 +171,15 @@ async def _setup_cells(client: MCPClient, labels: list[str], cell_type: str = "c
     """Insert cells with the given labels at indices 1..N."""
     for i, label in enumerate(labels):
         await client.insert_cell(i + 1, cell_type, label)
+
+
+def _execution_count(header: str) -> str:
+    """Extract the execution count from a read_cell header line.
+
+    Header format: "=====Cell N | type: <type> | execution count: <count>====="
+    Returns the count as a string, or "N/A" when the cell has none.
+    """
+    return str(header).split("execution count:")[1].strip("= ")
 
 
 async def _read_cell_header(client: MCPClient, index: int) -> tuple[str, str]:
@@ -298,13 +359,24 @@ async def test_move_cell_preserves_outputs(mcp_client_parametrized: MCPClient):
         exec_result = await c.execute_cell(1)
         assert exec_result is not None
 
+        # Read the cell before the move, so the move is compared against it.
+        before = await c.read_cell(1, include_outputs=True)
+        before_header, _before_source, *before_outputs = before["result"]
+
         # Move the executed cell from index 1 to index 2
         await c.move_cell(1, 2)
 
-        # Read cell at new position with outputs
+        # read_cell returns [header, source, *outputs], so assert on the outputs
+        # region only: the source is print('hello') and contains "hello" whether
+        # or not the outputs survived the move.
         cell = await c.read_cell(2, include_outputs=True)
-        cell_text = " ".join(str(item) for item in cell["result"]).strip()
-        assert "hello" in cell_text
+        header, _source, *outputs = cell["result"]
+        outputs_text = " ".join(str(item) for item in outputs).strip()
+        assert "hello" in outputs_text
+        assert outputs == before_outputs
+        # The execution count travels with the cell; "N/A" means it was lost.
+        assert _execution_count(header) == _execution_count(before_header)
+        assert _execution_count(header) != "N/A"
 
         await _cleanup_cells(c, 2)
 


### PR DESCRIPTION
Fixes #272

## Root cause

`move_cell` has three backends implementing one contract, and two of them implement it as a re-creation rather than a reorder.

`_move_cell_ydoc` and `_move_cell_websocket` both delete the cell and rebuild it from `(source, cell_type)`:

```python
deleted = nb.delete_cell(source_index)
cell_type = deleted.get("cell_type", "code")
cell_source = deleted.get("source", "")
nb.insert_cell(target_index, cell_source, cell_type)
```

`NotebookModel.insert_cell(index, source, cell_type)` routes to `nbformat.v4.new_code_cell(source)`, so the new cell has only the two fields that were passed in. Everything else the `deleted` node still holds is dropped on the floor: `outputs`, `execution_count`, `metadata` and tags, attachments, and the cell `id`. `_move_cell_file` reorders the cell object itself (`_apply_move`), which is why the file backend was never affected.

## The invariant

A move changes a cell's position and nothing else: source, cell type, outputs, execution count, metadata and attachments survive, identically on all three backends.

The fails-on-main test below is an existence proof that the payload now survives the path it runs; it cannot establish "nothing else rebuilds a cell". That part is settled by enumeration instead. Parsing the package for calls to the lossy primitive `NotebookModel.insert_cell(...)` returns exactly four call sites:

| call site | verdict |
|---|---|
| `insert_cell_tool.py:85` (`_insert_cell_ydoc`) | correct: creating a genuinely new cell from source, nothing to preserve |
| `insert_cell_tool.py:177` (`_insert_cell_websocket`) | correct: same |
| `move_cell_tool.py:91` (`_move_cell_ydoc`) | the bug, fixed here |
| `move_cell_tool.py:152` (`_move_cell_websocket`) | the bug, fixed here |

`delete_cell(...)` has exactly two call sites in the package, both in `move_cell_tool.py`, both fixed here. So the complete set of places that could destroy a cell payload on a move is the two lines this PR changes.

## Fix

Reinsert the deleted cell through `NotebookModel.insert(index, value: dict)`, which hands the whole cell to `YNotebook.create_ycell(value)`. That path rebuilds source, metadata and outputs as CRDT types and keeps every other key, including an incoming `id`. It is 4 insertions and 4 deletions across the two call sites, with no public API change and no new dependency.

## Verification

Docker `python:3.12-slim`, non-editable `pip install .`, module provenance printed on both sides (`/usr/local/lib/python3.12/site-packages/jupyter_mcp_server/tools/move_cell_tool.py`), source file sha256 `4e50c846...` on main against `20e73f9d...` on this branch.

Live end-to-end against a real Jupyter server and a real ipykernel, on main, MCP_SERVER mode:

```
BEFORE read_cell(1): ['=====Cell 1 | type: code | execution count: 1=====', "print('hello')", 'hello\n']
AFTER  read_cell(2): ['=====Cell 2 | type: code | execution count: N/A=====', "print('hello')"]
```

On this branch the same sequence returns `execution count: 1` and the `hello` output at the new index.

The repo's own suite, both modes CI runs:

- `make test-mcp-server` equivalent: 39 passed
- `make test-jupyter-server` equivalent: 39 passed

Reverting only the source file and keeping the tests: `test_move_cell_preserves_outputs` and `TestMoveCellPreservesPayload` both fail in MCP_SERVER mode (`assert 'hello' in ''`, and `assert [] == [{...'text': 'hello\n'...}]`).

### The existing test, and why it passed

`test_move_cell_preserves_outputs` already encoded exactly this invariant, with the docstring "Moving a cell that has been executed should preserve its outputs." It could not fail. `read_cell` returns `[header, source, *outputs]`, the test joined the whole result and asserted `"hello" in cell_text`, and the cell's source is literally `print('hello')`. The assertion was matching the source, which a move never loses.

It now unpacks the outputs region and compares against a read taken before the move. The execution count is compared before against after rather than pinned to a literal: the kernel's counter depends on what ran earlier in the session, so a hardcoded `1` passes in MCP_SERVER mode and fails in JUPYTER_SERVER mode for reasons that have nothing to do with this bug.

`TestMoveCellPreservesPayload` is added alongside the file's existing Section A unit tests, covering metadata and tags and the cell `id`, which the end-to-end path does not surface. It mocks only the connection manager: `delete_cell` and `insert` are the real `NotebookModel` methods, so no writer of the cell payload is mocked out.

## What I did not verify

- **`_move_cell_ydoc` was not executed.** A headless run creates no collaborative room, so `get_notebook_model()` returns `None` and the tool correctly falls back to the file path. I exercised its identical twin `_move_cell_websocket` over the same `NotebookModel` type and read `_move_cell_ydoc` by eye. Both call sites carry the same five-line block, but I am reporting one from execution and one from reading.
- **Attachments** on markdown cells: read from the code (`new_markdown_cell(source)` takes no attachments), not measured.
- **The cell `id`.** Today a move re-mints it, and this fix preserves it, because `create_ycell` keeps an incoming `id`. I have treated that as correct on the grounds that a move should not change cell identity, and the added unit test pins it. If you would rather a moved cell take a fresh `id`, say so and I will drop that assertion and the behavior with it.
- Not a regression: `move_cell` has a single commit (c45d8ec, "Add move_cell tool (#226)") and has not been touched since, so this is original behavior rather than something that broke later.

I left `ruff format` alone deliberately: it wants to reformat 52 files on a pristine main, so running it here would have buried a four-line fix in an unrelated reformat. The changed lines follow the surrounding style.

---

This PR was prepared by an AI agent (Claude) operating on @ebarkhordar's behalf. Every command above was executed and its output read; the wording of what was and was not verified is deliberate.
