### PR TITLE
fix: keep each output's nbformat type when writing results back to a notebook file

### DIFF
--- a/jupyter_mcp_server/tools/execute_cell_tool.py
+++ b/jupyter_mcp_server/tools/execute_cell_tool.py
@@ -9,7 +9,7 @@ import logging
 import time
 import nbformat
 from pathlib import Path
-from typing import Union, List
+from typing import Optional, Union, List
 from mcp.types import ImageContent
 
 from jupyter_mcp_server.hooks import HookEvent, HookRegistry
@@ -36,14 +36,19 @@ class ExecuteCellTool(BaseTool):
         self,
         notebook_path: str,
         cell_index: int,
-        outputs: List[Union[str, ImageContent]]
+        outputs: List[Union[str, ImageContent]],
+        raw_outputs: Optional[List[dict]] = None
     ):
-        """Write execution outputs back to a notebook cell."""
+        """Write execution outputs back to a notebook cell.
+
+        When raw_outputs is given, the kernel's own nbformat-shaped outputs are
+        persisted, which keeps each output's real output_type. Without them only
+        the formatted strings are available (the timeout path, for example), and
+        the output type can only be guessed from the string form.
+        """
 
         with open(notebook_path, 'r', encoding='utf-8') as f:
             notebook = nbformat.read(f, as_version=4)
-
-        clean_notebook_outputs(notebook)
 
         # Handle negative indices (e.g., -1 for last cell)
         num_cells = len(notebook.cells)
@@ -59,29 +64,38 @@ class ExecuteCellTool(BaseTool):
             logger.warning(f"Cell {cell_index} is not a code cell, cannot write outputs")
             return
 
-        # Convert formatted outputs to nbformat structure
-        cell.outputs = []
-        for output in outputs:
-            if isinstance(output, ImageContent):
-                cell.outputs.append(nbformat.v4.new_output(
-                    output_type='display_data',
-                    data={output.mimeType: output.data},
-                    metadata={}
-                ))
-            elif isinstance(output, str):
-                if output.startswith('[ERROR:') or output.startswith('[TIMEOUT ERROR:') or output.startswith('[PROGRESS:'):
+        if raw_outputs:
+            # The kernel already reported each output's type: keep it.
+            cell.outputs = [nbformat.from_dict(output) for output in raw_outputs]
+        else:
+            # Only the formatted strings are available, so the type has to be
+            # guessed from the string form.
+            cell.outputs = []
+            for output in outputs:
+                if isinstance(output, ImageContent):
                     cell.outputs.append(nbformat.v4.new_output(
-                        output_type='stream',
-                        name='stdout',
-                        text=output
+                        output_type='display_data',
+                        data={output.mimeType: output.data},
+                        metadata={}
                     ))
-                else:
-                    cell.outputs.append(nbformat.v4.new_output(
-                        output_type='execute_result',
-                        data={'text/plain': output},
-                        metadata={},
-                        execution_count=None
-                    ))
+                elif isinstance(output, str):
+                    if output.startswith('[ERROR:') or output.startswith('[TIMEOUT ERROR:') or output.startswith('[PROGRESS:'):
+                        cell.outputs.append(nbformat.v4.new_output(
+                            output_type='stream',
+                            name='stdout',
+                            text=output
+                        ))
+                    else:
+                        cell.outputs.append(nbformat.v4.new_output(
+                            output_type='execute_result',
+                            data={'text/plain': output},
+                            metadata={},
+                            execution_count=None
+                        ))
+
+        # Strip kernel-protocol fields that are not part of the nbformat schema
+        # (the raw outputs above come straight from the kernel).
+        clean_notebook_outputs(notebook)
 
         # Update execution count
         max_count = 0
@@ -89,6 +103,11 @@ class ExecuteCellTool(BaseTool):
             if c.cell_type == 'code' and c.execution_count:
                 max_count = max(max_count, c.execution_count)
         cell.execution_count = max_count + 1
+
+        # An execute_result carries the execution count of the cell that produced it.
+        for output in cell.outputs:
+            if output.get('output_type') == 'execute_result':
+                output['execution_count'] = cell.execution_count
 
         with open(notebook_path, 'w', encoding='utf-8') as f:
             nbformat.write(notebook, f)
@@ -234,15 +253,19 @@ class ExecuteCellTool(BaseTool):
                     return []
 
                 # Execute without RTC metadata
+                raw_outputs: List[dict] = []
                 outputs = await execute_via_execution_stack(
                     serverapp=serverapp,
                     kernel_id=kernel_id,
                     code=code_to_execute,
-                    timeout=timeout_seconds
+                    timeout=timeout_seconds,
+                    raw_outputs=raw_outputs
                 )
 
                 # Write outputs back to file
-                await self._write_outputs_to_cell(notebook_path, cell_index, outputs)
+                await self._write_outputs_to_cell(
+                    notebook_path, cell_index, outputs, raw_outputs=raw_outputs
+                )
 
                 return outputs
 

--- a/jupyter_mcp_server/utils.py
+++ b/jupyter_mcp_server/utils.py
@@ -6,7 +6,7 @@ import re
 import asyncio
 import time
 import json
-from typing import Any, Union
+from typing import Any, Optional, Union
 from mcp.types import ImageContent
 from jupyter_mcp_server.config import ALLOW_IMG_OUTPUT
 from jupyter_mcp_server.hooks import HookEvent, HookRegistry
@@ -428,10 +428,11 @@ async def execute_via_execution_stack(
     cell_id: str = None,
     timeout: int = 300,
     poll_interval: float = 0.1,
-    logger = None
+    logger = None,
+    raw_outputs: Optional[list] = None
 ) -> list[Union[str, ImageContent]]:
     """Execute code using ExecutionStack (JUPYTER_SERVER mode with jupyter-server-nbmodel).
-    
+
     This uses the ExecutionStack from jupyter-server-nbmodel extension directly,
     avoiding the reentrant HTTP call issue. This is the preferred method for code
     execution in JUPYTER_SERVER mode.
@@ -445,7 +446,12 @@ async def execute_via_execution_stack(
         timeout: Maximum time to wait for execution (seconds)
         poll_interval: Time between polling for results (seconds)
         logger: Logger instance (optional)
-        
+        raw_outputs: Optional list. When provided, the nbformat-shaped outputs
+            reported by the kernel are appended to it, so callers that persist
+            outputs to disk can keep each output's real ``output_type`` instead
+            of re-deriving it from the formatted strings. The formatted return
+            value is unaffected.
+
     Returns:
         List of formatted outputs (strings or ImageContent)
         
@@ -509,6 +515,13 @@ async def execute_via_execution_stack(
                         error_info = result["error"]
                         logger.error(f"Execution error: {error_info}")
                         error_output = [f"[ERROR: {error_info.get('ename', 'Unknown')}: {error_info.get('evalue', '')}]"]
+                        if raw_outputs is not None:
+                            raw_outputs.append({
+                                "output_type": "error",
+                                "ename": error_info.get("ename", "Unknown"),
+                                "evalue": error_info.get("evalue", ""),
+                                "traceback": error_info.get("traceback", []),
+                            })
                         await HookRegistry.get_instance().fire(
                             HookEvent.AFTER_EXECUTE,
                             code=code, kernel_id=kernel_id, metadata=metadata,
@@ -535,6 +548,8 @@ async def execute_via_execution_stack(
 
                     if outputs:
                         formatted = safe_extract_outputs(outputs)
+                        if raw_outputs is not None:
+                            raw_outputs.extend(outputs)
                         logger.info(f"Execution completed with {len(formatted)} formatted outputs: {formatted}")
                     else:
                         formatted = []

--- a/tests/test_execute_cell_output_fidelity.py
+++ b/tests/test_execute_cell_output_fidelity.py
@@ -1,0 +1,170 @@
+# Copyright (c) 2024- Datalayer, Inc.
+#
+# BSD 3-Clause License
+
+"""Unit tests for the output types execute_cell persists in JUPYTER_SERVER file mode.
+
+The kernel reports each output's nbformat type. These tests pin that the type
+survives the write-back to the .ipynb, instead of being re-derived from the
+formatted string form.
+"""
+
+import nbformat
+import pytest
+
+from jupyter_mcp_server.tools.execute_cell_tool import ExecuteCellTool
+
+
+STREAM_OUTPUT = {
+    "output_type": "stream",
+    "name": "stdout",
+    "text": "hello\n",
+}
+
+ERROR_OUTPUT = {
+    "output_type": "error",
+    "ename": "ZeroDivisionError",
+    "evalue": "division by zero",
+    "traceback": [
+        "Traceback (most recent call last):",
+        "ZeroDivisionError: division by zero",
+    ],
+}
+
+EXECUTE_RESULT_OUTPUT = {
+    "output_type": "execute_result",
+    "data": {"text/plain": "2"},
+    "metadata": {},
+    "execution_count": 1,
+}
+
+DISPLAY_DATA_OUTPUT = {
+    "output_type": "display_data",
+    "data": {"image/png": "aGVsbG8="},
+    "metadata": {},
+}
+
+
+def _write_notebook(tmp_path, source="print('hello')"):
+    notebook = nbformat.v4.new_notebook()
+    notebook.cells.append(nbformat.v4.new_code_cell(source=source))
+    path = tmp_path / "notebook.ipynb"
+    with open(path, "w", encoding="utf-8") as f:
+        nbformat.write(notebook, f)
+    return str(path)
+
+
+def _read_notebook(path):
+    with open(path, "r", encoding="utf-8") as f:
+        return nbformat.read(f, as_version=4)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "raw_output,expected_type",
+    [
+        (STREAM_OUTPUT, "stream"),
+        (ERROR_OUTPUT, "error"),
+        (EXECUTE_RESULT_OUTPUT, "execute_result"),
+        (DISPLAY_DATA_OUTPUT, "display_data"),
+    ],
+    ids=["stream", "error", "execute_result", "display_data"],
+)
+async def test_output_type_round_trips(tmp_path, raw_output, expected_type):
+    """Every output the kernel reports keeps its type on disk."""
+    path = _write_notebook(tmp_path)
+    tool = ExecuteCellTool()
+
+    await tool._write_outputs_to_cell(path, 0, [], raw_outputs=[raw_output])
+
+    notebook = _read_notebook(path)
+    assert notebook.cells[0].outputs[0]["output_type"] == expected_type
+    nbformat.validate(notebook)
+
+
+@pytest.mark.asyncio
+async def test_error_output_keeps_its_fields(tmp_path):
+    """An error keeps ename, evalue and traceback, so error scrapers can read it."""
+    path = _write_notebook(tmp_path)
+    tool = ExecuteCellTool()
+
+    await tool._write_outputs_to_cell(path, 0, [], raw_outputs=[ERROR_OUTPUT])
+
+    output = _read_notebook(path).cells[0].outputs[0]
+    assert output["output_type"] == "error"
+    assert output["ename"] == "ZeroDivisionError"
+    assert output["evalue"] == "division by zero"
+    assert output["traceback"] == ERROR_OUTPUT["traceback"]
+
+
+@pytest.mark.asyncio
+async def test_stream_output_keeps_name_and_text(tmp_path):
+    """stderr stays distinguishable from stdout."""
+    path = _write_notebook(tmp_path)
+    tool = ExecuteCellTool()
+    stderr_output = {"output_type": "stream", "name": "stderr", "text": "oops\n"}
+
+    await tool._write_outputs_to_cell(path, 0, [], raw_outputs=[stderr_output])
+
+    output = _read_notebook(path).cells[0].outputs[0]
+    assert output["output_type"] == "stream"
+    assert output["name"] == "stderr"
+    assert output["text"] == "oops\n"
+
+
+@pytest.mark.asyncio
+async def test_execute_result_execution_count_matches_cell(tmp_path):
+    """The execute_result reports the same execution count as the cell."""
+    path = _write_notebook(tmp_path)
+    tool = ExecuteCellTool()
+
+    await tool._write_outputs_to_cell(path, 0, [], raw_outputs=[EXECUTE_RESULT_OUTPUT])
+
+    cell = _read_notebook(path).cells[0]
+    assert cell.execution_count == 1
+    assert cell.outputs[0]["execution_count"] == cell.execution_count
+
+
+@pytest.mark.asyncio
+async def test_multiple_outputs_keep_their_order_and_types(tmp_path):
+    """A cell that prints, then raises, keeps both outputs distinct."""
+    path = _write_notebook(tmp_path)
+    tool = ExecuteCellTool()
+
+    await tool._write_outputs_to_cell(
+        path, 0, [], raw_outputs=[STREAM_OUTPUT, ERROR_OUTPUT]
+    )
+
+    outputs = _read_notebook(path).cells[0].outputs
+    assert [o["output_type"] for o in outputs] == ["stream", "error"]
+
+
+@pytest.mark.asyncio
+async def test_transient_field_is_stripped(tmp_path):
+    """'transient' is kernel protocol, not nbformat, so it must not be persisted."""
+    path = _write_notebook(tmp_path)
+    tool = ExecuteCellTool()
+    with_transient = dict(DISPLAY_DATA_OUTPUT, transient={"display_id": "abc"})
+
+    await tool._write_outputs_to_cell(path, 0, [], raw_outputs=[with_transient])
+
+    notebook = _read_notebook(path)
+    assert "transient" not in notebook.cells[0].outputs[0]
+    nbformat.validate(notebook)
+
+
+@pytest.mark.asyncio
+async def test_falls_back_to_formatted_strings_without_raw_outputs(tmp_path):
+    """Callers with only formatted strings (the timeout path) still write outputs."""
+    path = _write_notebook(tmp_path)
+    tool = ExecuteCellTool()
+
+    await tool._write_outputs_to_cell(
+        path, 0, ["[TIMEOUT ERROR: Execution exceeded 1 seconds]"]
+    )
+
+    notebook = _read_notebook(path)
+    outputs = notebook.cells[0].outputs
+    assert len(outputs) == 1
+    assert outputs[0]["output_type"] == "stream"
+    nbformat.validate(notebook)


### PR DESCRIPTION
Fixes #277.

## Root cause

In JUPYTER_SERVER mode with the notebook not open in a collaborative session, `execute_cell` writes results straight to the `.ipynb`. The kernel reports each output with its nbformat type, and that type is thrown away and then guessed back:

- `execute_via_execution_stack` receives `result["outputs"]` from `ExecutionStack`, already nbformat-shaped, and returns only `safe_extract_outputs(...)`, a list of display strings.
- `_write_outputs_to_cell` re-derives the type from the string: `[ERROR:` / `[TIMEOUT ERROR:` / `[PROGRESS:` prefixes become `stream`, and everything else becomes `execute_result`.

A `print()` is therefore persisted as `execute_result`, and a traceback is persisted as `execute_result` too, since `safe_extract_outputs` hands back the bare traceback text with no `[ERROR:` prefix. Nothing on this path writes `output_type: error`. The synthesized `execute_result` also gets `execution_count: None` while its cell gets `max + 1`.

The notebook stays schema valid, so nothing complains. The damage is downstream, in tooling that keys on `output_type`: a notebook whose cells raised contains no `error` output at all. The RTC path is unaffected, it syncs through the YDoc and never calls this function.

## Fix

The structured outputs are already in hand one frame up, they are just discarded. `execute_via_execution_stack` takes an optional `raw_outputs` list and, when given one, appends the kernel's nbformat-shaped outputs to it. Its return value, and therefore the MCP tool's return value, is unchanged. `_write_outputs_to_cell` persists those outputs as they arrived instead of re-inflating strings, and gives each `execute_result` the execution count of its cell.

When no raw outputs are available (the timeout path reaches the write-back with strings only) the previous string form is kept, so that path behaves exactly as before.

`clean_notebook_outputs` moves to after the outputs are assigned, so it also strips `transient` from the kernel's own outputs. On the early-return paths it had no effect before, since the file is not written there.

## The invariant, and who else writes these outputs

Invariant: on the JUPYTER_SERVER file-mode `execute_cell` path, every output persisted to the `.ipynb` carries the `output_type` the kernel reported for it.

That quantifies over all writers of a cell's persisted `outputs`, which a passing test cannot check, so I enumerated them by parsing the package with `ast` (`X.outputs = ...`, subscript assignment and `append`/`extend`/`update`) and adjudicated each to its own type and path. Twenty candidates:

| writer | verdict |
| --- | --- |
| `execute_cell_tool._write_outputs_to_cell` (:63-84) | the fault site, and the only writer on this path. Fixed here. |
| `execute_cell_tool.py:384` `partial_outputs.append` | a local list of strings on the MCP_SERVER streaming path, not a cell field. |
| `utils.execute_cell_local` (:857, :860, :914, :918, :925) | same defect shape, but unreachable: zero callers in the package. Left alone. |
| `utils.execute_code_local` (:693-717) | builds correctly typed nbformat outputs from kernel messages. This is the shape the fix keeps. |
| `local_backend.append_cell` / `insert_cell` (:198, :249) | initialize `outputs` to `[]` on cell creation, not execution write-back. |
| `local_backend.execute_cell` (:414, :427) | a separate execution path that does not run under `ExecuteCellTool`'s JUPYTER_SERVER branch. Out of scope. |

The two self-labelled "simplified" comments on this behavior are in `execute_cell_local`, which is the dead one, so they do not describe the live path this changes. None of these writers is mocked in the tests below: the intersection of "writers" and "things the tests replace" is empty, because the tests mock nothing.

## Verification

Clean `python:3.11-slim` container, HEAD `8586b559`, module path printed on both sides so the copy under test is the installed one.

A real `python3` kernel driven through the real `ExecutionStack`, the real `safe_extract_outputs` and the real `_write_outputs_to_cell`, ending at the file on disk, with nothing mocked:

```
                   kernel emitted   persisted   main     branch
print('hello')     stream           ->          WRONG    ok
1/0                error            ->          WRONG    ok
2                  execute_result   ->          ok       ok

wrong type:  main 2/3    branch 0/3     (nbformat.validate passed on both sides)
```

Ten regression tests in `tests/test_execute_cell_output_fidelity.py`, one per behavior claimed above: the four output types round-tripping, `error` keeping `ename`/`evalue`/`traceback`, `stream` keeping `stderr` apart from `stdout`, `execute_result` agreeing with its cell's execution count, ordering across two outputs, `transient` being stripped, and the string fallback still working. They need no live server:

```
main:   9 failed, 1 passed
branch: 10 passed
```

The one that passes on both is the fallback test, which pins existing behavior. The other nine fail on main partly because `raw_outputs` does not exist there, so they pin the fix rather than prove the bug: the end-to-end run above is what demonstrates the bug on unmodified HEAD.

Pre-existing suites, same command and container on both sides:

```
main:   6 passed, 35 errors
branch: 6 passed, 35 errors
```

The 35 errors are identical on main and need a live JupyterLab my container does not provide, so I am relying on CI for those legs. `ruff` and `mypy` report the same counts on the two changed files before and after (0 and 22), the license header matches `.licenserc.yaml`, and the bare-install smoke test imports all 44 modules.

What I did not verify: I did not run nbconvert or papermill to watch them misread the notebook, so the specific rendering consequences are read from what `output_type` means, not measured. I did not stand up a full Jupyter Server with the extension loaded; the end-to-end run drives `ExecutionStack` directly with `ydoc_extension=None`, which is the file-mode configuration, but it is not a live server. I did not exercise the RTC path, which this does not touch.

Written with AI assistance (Claude), run and verified by @ebarkhordar.
