### PR TITLE
fix: return the timeout log and keep image outputs on the execute_cell streaming path

### DIFF
--- a/jupyter_mcp_server/tools/execute_cell_tool.py
+++ b/jupyter_mcp_server/tools/execute_cell_tool.py
@@ -277,6 +277,7 @@ class ExecuteCellTool(BaseTool):
 
                     start_time = time.time()
                     last_output_count = 0
+                    timed_out = False
 
                     # Monitor progress
                     while not execution_task.done():
@@ -285,6 +286,7 @@ class ExecuteCellTool(BaseTool):
                         # Check timeout
                         if elapsed > timeout_seconds:
                             execution_task.cancel()
+                            timed_out = True
                             outputs_log.append(f"[TIMEOUT at {elapsed:.1f}s: Cancelling execution]")
                             try:
                                 kernel.interrupt()
@@ -316,8 +318,10 @@ class ExecuteCellTool(BaseTool):
 
                         await asyncio.sleep(1)
 
-                    # Get final result
-                    if not execution_task.cancelled():
+                    # Get final result. On timeout the task was cancelled above, so
+                    # awaiting it would raise CancelledError, which is a BaseException
+                    # and is not caught below, discarding the timeout log just built.
+                    if not timed_out:
                         try:
                             await execution_task
                             final_outputs = notebook[cell_index].get("outputs", [])
@@ -328,7 +332,9 @@ class ExecuteCellTool(BaseTool):
                                 remaining = final_outputs[last_output_count:]
                                 for output in remaining:
                                     extracted = extract_output(output)
-                                    if extracted.strip():
+                                    if not isinstance(extracted, str):
+                                        outputs_log.append(extracted)
+                                    elif extracted.strip():
                                         outputs_log.append(extracted)
 
                         except Exception as e:

--- a/tests/test_execute_cell_stream.py
+++ b/tests/test_execute_cell_stream.py
@@ -1,0 +1,128 @@
+# Copyright (c) 2024- Datalayer, Inc.
+#
+# BSD 3-Clause License
+
+"""Unit tests for ExecuteCellTool's streaming (stream=True) branch.
+
+These tests exercise the tool's own control flow with in-memory stand-ins for
+the kernel and the notebook connection, so no running Jupyter server or kernel
+is required.
+"""
+
+import contextlib
+import time
+
+import pytest
+
+from jupyter_mcp_server.tools._base import ServerMode
+from jupyter_mcp_server.tools.execute_cell_tool import ExecuteCellTool
+
+# 1x1 transparent PNG.
+PNG_B64 = (
+    "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk"
+    "YPhfDwAChwGA60e6kgAAAABJRU5ErkJggg=="
+)
+
+
+class FakeKernel:
+    """Minimal stand-in covering the surface the streaming branch uses."""
+
+    def __init__(self):
+        self.interrupted = False
+
+    def interrupt(self):
+        self.interrupted = True
+
+
+class FakeNotebook:
+    """Single-cell notebook whose execute_cell runs a caller-supplied callable."""
+
+    def __init__(self, cell, execute_impl):
+        self._cell = cell
+        self._execute_impl = execute_impl
+
+    def __len__(self):
+        return 1
+
+    def __getitem__(self, index):
+        return self._cell
+
+    def execute_cell(self, cell_index, kernel):
+        return self._execute_impl()
+
+
+class FakeNotebookManager:
+    def __init__(self, notebook):
+        self._notebook = notebook
+
+    def get_current_notebook(self):
+        return "default"
+
+    def get_kernel_id(self, notebook_name):
+        return "kernel-1"
+
+    @contextlib.asynccontextmanager
+    async def _connection(self):
+        yield self._notebook
+
+    def get_current_connection(self):
+        return self._connection()
+
+
+async def _run_stream(cell, execute_impl, timeout_seconds, kernel):
+    manager = FakeNotebookManager(FakeNotebook(cell, execute_impl))
+    return await ExecuteCellTool().execute(
+        mode=ServerMode.MCP_SERVER,
+        server_client=None,
+        contents_manager=None,
+        kernel_manager=None,
+        kernel_spec_manager=None,
+        notebook_manager=manager,
+        serverapp=None,
+        cell_index=0,
+        timeout_seconds=timeout_seconds,
+        stream=True,
+        progress_interval=1,
+        ensure_kernel_alive_fn=lambda: kernel,
+    )
+
+
+@pytest.mark.asyncio
+async def test_stream_timeout_returns_partial_log():
+    """A timeout in streaming mode returns the timeout log it builds, the way the
+    non-streaming branch returns its [TIMEOUT ERROR: ...] marker, instead of
+    letting CancelledError escape execute()."""
+    cell = {"source": "time.sleep(60)", "outputs": []}
+    kernel = FakeKernel()
+
+    result = await _run_stream(cell, lambda: time.sleep(5), timeout_seconds=0, kernel=kernel)
+
+    assert isinstance(result, list)
+    assert any("[TIMEOUT at" in entry for entry in result if isinstance(entry, str))
+    assert kernel.interrupted
+
+
+@pytest.mark.asyncio
+async def test_stream_preserves_image_output_on_terminal_drain():
+    """Outputs landing between the final poll and completion are drained after the
+    task finishes. extract_output returns ImageContent for image/png, so the drain
+    must not assume a str, the way the monitoring loop above it already does not."""
+    image_output = {
+        "output_type": "display_data",
+        "data": {"image/png": PNG_B64},
+        "metadata": {},
+    }
+    cell = {"source": "plt.show()", "outputs": []}
+
+    def execute_impl():
+        # The output appears only at completion, after the final poll.
+        cell["outputs"] = [image_output]
+
+    result = await _run_stream(cell, execute_impl, timeout_seconds=30, kernel=FakeKernel())
+
+    images = [entry for entry in result if not isinstance(entry, str)]
+    assert len(images) == 1
+    assert images[0].data == PNG_B64
+    assert not any(
+        isinstance(entry, str) and entry.startswith("[ERROR:") for entry in result
+    )


### PR DESCRIPTION
Fixes #275.

## Root cause

Two defects in the terminal handling of `ExecuteCellTool.execute`'s `stream=True` branch. Neither is present in the non-streaming branch of the same function, which is what makes them look like oversights rather than intent.

**Timeout discards its own log.** The loop cancels the execution task, appends the timeout entries, and breaks. The final block is then guarded by `if not execution_task.cancelled():`. `Task.cancelled()` is `False` immediately after `cancel()`, because the task has not processed the cancellation yet, so the guard always passes and the `await execution_task` inside raises `CancelledError`. That derives from `BaseException`, so the `except Exception` below does not catch it: it escapes `execute()`, the timeout log is dropped and `AFTER_EXECUTE` never fires. The non-streaming branch instead returns partial outputs plus a `[TIMEOUT ERROR: ...]` marker. The `.cancelled()` call is dead code as written.

**The terminal drain assumes a str.** `if extracted.strip():` runs on the result of `extract_output`, declared `-> Union[str, ImageContent]`, which returns `ImageContent` for `image/png` when `ALLOW_IMG_OUTPUT` is on (the default). The `AttributeError` is swallowed by the `except Exception` below, so an image is replaced by `[ERROR: 'ImageContent' object has no attribute 'strip']`, which the caller cannot tell apart from a real execution error. The monitoring loop 28 lines above already type-checks the same union.

## Fix

Track the timeout in a local `timed_out` flag and gate the completion block on it, so the timeout path returns `outputs_log` like the non-streaming branch. Mirror the monitoring loop's `isinstance` check on the drain path so `ImageContent` passes through, keeping the existing empty-string filter for strings.

Nine lines, one function, no signature or behavior change on the paths that already worked.

## Verification

Both defects were reproduced on HEAD `4d07938d` and re-run against the branch, in a clean `python:3.12-slim` container, with the module path printed on both sides to prove the installed copy is the one under test.

Two regression tests in `tests/test_execute_cell_stream.py`, one per defect. They drive the real `execute()` with in-memory stand-ins for the kernel and the notebook connection, following the pattern in `tests/test_restart_notebook_tool.py`, so no live server or kernel is needed. Both **fail on main and pass on the branch**:

```
main:   2 failed
branch: 2 passed
```

Full suite, same command and container on both sides:

```
main:   1 failed, 102 passed, 1 skipped, 100 errors
branch: 1 failed, 104 passed, 1 skipped, 100 errors
```

The +2 are the new tests. The pre-existing failure and the 100 errors are identical on main and need a live JupyterLab that my container does not provide, so I am relying on CI for the integration legs. `license-eye header check` and `ruff` on the changed files are clean (the new test file adds only the `S101` asserts that every test file here has).

I did not drive a live kernel or a live RTC server. Both claims are about `execute()`'s own control flow and return value, and the tests do not need one.

Written with AI assistance (Claude), run and verified by @ebarkhordar.
