### PR TITLE
fix: await LocalBackend contents_manager calls with ensure_async (#283)

### DIFF
--- a/jupyter_mcp_server/jupyter_extension/backends/local_backend.py
+++ b/jupyter_mcp_server/jupyter_extension/backends/local_backend.py
@@ -14,6 +14,7 @@ import asyncio
 from mcp.types import ImageContent
 from jupyter_mcp_server.jupyter_extension.backends.base import Backend
 from jupyter_mcp_server.utils import safe_extract_outputs
+from jupyter_core.utils import ensure_async
 
 if TYPE_CHECKING:
     from jupyter_server.serverapp import ServerApp
@@ -56,11 +57,8 @@ class LocalBackend(Backend):
         Returns:
             Notebook content dictionary
         """
-        model = await asyncio.to_thread(
-            self.contents_manager.get,
-            path,
-            type='notebook',
-            content=True
+        model = await ensure_async(
+            self.contents_manager.get(path, type='notebook', content=True)
         )
         return model['content']
     
@@ -81,12 +79,10 @@ class LocalBackend(Backend):
     async def _list_notebooks_recursive(self, path: str, notebooks: list[str]) -> None:
         """Helper to recursively list notebooks."""
         try:
-            model = await asyncio.to_thread(
-                self.contents_manager.get,
-                path,
-                content=True
+            model = await ensure_async(
+                self.contents_manager.get(path, content=True)
             )
-            
+
             if model['type'] == 'directory':
                 for item in model['content']:
                     item_path = f"{path}/{item['name']}" if path else item['name']
@@ -110,10 +106,8 @@ class LocalBackend(Backend):
             True if exists
         """
         try:
-            await asyncio.to_thread(
-                self.contents_manager.get,
-                path,
-                content=False
+            await ensure_async(
+                self.contents_manager.get(path, content=False)
             )
             return True
         except Exception:
@@ -129,9 +123,8 @@ class LocalBackend(Backend):
         Returns:
             Created notebook content
         """
-        model = await asyncio.to_thread(
-            self.contents_manager.new,
-            path=path
+        model = await ensure_async(
+            self.contents_manager.new(path=path)
         )
         return model['content']
     
@@ -202,13 +195,14 @@ class LocalBackend(Backend):
         content['cells'] = cells
         
         # Save updated notebook
-        await asyncio.to_thread(
-            self.contents_manager.save,
-            {
-                'type': 'notebook',
-                'content': content
-            },
-            path
+        await ensure_async(
+            self.contents_manager.save(
+                {
+                    'type': 'notebook',
+                    'content': content
+                },
+                path
+            )
         )
         
         return len(cells) - 1
@@ -253,13 +247,14 @@ class LocalBackend(Backend):
         content['cells'] = cells
         
         # Save updated notebook
-        await asyncio.to_thread(
-            self.contents_manager.save,
-            {
-                'type': 'notebook',
-                'content': content
-            },
-            path
+        await ensure_async(
+            self.contents_manager.save(
+                {
+                    'type': 'notebook',
+                    'content': content
+                },
+                path
+            )
         )
         
         return cell_index
@@ -279,13 +274,14 @@ class LocalBackend(Backend):
             cells.pop(cell_index)
             content['cells'] = cells
             
-            await asyncio.to_thread(
-                self.contents_manager.save,
-                {
-                    'type': 'notebook',
-                    'content': content
-                },
-                path
+            await ensure_async(
+                self.contents_manager.save(
+                    {
+                        'type': 'notebook',
+                        'content': content
+                    },
+                    path
+                )
             )
     
     async def overwrite_cell(
@@ -324,13 +320,14 @@ class LocalBackend(Backend):
         cell['source'] = new_source
         content['cells'] = cells
         
-        await asyncio.to_thread(
-            self.contents_manager.save,
-            {
-                'type': 'notebook',
-                'content': content
-            },
-            path
+        await ensure_async(
+            self.contents_manager.save(
+                {
+                    'type': 'notebook',
+                    'content': content
+                },
+                path
+            )
         )
         
         return (old_source, new_source_str)
@@ -425,10 +422,11 @@ class LocalBackend(Backend):
         content = await self.get_notebook_content(path)
         if cell_index < len(content['cells']):
             content['cells'][cell_index]['outputs'] = outputs
-            await asyncio.to_thread(
-                self.contents_manager.save,
-                {'type': 'notebook', 'content': content},
-                path
+            await ensure_async(
+                self.contents_manager.save(
+                    {'type': 'notebook', 'content': content},
+                    path
+                )
             )
         
         return safe_extract_outputs(outputs)

--- a/tests/test_local_backend_contents_manager.py
+++ b/tests/test_local_backend_contents_manager.py
@@ -1,0 +1,139 @@
+#!/usr/bin/env python3
+# Copyright (c) 2024- Datalayer, Inc.
+#
+# BSD 3-Clause License
+
+"""Regression tests for LocalBackend ContentsManager support.
+
+``LocalBackend`` (JUPYTER_SERVER mode) reaches the notebook file system through
+``serverapp.contents_manager``. jupyter-server ships both synchronous and
+asynchronous ContentsManager implementations, and the default
+(``AsyncLargeFileManager``) is asynchronous, so ``get``/``new``/``save`` are
+coroutine functions. The backend must therefore await the return value with
+``ensure_async``, which awaits awaitables and passes plain values through, so
+that both flavours work. This mirrors the tool-side fix in #281.
+"""
+
+import copy
+
+import pytest
+
+from jupyter_mcp_server.jupyter_extension.backends.local_backend import LocalBackend
+
+_CELLS = [{"cell_type": "code", "source": ["print(1)"], "metadata": {}, "outputs": []}]
+
+_NOTEBOOK_MODEL = {
+    "name": "notebook.ipynb",
+    "path": "notebook.ipynb",
+    "type": "notebook",
+    "content": {"cells": list(_CELLS), "metadata": {}, "nbformat": 4, "nbformat_minor": 5},
+}
+
+_ROOT_MODEL = {
+    "name": "",
+    "path": "",
+    "type": "directory",
+    "content": [
+        {"name": "notebook.ipynb", "path": "notebook.ipynb", "type": "notebook"},
+        {"name": "other.ipynb", "path": "other.ipynb", "type": "notebook"},
+    ],
+}
+
+
+class SyncContentsManager:
+    """Minimal synchronous ContentsManager: methods return plain values."""
+
+    def __init__(self):
+        self.saved = []
+
+    def get(self, path, content=True, type=None, format=None):
+        if type == "directory" or path in ("", "."):
+            return copy.deepcopy(_ROOT_MODEL)
+        if path not in ("notebook.ipynb", "other.ipynb"):
+            raise FileNotFoundError(path)
+        model = copy.deepcopy(_NOTEBOOK_MODEL)
+        if not content:
+            del model["content"]
+        return model
+
+    def new(self, model=None, path=""):
+        created = copy.deepcopy(_NOTEBOOK_MODEL)
+        created["path"] = path
+        return created
+
+    def save(self, model, path):
+        self.saved.append((path, model))
+        return copy.deepcopy(_NOTEBOOK_MODEL)
+
+
+class AsyncContentsManager(SyncContentsManager):
+    """Minimal asynchronous ContentsManager: methods are coroutine functions."""
+
+    async def get(self, path, content=True, type=None, format=None):
+        return SyncContentsManager.get(self, path, content=content, type=type)
+
+    async def new(self, model=None, path=""):
+        return SyncContentsManager.new(self, model=model, path=path)
+
+    async def save(self, model, path):
+        return SyncContentsManager.save(self, model, path)
+
+
+class _FakeServerApp:
+    def __init__(self, contents_manager):
+        self.contents_manager = contents_manager
+        self.kernel_manager = None
+        self.kernel_spec_manager = None
+
+
+MANAGERS = [
+    pytest.param(SyncContentsManager, id="sync"),
+    pytest.param(AsyncContentsManager, id="async"),
+]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("manager_cls", MANAGERS)
+async def test_get_notebook_content_supports_sync_and_async_managers(manager_cls):
+    """get_notebook_content must return the model content with either flavour."""
+    backend = LocalBackend(_FakeServerApp(manager_cls()))
+    content = await backend.get_notebook_content("notebook.ipynb")
+    assert content["cells"] == _CELLS
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("manager_cls", MANAGERS)
+async def test_list_notebooks_supports_sync_and_async_managers(manager_cls):
+    """list_notebooks must enumerate the directory with either flavour."""
+    backend = LocalBackend(_FakeServerApp(manager_cls()))
+    notebooks = await backend.list_notebooks()
+    assert notebooks == ["notebook.ipynb", "other.ipynb"]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("manager_cls", MANAGERS)
+async def test_notebook_exists_supports_sync_and_async_managers(manager_cls):
+    """notebook_exists must report both existence and absence with either flavour."""
+    backend = LocalBackend(_FakeServerApp(manager_cls()))
+    assert await backend.notebook_exists("notebook.ipynb") is True
+    assert await backend.notebook_exists("missing.ipynb") is False
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("manager_cls", MANAGERS)
+async def test_create_notebook_supports_sync_and_async_managers(manager_cls):
+    """create_notebook must return the created model content with either flavour."""
+    backend = LocalBackend(_FakeServerApp(manager_cls()))
+    content = await backend.create_notebook("new.ipynb")
+    assert content["cells"] == _CELLS
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("manager_cls", MANAGERS)
+async def test_append_cell_saves_with_sync_and_async_managers(manager_cls):
+    """append_cell exercises the get+save round trip with either flavour."""
+    cm = manager_cls()
+    backend = LocalBackend(_FakeServerApp(cm))
+    index = await backend.append_cell("notebook.ipynb", "code", "print(2)")
+    assert index == len(_CELLS)
+    assert cm.saved and cm.saved[-1][0] == "notebook.ipynb"


### PR DESCRIPTION
## Root cause

`LocalBackend` reaches the notebook file system through `serverapp.contents_manager`, wrapping every call in `asyncio.to_thread(self.contents_manager.<method>, ...)`. `asyncio.to_thread` runs the callable in a worker thread and returns its result. jupyter-server's default contents manager, `AsyncLargeFileManager`, defines `get`/`new`/`save` as coroutine functions, so the worker thread returns an un-awaited coroutine object rather than a model dict.

On a default (async) install the caller then mishandles that coroutine:

- `_list_notebooks_recursive` subscripts it (`model['type']`), the bare `except Exception` swallows the resulting `TypeError`, and `list_notebooks` silently returns `[]`.
- `get_notebook_content`, `create_notebook`, and the save paths raise `TypeError: 'coroutine' object is not subscriptable` or leave the coroutine un-awaited.
- `notebook_exists` reports every path as present, because the un-awaited coroutine is truthy and the lookup body never runs.

This is the `LocalBackend` mirror of the tool-side bug fixed in #281. #281 corrected `await contents_manager.get(...)` (right for async, broken for sync); this backend has the opposite shape, `to_thread(contents_manager.get, ...)` (right for sync, broken for the default async).

## Fix

Wrap the nine `contents_manager` calls (`get`/`new`/`save`, across the read, list, exists, create, append, insert, delete, overwrite, and execute-save paths) in `jupyter_core.utils.ensure_async`, which awaits awaitables and passes plain values through, so both flavours work. This is the same pattern #281 applied to the tool files. The one genuinely-synchronous `to_thread` call, `client.get_iopub_msg`, is left as is.

Invariant: every `contents_manager` call in `LocalBackend` is awaited correctly for both a synchronous and an asynchronous ContentsManager. I enumerated the call sites by parsing the module (nine `self.contents_manager.{get,new,save}` calls, no other `contents_manager` access); all nine are wrapped.

## Verification

Run in a clean `python:3.12-slim` container against current HEAD, `jupyter_server==2.20.0`, `jupyter_core==5.9.1`, with the default `contents_manager` resolving to `AsyncLargeFileManager`:

- Added `tests/test_local_backend_contents_manager.py`, parametrized over a synchronous and an asynchronous ContentsManager (same shape as `tests/test_contents_manager_sync.py`), covering `get_notebook_content`, `list_notebooks`, `notebook_exists` (present and absent), `create_notebook`, and the get+save round trip through `append_cell`.
- On `main` the five async cases fail: `get_notebook_content`/`create_notebook`/`append_cell` raise `TypeError`, `list_notebooks` returns `[]`, and `notebook_exists` reports a missing path as present. With the fix all ten pass.
- `tests/test_contents_manager_sync.py` (#281) still passes, so the tool-side path is unaffected.

Not verified: I did not run the manual MCP-client end-to-end flow from CONTRIBUTING. The save paths other than `append_cell` (`insert_cell`/`delete_cell`/`overwrite_cell`/`execute_cell`) use the identical wrapped call and are covered by inspection, not each exercised individually.

Fixes #283.
