### PR TITLE
fix: honour execute_code kernel_id in MCP_SERVER mode

### DIFF
--- a/jupyter_mcp_server/tools/execute_code_tool.py
+++ b/jupyter_mcp_server/tools/execute_code_tool.py
@@ -51,6 +51,33 @@ class ExecuteCodeTool(BaseTool):
             logger=logger
         )
     
+    def _connect_to_kernel(self, kernel_id: str, server_client):
+        """Connect to an existing kernel by ID (MCP_SERVER mode).
+
+        Returns (kernel, None) on success, or (None, error_message) if the id
+        does not name a kernel on the server.
+        """
+        from jupyter_kernel_client import KernelClient
+
+        from jupyter_mcp_server.config import get_config
+
+        if server_client is not None:
+            kernels = server_client.kernels.list_kernels()
+            if not any(kernel.id == kernel_id for kernel in kernels):
+                return None, (
+                    f"[ERROR: Kernel '{kernel_id}' not found in jupyter server, please check "
+                    f"whether the kernel already exists using 'list_kernels' tool.]"
+                )
+
+        config = get_config()
+        kernel = KernelClient(
+            server_url=config.runtime_url,
+            token=config.runtime_token,
+            kernel_id=kernel_id,
+        )
+        kernel.start()
+        return kernel, None
+
     async def _execute_via_notebook_manager(
         self,
         notebook_manager: NotebookManager,
@@ -58,23 +85,69 @@ class ExecuteCodeTool(BaseTool):
         timeout: int,
         ensure_kernel_alive_fn,
         wait_for_kernel_idle_fn,
-        safe_extract_outputs_fn
+        safe_extract_outputs_fn,
+        kernel_id: str = None,
+        server_client=None
     ) -> list[Union[str, ImageContent]]:
-        """Execute code using notebook_manager (MCP_SERVER mode - original logic)."""
+        """Execute code using notebook_manager (MCP_SERVER mode - original logic).
+
+        When kernel_id names a kernel other than the current notebook's, the code
+        runs in that kernel instead. Such a connection is opened for this call only
+        and closed afterwards without shutting the kernel down.
+        """
         # Get current notebook name and kernel
         current_notebook = notebook_manager.get_current_notebook() or "default"
-        kernel = notebook_manager.get_kernel(current_notebook)
+        current_kernel_id = notebook_manager.get_kernel_id(current_notebook)
 
-        if not kernel:
-            # Ensure kernel is alive
-            kernel = ensure_kernel_alive_fn()
+        # A kernel we connect to here is borrowed, not owned: it must be released
+        # in the finally below, and never shut down.
+        borrowed_kernel = None
+        if kernel_id is not None and kernel_id != current_kernel_id:
+            kernel, error = self._connect_to_kernel(kernel_id, server_client)
+            if error is not None:
+                return [error]
+            borrowed_kernel = kernel
+            kid = kernel_id
+        else:
+            kernel = notebook_manager.get_kernel(current_notebook)
 
+            if not kernel:
+                # Ensure kernel is alive
+                kernel = ensure_kernel_alive_fn()
+
+            kid = current_kernel_id or ""
+
+        try:
+            return await self._execute_on_kernel(
+                kernel=kernel,
+                kid=kid,
+                code=code,
+                timeout=timeout,
+                wait_for_kernel_idle_fn=wait_for_kernel_idle_fn,
+                safe_extract_outputs_fn=safe_extract_outputs_fn,
+            )
+        finally:
+            if borrowed_kernel is not None:
+                try:
+                    borrowed_kernel.stop(shutdown_kernel=False)
+                except Exception as stop_err:
+                    logger.warning(f"Failed to release kernel {kid}: {stop_err}")
+
+    async def _execute_on_kernel(
+        self,
+        kernel,
+        kid: str,
+        code: str,
+        timeout: int,
+        wait_for_kernel_idle_fn,
+        safe_extract_outputs_fn
+    ) -> list[Union[str, ImageContent]]:
+        """Run code on an already-resolved kernel (MCP_SERVER mode)."""
         # Wait for kernel to be idle before executing
         await wait_for_kernel_idle_fn(kernel, max_wait_seconds=30)
 
         logger.info(f"Executing IPython code (MCP_SERVER) with timeout {timeout}s: {code[:100]}...")
 
-        kid = notebook_manager.get_kernel_id(current_notebook) or ""
         hooks = HookRegistry.get_instance()
         hook_ctx = await hooks.fire(
             HookEvent.BEFORE_EXECUTE,
@@ -151,14 +224,14 @@ class ExecuteCodeTool(BaseTool):
         
         Args:
             mode: Server mode (MCP_SERVER or JUPYTER_SERVER)
-            server_client: JupyterServerClient (not used)
+            server_client: JupyterServerClient (used to resolve kernel_id in MCP_SERVER mode)
             contents_manager: Contents manager (not used)
             kernel_manager: Kernel manager (for JUPYTER_SERVER mode)
             kernel_spec_manager: Kernel spec manager (not used)
             notebook_manager: Notebook manager (for MCP_SERVER mode)
             code: IPython code to execute (supports magic commands, shell commands with !, and Python code)
             timeout: Execution timeout in seconds (default: 60s)
-            kernel_id: Kernel ID (for JUPYTER_SERVER mode)
+            kernel_id: Kernel to execute in; defaults to the current notebook's kernel
             ensure_kernel_alive_fn: Function to ensure kernel is alive (for MCP_SERVER mode)
             wait_for_kernel_idle_fn: Function to wait for kernel idle state (for MCP_SERVER mode)
             safe_extract_outputs_fn: Function to safely extract outputs
@@ -210,14 +283,16 @@ class ExecuteCodeTool(BaseTool):
             if wait_for_kernel_idle_fn is None:
                 raise ValueError("wait_for_kernel_idle_fn is required for MCP_SERVER mode")
             
-            logger.info("Executing IPython in MCP_SERVER mode")
+            logger.info(f"Executing IPython in MCP_SERVER mode with kernel_id={kernel_id}")
             return await self._execute_via_notebook_manager(
                 notebook_manager=notebook_manager,
                 code=code,
                 timeout=timeout,
                 ensure_kernel_alive_fn=ensure_kernel_alive_fn,
                 wait_for_kernel_idle_fn=wait_for_kernel_idle_fn,
-                safe_extract_outputs_fn=safe_extract_outputs_fn
+                safe_extract_outputs_fn=safe_extract_outputs_fn,
+                kernel_id=kernel_id,
+                server_client=server_client
             )
         
         else:

--- a/tests/test_execute_code_kernel_id.py
+++ b/tests/test_execute_code_kernel_id.py
@@ -1,0 +1,126 @@
+# Copyright (c) 2024- Datalayer, Inc.
+#
+# BSD 3-Clause License
+
+"""Tests for execute_code(kernel_id=...) kernel targeting in MCP_SERVER mode.
+
+These run against the real Jupyter server fixture with two real kernels, since
+what is under test is which kernel the code actually reaches.
+"""
+
+import pytest
+from jupyter_kernel_client import KernelClient
+from jupyter_server_client import JupyterServerClient
+
+from jupyter_mcp_server.config import reset_config, set_config
+from jupyter_mcp_server.notebook_manager import NotebookManager
+from jupyter_mcp_server.tools._base import ServerMode
+from jupyter_mcp_server.tools.execute_code_tool import ExecuteCodeTool
+from jupyter_mcp_server.utils import safe_extract_outputs, wait_for_kernel_idle
+
+from .conftest import JUPYTER_TOKEN
+
+
+@pytest.fixture
+def targeting_setup(jupyter_server):
+    """Two live kernels, each holding a distinct MARKER, with the first bound to
+    the current notebook. Yields (notebook_manager, server_client, raw_kernel_id).
+    """
+    set_config(runtime_url=jupyter_server, runtime_token=JUPYTER_TOKEN)
+    server_client = JupyterServerClient(base_url=jupyter_server, token=JUPYTER_TOKEN)
+
+    current_kernel = KernelClient(server_url=jupyter_server, token=JUPYTER_TOKEN)
+    current_kernel.start()
+    raw_kernel = KernelClient(server_url=jupyter_server, token=JUPYTER_TOKEN)
+    raw_kernel.start()
+
+    try:
+        # Give each kernel its own identity so the assertion cannot pass by luck.
+        current_kernel.execute("MARKER = 'current-notebook-kernel'")
+        raw_kernel.execute("MARKER = 'raw-kernel'")
+
+        notebook_manager = NotebookManager()
+        notebook_manager.add_notebook(
+            "nb",
+            current_kernel,
+            server_url=jupyter_server,
+            token=JUPYTER_TOKEN,
+            path="nb.ipynb",
+        )
+        notebook_manager.set_current_notebook("nb")
+
+        yield notebook_manager, server_client, raw_kernel.id
+    finally:
+        current_kernel.stop()
+        raw_kernel.stop()
+        reset_config()
+
+
+async def _execute(notebook_manager, server_client, code, kernel_id=None):
+    def _no_kernel_expected():
+        raise AssertionError("the current notebook already has a kernel")
+
+    return await ExecuteCodeTool().execute(
+        mode=ServerMode.MCP_SERVER,
+        server_client=server_client,
+        notebook_manager=notebook_manager,
+        code=code,
+        timeout=30,
+        kernel_id=kernel_id,
+        ensure_kernel_alive_fn=_no_kernel_expected,
+        wait_for_kernel_idle_fn=wait_for_kernel_idle,
+        safe_extract_outputs_fn=safe_extract_outputs,
+    )
+
+
+@pytest.mark.asyncio
+async def test_execute_code_runs_in_the_requested_kernel(targeting_setup):
+    """kernel_id must select the kernel the code runs in, not be discarded."""
+    notebook_manager, server_client, raw_kernel_id = targeting_setup
+
+    outputs = await _execute(
+        notebook_manager, server_client, "print(MARKER)", kernel_id=raw_kernel_id
+    )
+
+    assert "raw-kernel" in "".join(str(output) for output in outputs)
+
+
+@pytest.mark.asyncio
+async def test_execute_code_leaves_the_targeted_kernel_running(targeting_setup):
+    """The targeted kernel is borrowed, so it must survive the call and keep its
+    state: releasing the connection must not shut a kernel down."""
+    notebook_manager, server_client, raw_kernel_id = targeting_setup
+
+    await _execute(notebook_manager, server_client, "print(MARKER)", kernel_id=raw_kernel_id)
+
+    assert any(kernel.id == raw_kernel_id for kernel in server_client.kernels.list_kernels())
+
+    outputs = await _execute(
+        notebook_manager, server_client, "print(MARKER)", kernel_id=raw_kernel_id
+    )
+    assert "raw-kernel" in "".join(str(output) for output in outputs)
+
+
+@pytest.mark.asyncio
+async def test_execute_code_without_kernel_id_uses_the_current_notebook(targeting_setup):
+    """Omitting kernel_id keeps the documented default: the current notebook's kernel."""
+    notebook_manager, server_client, _ = targeting_setup
+
+    outputs = await _execute(notebook_manager, server_client, "print(MARKER)")
+
+    assert "current-notebook-kernel" in "".join(str(output) for output in outputs)
+
+
+@pytest.mark.asyncio
+async def test_execute_code_reports_an_unknown_kernel_id(targeting_setup):
+    """An unknown kernel_id must be reported, never silently redirected to
+    whichever kernel happens to be current."""
+    notebook_manager, server_client, _ = targeting_setup
+
+    outputs = await _execute(
+        notebook_manager, server_client, "print(MARKER)", kernel_id="no-such-kernel"
+    )
+
+    joined = "".join(str(output) for output in outputs)
+    assert "no-such-kernel" in joined and "not found" in joined
+    assert "current-notebook-kernel" not in joined

--- a/tests/test_execute_code_kernel_id.py
+++ b/tests/test_execute_code_kernel_id.py
@@ -8,6 +8,8 @@ These run against the real Jupyter server fixture with two real kernels, since
 what is under test is which kernel the code actually reaches.
 """
 
+import time
+
 import pytest
 from jupyter_kernel_client import KernelClient
 from jupyter_server_client import JupyterServerClient
@@ -19,6 +21,25 @@ from jupyter_mcp_server.tools.execute_code_tool import ExecuteCodeTool
 from jupyter_mcp_server.utils import safe_extract_outputs, wait_for_kernel_idle
 
 from .conftest import JUPYTER_TOKEN
+
+
+def _seed(server_client, kernel, marker, timeout=60):
+    """Wait for a kernel to be ready, then give it its identity.
+
+    A kernel is created asynchronously, so ``start()`` returns while the server may
+    still report it as ``starting``. ``KernelClient.execution_state`` cannot answer
+    this: it caches the creation reply and is only valid after ``refresh()``. Ask
+    the server, then assert the seeding ran, so a kernel that never came up fails
+    here rather than as a puzzling timeout inside the assertion under test.
+    """
+    deadline = time.monotonic() + timeout
+    while server_client.kernels.get_kernel(kernel.id).execution_state != "idle":
+        if time.monotonic() > deadline:
+            raise AssertionError(f"kernel {kernel.id} was not ready within {timeout}s")
+        time.sleep(0.1)
+
+    reply = kernel.execute(f"MARKER = {marker!r}")
+    assert reply["status"] == "ok", f"seeding {marker} failed: {reply}"
 
 
 @pytest.fixture
@@ -36,8 +57,8 @@ def targeting_setup(jupyter_server):
 
     try:
         # Give each kernel its own identity so the assertion cannot pass by luck.
-        current_kernel.execute("MARKER = 'current-notebook-kernel'")
-        raw_kernel.execute("MARKER = 'raw-kernel'")
+        _seed(server_client, current_kernel, "current-notebook-kernel")
+        _seed(server_client, raw_kernel, "raw-kernel")
 
         notebook_manager = NotebookManager()
         notebook_manager.add_notebook(


### PR DESCRIPTION
Fixes #279

## Root cause

`server.py:799` resolves `kernel_id` only in JUPYTER_SERVER mode, but a user-supplied `kernel_id` is passed to the tool in either mode. `ExecuteCodeTool.execute` routes MCP_SERVER to `_execute_via_notebook_manager`, which had no `kernel_id` parameter, so the argument was dropped and the code always ran on the current notebook's kernel. The wrong kernel's output was then returned as success, with no error for the caller to notice. MCP_SERVER is the default mode, and the docs publish `kernel_id` without qualifying it by mode.

## Fix

`kernel_id` is threaded through to the notebook-manager path. When it names a kernel other than the current notebook's, the tool validates it against `server_client.kernels.list_kernels()` and connects with the same `KernelClient(server_url=..., token=..., kernel_id=...)` pattern `use_notebook_tool.py:215-226` already uses in this mode. An unknown id now returns the same "not found, check `list_kernels`" message `use_notebook` gives, instead of silently redirecting to whichever kernel is current. Omitting `kernel_id` is unchanged.

Such a kernel is borrowed, not owned, so it is released in a `finally` with an explicit `stop(shutdown_kernel=False)` and never shut down. The execution body moved into `_execute_on_kernel` unchanged so that both paths share it, which is why the diff is larger than the behaviour change.

## Invariant, and how it is discharged

The claim is that a borrowed kernel outlives the call. A passing test only shows that this path does not kill it, so I enumerated every writer of kernel liveness in the package by parsing rather than grepping, and adjudicated each:

| writer | reaches a borrowed kernel? |
| --- | --- |
| `local_backend.py:450` `shutdown_kernel()` | no, JUPYTER_SERVER mode only |
| `notebook_manager.py:143` `kernel.stop()` (shuts down if `_own_kernel`) | no, only kernels registered via `add_notebook`; this path never registers one |
| `execute_code_tool.py` (this diff) | yes, explicit `shutdown_kernel=False` |
| `utils.py:279` `kernel.stop()` | no, `create_kernel` failure cleanup for a kernel it just created |

`KernelClient._own_kernel` is `self._manager.kernel is None`, so connecting to an existing kernel already leaves it false. The explicit `shutdown_kernel=False` does not rely on that.

## Verification

Clean `python:3.11-slim` container, against the real `jupyter lab` fixture with two real kernels. Nothing is mocked: real `ExecuteCodeTool`, real `NotebookManager`, real `KernelClient`, real `wait_for_kernel_idle` and `safe_extract_outputs`.

`tests/test_execute_code_kernel_id.py` adds four tests, one per behaviour claimed above:

| test | on main | on this branch |
| --- | --- | --- |
| runs in the requested kernel | fail | pass |
| targeted kernel left running, state intact | fail | pass |
| unknown kernel_id reported, not redirected | fail | pass |
| no kernel_id still uses the current notebook | pass | pass |

The last one passes on both by design; it pins the default against regression.

```
python -m pytest tests/test_execute_code_kernel_id.py -q
```

Existing suites stay green in the same container: `test_tools.py`, `test_execute_cell_stream.py`, `test_execute_cell_output_fidelity.py` (51 passed), plus `test_hooks.py`, `test_otel_hooks.py`, `test_config.py`, `test_common.py`, `test_use_notebook_create_local.py`, `test_restart_notebook_tool.py`, `test_move_cell.py`, `test_edit_cell_source.py`, `test_prompts.py`, `test_use_notebook_ui_open.py` (145 passed, 1 skipped). `license-eye header check` passes on the new file, and the sdist and wheel build.

## What I did not verify

The tests target a raw kernel on the same local server the fixture starts. I did not run this against a remote `runtime_url` deployment, which is the setup the feature is aimed at, so the connection there is covered by the shared `KernelClient` path and not by an executed test.

`BEFORE_EXECUTE` and `AFTER_EXECUTE` hooks now fire with the targeted kernel's id rather than the current notebook's, which is what the hook payload claims to carry. `test_hooks.py` and `test_otel_hooks.py` pass, but neither exercises hooks with a targeted `kernel_id`, so that combination is untested.
