### PR TITLE
fix: support synchronous ContentsManager via ensure_async

### DIFF
--- a/jupyter_mcp_server/tools/jupyter_cite_prompt.py
+++ b/jupyter_mcp_server/tools/jupyter_cite_prompt.py
@@ -10,6 +10,7 @@ from jupyter_server_client import JupyterServerClient
 from jupyter_mcp_server.tools._base import BaseTool, ServerMode
 from jupyter_mcp_server.notebook_manager import NotebookManager
 from jupyter_mcp_server.models import Notebook
+from jupyter_core.utils import ensure_async
 
 
 class JupyterCitePrompt(BaseTool):
@@ -142,7 +143,7 @@ class JupyterCitePrompt(BaseTool):
             # Local mode: read notebook directly from file system
             notebook_path = notebook_manager.get_notebook_path(notebook_name)
             
-            model = await contents_manager.get(notebook_path, content=True, type='notebook')
+            model = await ensure_async(contents_manager.get(notebook_path, content=True, type='notebook'))
             if 'content' not in model:
                 raise ValueError(f"Could not read notebook content from {notebook_path}")
             notebook = Notebook(**model['content'])

--- a/jupyter_mcp_server/tools/list_files_tool.py
+++ b/jupyter_mcp_server/tools/list_files_tool.py
@@ -11,6 +11,7 @@ from jupyter_server_client import JupyterServerClient
 from jupyter_mcp_server.tools._base import BaseTool, ServerMode
 from jupyter_mcp_server.config import get_config
 from jupyter_mcp_server.utils import format_TSV
+from jupyter_core.utils import ensure_async
 
 
 def format_size(size_bytes: int) -> str:
@@ -106,7 +107,7 @@ async def _list_files_local(
     
     try:
         # Get directory contents
-        model = await contents_manager.get(path, content=True, type='directory')
+        model = await ensure_async(contents_manager.get(path, content=True, type='directory'))
         
         if 'content' not in model:
             return all_files

--- a/jupyter_mcp_server/tools/read_cell_tool.py
+++ b/jupyter_mcp_server/tools/read_cell_tool.py
@@ -11,6 +11,7 @@ from jupyter_mcp_server.notebook_manager import NotebookManager
 from jupyter_mcp_server.models import Notebook
 from jupyter_mcp_server.utils import get_current_notebook_context
 from mcp.types import ImageContent
+from jupyter_core.utils import ensure_async
 
 
 class ReadCellTool(BaseTool):
@@ -52,7 +53,7 @@ class ReadCellTool(BaseTool):
             if not notebook_path:
                 return ["No active notebook. Use the use_notebook tool to activate a notebook first."]
 
-            model = await contents_manager.get(notebook_path, content=True, type='notebook')
+            model = await ensure_async(contents_manager.get(notebook_path, content=True, type='notebook'))
             if 'content' not in model:
                 raise ValueError(f"Could not read notebook content from {notebook_path}")
             notebook = Notebook(**model['content'])

--- a/jupyter_mcp_server/tools/read_notebook_tool.py
+++ b/jupyter_mcp_server/tools/read_notebook_tool.py
@@ -9,6 +9,7 @@ from jupyter_server_client import JupyterServerClient
 from jupyter_mcp_server.tools._base import BaseTool, ServerMode
 from jupyter_mcp_server.notebook_manager import NotebookManager
 from jupyter_mcp_server.models import Notebook
+from jupyter_core.utils import ensure_async
 
 
 class ReadNotebookTool(BaseTool):
@@ -48,7 +49,7 @@ class ReadNotebookTool(BaseTool):
             # Local mode: read notebook directly from file system
             notebook_path = notebook_manager.get_notebook_path(notebook_name)
             
-            model = await contents_manager.get(notebook_path, content=True, type='notebook')
+            model = await ensure_async(contents_manager.get(notebook_path, content=True, type='notebook'))
             if 'content' not in model:
                 raise ValueError(f"Could not read notebook content from {notebook_path}")
             notebook = Notebook(**model['content'])

--- a/jupyter_mcp_server/tools/use_notebook_tool.py
+++ b/jupyter_mcp_server/tools/use_notebook_tool.py
@@ -12,6 +12,7 @@ from jupyter_kernel_client import KernelClient
 from jupyter_mcp_server.tools._base import BaseTool, ServerMode
 from jupyter_mcp_server.notebook_manager import NotebookManager
 from jupyter_mcp_server.models import Notebook
+from jupyter_core.utils import ensure_async
 
 logger = logging.getLogger(__name__)
 
@@ -98,7 +99,7 @@ class UseNotebookTool(BaseTool):
             parent_path = str(path.parent) if str(path.parent) != "." else ""
             
             # Get directory contents using local API
-            model = await contents_manager.get(parent_path, content=True, type='directory')
+            model = await ensure_async(contents_manager.get(parent_path, content=True, type='directory'))
             
             if mode == "connect":
                 file_exists = any(item['name'] == path.name for item in model.get('content', []))
@@ -206,7 +207,7 @@ class UseNotebookTool(BaseTool):
                 }
                 if mode == ServerMode.JUPYTER_SERVER and contents_manager is not None:
                     # Use local API to create notebook
-                    await contents_manager.new(model={'type': 'notebook', 'content': content, 'format': 'json'}, path=notebook_path)
+                    await ensure_async(contents_manager.new(model={'type': 'notebook', 'content': content, 'format': 'json'}, path=notebook_path))
                 elif mode == ServerMode.MCP_SERVER and server_client is not None:
                     server_client.contents.create_notebook(notebook_path, content=content)
 
@@ -282,7 +283,7 @@ class UseNotebookTool(BaseTool):
         try:
             if mode == ServerMode.JUPYTER_SERVER and contents_manager is not None:
                 # Read notebook to get cell count and first 20 cells
-                model = await contents_manager.get(notebook_path, content=True, type='notebook')
+                model = await ensure_async(contents_manager.get(notebook_path, content=True, type='notebook'))
                 if 'content' in model:
                     notebook = Notebook(**model['content'])
                 else:

--- a/tests/test_contents_manager_sync.py
+++ b/tests/test_contents_manager_sync.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python3
+# Copyright (c) 2024- Datalayer, Inc.
+#
+# BSD 3-Clause License
+
+"""Regression tests for synchronous ContentsManager support.
+
+jupyter-server supports both synchronous and asynchronous ContentsManager
+implementations. Several widely used managers are synchronous -- notably
+``jupytext.TextFileContentsManager``, which resolves to
+``SyncJupytextContentsManager`` -- and their methods return plain values rather
+than coroutines. Awaiting such a return value directly raises::
+
+    TypeError: object dict can't be used in 'await' expression
+
+The JUPYTER_SERVER-mode helpers must therefore wrap contents_manager calls in
+``ensure_async``, which awaits awaitables and passes plain values through.
+"""
+
+import pytest
+
+from jupyter_mcp_server.tools.list_files_tool import _list_files_local
+from jupyter_mcp_server.tools.use_notebook_tool import UseNotebookTool
+
+_ROOT_MODEL = {
+    "name": "",
+    "path": "",
+    "type": "directory",
+    "content": [
+        {
+            "name": "notebook.ipynb",
+            "path": "notebook.ipynb",
+            "type": "notebook",
+            "size": 1024,
+            "last_modified": "2026-01-01T00:00:00Z",
+        },
+        {
+            "name": "data",
+            "path": "data",
+            "type": "directory",
+            "last_modified": "2026-01-01T00:00:00Z",
+        },
+    ],
+}
+
+
+class SyncContentsManager:
+    """Minimal synchronous ContentsManager: ``get`` returns a dict, not a coroutine."""
+
+    def get(self, path, content=True, type=None, format=None):
+        if path in ("", "."):
+            return dict(_ROOT_MODEL)
+        raise FileNotFoundError(path)
+
+
+class AsyncContentsManager:
+    """Minimal asynchronous ContentsManager: ``get`` is a coroutine function."""
+
+    async def get(self, path, content=True, type=None, format=None):
+        return SyncContentsManager().get(path, content=content, type=type)
+
+
+MANAGERS = [
+    pytest.param(SyncContentsManager, id="sync"),
+    pytest.param(AsyncContentsManager, id="async"),
+]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("manager_cls", MANAGERS)
+async def test_list_files_local_supports_sync_and_async_managers(manager_cls):
+    """list_files must work regardless of the ContentsManager flavour."""
+    files = await _list_files_local(manager_cls(), path="", max_depth=0)
+    assert [f["path"] for f in files] == ["notebook.ipynb", "data"]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("manager_cls", MANAGERS)
+async def test_check_path_local_supports_sync_and_async_managers(manager_cls):
+    """use_notebook must find an existing notebook with either flavour."""
+    ok, error = await UseNotebookTool()._check_path_local(
+        manager_cls(), "notebook.ipynb", "connect"
+    )
+    assert ok, error


### PR DESCRIPTION
jupyter-server supports both synchronous and asynchronous ContentsManager implementations, but the JUPYTER_SERVER-mode helpers await contents_manager calls directly. With a synchronous manager those calls return plain values, so awaiting them raises:

    TypeError: object dict can't be used in 'await' expression

This is not hypothetical: jupytext.TextFileContentsManager resolves to SyncJupytextContentsManager, and setting

    c.ServerApp.contents_manager_class = 'jupytext.TextFileContentsManager'

is a common deployment. It breaks use_notebook, list_files, read_cells and read_notebook. list_files fails silently -- the except branch swallows the TypeError and returns an empty list, so the tool reports 'No files found' while the server's own /api/contents lists the directory fine.

Wrap the seven contents_manager calls in jupyter_core.utils.ensure_async, which awaits awaitables and passes plain values through. This is what jupyter-server's own handlers do and is a no-op for async managers.

Adds regression tests parametrized over a sync and an async manager.