### PR TITLE
fix: apply the execution timeout config to execute_code

### DIFF
--- a/jupyter_mcp_server/server.py
+++ b/jupyter_mcp_server/server.py
@@ -776,7 +776,7 @@ async def move_cell(
 @with_hooks("execute_code")
 async def execute_code(
     code: Annotated[str, Field(description="Code to execute (supports magic commands with %, shell commands with !)")],
-    timeout: Annotated[int, Field(description="Execution timeout in seconds",le=3600)] = 30,
+    timeout: Annotated[int, Field(description="Maximum seconds to wait for execution (0 = use config default)")] = 30,
     kernel_id: Annotated[str | None, Field(description="Target an existing kernel by ID (e.g. a raw kernel with no notebook). If omitted, uses the current notebook's kernel.")] = None,
 ) -> Annotated[list[str | ImageContent], Field(description="List of outputs from the executed code")]:
     """Execute code directly in a kernel (not saved to notebook).
@@ -796,6 +796,10 @@ async def execute_code(
     1. Import new modules or perform variable assignments that affect subsequent Notebook execution
     2. Execute dangerous code that may harm the Jupyter server or the user's data without permission
     """
+    config = get_config()
+    # Use config default if timeout is 0, otherwise clamp to max
+    effective_timeout = config.execution_timeout if timeout == 0 else min(timeout, config.max_execution_timeout)
+
     if kernel_id is None and server_context.mode == ServerMode.JUPYTER_SERVER:
         current_notebook = notebook_manager.get_current_notebook() or "default"
         kernel_id = notebook_manager.get_kernel_id(current_notebook)
@@ -807,7 +811,7 @@ async def execute_code(
             kernel_manager=server_context.kernel_manager,
             notebook_manager=notebook_manager,
             code=code,
-            timeout=timeout,
+            timeout=effective_timeout,
             kernel_id=kernel_id,
             ensure_kernel_alive_fn=__ensure_kernel_alive,
             wait_for_kernel_idle_fn=wait_for_kernel_idle,

--- a/tests/test_execute_code_timeout.py
+++ b/tests/test_execute_code_timeout.py
@@ -1,0 +1,75 @@
+# Copyright (c) 2024- Datalayer, Inc.
+#
+# BSD 3-Clause License
+
+"""Unit tests for execute_code's timeout resolution in server.py.
+
+execute_cell and insert_execute_code_cell resolve their ``timeout`` against the
+config before running: ``0`` means "use config default" (``execution_timeout``)
+and any positive value is clamped to ``max_execution_timeout``. execute_code is
+the third execution tool and did neither. These tests pin it to the same
+contract by capturing the timeout that reaches ExecuteCodeTool, so no kernel is
+required.
+"""
+
+import pytest
+
+from jupyter_mcp_server import server
+from jupyter_mcp_server.config import reset_config, set_config
+from jupyter_mcp_server.tools.execute_code_tool import ExecuteCodeTool
+
+
+@pytest.fixture
+def captured_timeout(monkeypatch):
+    """Record the timeout ExecuteCodeTool receives, so the value server.py
+    resolves is observable without a running kernel. A low ceiling and a
+    distinct default keep every assertion unambiguous."""
+    seen = {}
+
+    async def _fake_execute(self, *args, timeout, **kwargs):
+        seen["timeout"] = timeout
+        return ["ok"]
+
+    monkeypatch.setattr(ExecuteCodeTool, "execute", _fake_execute)
+    set_config(execution_timeout=45, max_execution_timeout=60)
+    try:
+        yield seen
+    finally:
+        reset_config()
+
+
+async def _run(**kwargs):
+    # kernel_id is supplied so timeout resolution, not kernel routing, is exercised.
+    return await server.execute_code(code="1 + 1", kernel_id="k1", **kwargs)
+
+
+@pytest.mark.asyncio
+async def test_positive_timeout_is_clamped_to_max(captured_timeout):
+    """A timeout above the operator's max_execution_timeout must be clamped down,
+    not passed through, so a lowered ceiling actually binds here."""
+    await _run(timeout=3600)
+    assert captured_timeout["timeout"] == 60
+
+
+@pytest.mark.asyncio
+async def test_zero_timeout_uses_config_default(captured_timeout):
+    """timeout=0 means 'use config default', as the other two execution tools
+    publish; it must not reach the kernel as 0 (asyncio.wait_for(timeout=0)
+    expires immediately)."""
+    await _run(timeout=0)
+    assert captured_timeout["timeout"] == 45
+
+
+@pytest.mark.asyncio
+async def test_in_range_timeout_is_passed_through(captured_timeout):
+    """A positive timeout under the ceiling is honoured unchanged."""
+    await _run(timeout=30)
+    assert captured_timeout["timeout"] == 30
+
+
+@pytest.mark.asyncio
+async def test_omitted_timeout_keeps_the_default(captured_timeout):
+    """Omitting timeout keeps the tool's documented default and clamps it like
+    any other value (the default sits under the ceiling, so it is unchanged)."""
+    await _run()
+    assert captured_timeout["timeout"] == 30


### PR DESCRIPTION
## Root cause

Three tools run code with a `timeout`: `execute_cell`, `insert_execute_code_cell`, and `execute_code`. The first two resolve the timeout against the config before running:

```python
config = get_config()
effective_timeout = config.execution_timeout if timeout == 0 else min(timeout, config.max_execution_timeout)
```

`execute_code` did neither. It forwarded its raw `timeout` straight to the tool (`server.py:810`), with a hardcoded `Field(le=3600)` as its only bound. Two consequences:

- **`max_execution_timeout` does not bind.** An operator who lowers the ceiling (`--max-execution-timeout 60`) still has it enforced on `execute_cell` and `insert_execute_code_cell`, but `execute_code` accepts and passes through any value up to 3600, so the ceiling is silently unenforced on one of the three.
- **`timeout=0` is not the config default here.** The other two tools document `0` as "use config default"; `execute_code` forwarded `0` verbatim to `asyncio.wait_for(timeout=0)` (`execute_code_tool.py:165`), which expires immediately.

The `le=3600` cap is a stale duplicate: it was raised to 3600 in #257, thirteen days before the config landed (#266), and was never reconciled with `max_execution_timeout` (whose own default is 3600).

## Fix

Resolve `effective_timeout` in `execute_code` with the same expression the other two tools use, and drop `le=3600` in favour of the config ceiling. Three lines, no new behaviour beyond aligning the contract:

- `timeout=0` now resolves to `config.execution_timeout` instead of expiring at once.
- a positive `timeout` is clamped to `config.max_execution_timeout`.
- a positive `timeout` under the ceiling is unchanged.

## The one thing I did not change: the default

`execute_code` still defaults to `timeout=30`, while its two siblings default to `timeout=0` (which now means `execution_timeout`, 120 by default). Aligning it would change the out-of-the-box `execute_code` timeout from 30s to 120s. That is a public-behaviour change and your call, so I left it. Happy to switch the default to `0` in this PR if you would rather the three tools match exactly.

Context: this follows the "Left out on purpose" note in #270 and the discussion on #264, where the scope of the default was flagged as yours to decide.

## Verification

Run in a clean `python:3.12-slim` container against this branch (`server.__file__` confirmed to be the installed source).

New `tests/test_execute_code_timeout.py` captures the timeout that reaches `ExecuteCodeTool`, so the resolution is observable without a kernel. With `execution_timeout=45`, `max_execution_timeout=60`:

- `timeout=3600` resolves to `60` (clamped). Fails on `main` (passes 3600 through).
- `timeout=0` resolves to `45`. Fails on `main` (passes 0 through).
- `timeout=30` resolves to `30`, and omitting `timeout` keeps `30`. Unchanged on `main`.

All four pass on the branch; the first two fail on `main`, so the test pins the fix.

What I did not do: this is verified at the resolution boundary, not driven end-to-end through a live kernel. The change only alters the timeout value handed to `ExecuteCodeTool`; the tool and its kernel routing are untouched and already covered by `test_execute_code_kernel_id.py`. That `asyncio.wait_for(timeout=0)` raises immediately is confirmed on stock asyncio this session, not observed through a kernel.
