### PR TITLE
fix: don't persist the [No output generated] sentinel as a cell output

### DIFF
--- a/jupyter_mcp_server/tools/execute_cell_tool.py
+++ b/jupyter_mcp_server/tools/execute_cell_tool.py
@@ -79,6 +79,12 @@ class ExecuteCellTool(BaseTool):
                         metadata={}
                     ))
                 elif isinstance(output, str):
+                    if output == '[No output generated]':
+                        # A display-only sentinel for the tool response (see
+                        # execute_via_execution_stack in utils.py): a cell that
+                        # produced nothing must persist no output, not a
+                        # fabricated execute_result.
+                        continue
                     if output.startswith('[ERROR:') or output.startswith('[TIMEOUT ERROR:') or output.startswith('[PROGRESS:'):
                         cell.outputs.append(nbformat.v4.new_output(
                             output_type='stream',

--- a/tests/test_execute_cell_output_fidelity.py
+++ b/tests/test_execute_cell_output_fidelity.py
@@ -168,3 +168,42 @@ async def test_falls_back_to_formatted_strings_without_raw_outputs(tmp_path):
     assert len(outputs) == 1
     assert outputs[0]["output_type"] == "stream"
     nbformat.validate(notebook)
+
+
+@pytest.mark.asyncio
+async def test_error_string_still_persisted_without_raw_outputs(tmp_path):
+    """An [ERROR: ...] fallback string keeps being written as a stream output."""
+    path = _write_notebook(tmp_path)
+    tool = ExecuteCellTool()
+
+    await tool._write_outputs_to_cell(path, 0, ["[ERROR: RuntimeError: boom]"])
+
+    notebook = _read_notebook(path)
+    outputs = notebook.cells[0].outputs
+    assert len(outputs) == 1
+    assert outputs[0]["output_type"] == "stream"
+    assert outputs[0]["text"] == "[ERROR: RuntimeError: boom]"
+    nbformat.validate(notebook)
+
+
+@pytest.mark.asyncio
+async def test_no_output_sentinel_is_not_persisted(tmp_path):
+    """A cell that produced nothing must persist no output.
+
+    In JUPYTER_SERVER file mode an output-less cell (``x = 1``, an import, a
+    def) makes execute_via_execution_stack return the ``[No output generated]``
+    sentinel with raw_outputs empty. That sentinel is meant only for the tool
+    response, so it must not be written back as a fabricated execute_result.
+    """
+    path = _write_notebook(tmp_path, source="x = 1")
+    tool = ExecuteCellTool()
+
+    await tool._write_outputs_to_cell(
+        path, 0, ["[No output generated]"], raw_outputs=[]
+    )
+
+    cell = _read_notebook(path).cells[0]
+    assert cell.outputs == []
+    # The cell was executed, so it still carries an execution count.
+    assert cell.execution_count == 1
+    nbformat.validate(_read_notebook(path))


### PR DESCRIPTION
Fixes #285.

### Root cause

In `JUPYTER_SERVER` file mode, an output-less cell (`x = 1`, an `import`, a `def`) makes `execute_via_execution_stack` return the display sentinel `["[No output generated]"]` while leaving `raw_outputs` empty (`utils.py:562`). `_write_outputs_to_cell` then takes the `raw_outputs`-empty fallback, and since the sentinel does not start with `[ERROR:`, `[TIMEOUT ERROR:`, or `[PROGRESS:`, it was written back as an `execute_result` with `data={'text/plain': '[No output generated]'}`. A cell that produced nothing was persisted with a phantom result output.

This is a residual of #278, which fixed the real-output fidelity path in this function and intentionally kept the string fallback for the error, timeout, and progress cases. Those cases are correct; only the empty-output sentinel should not reach `cell.outputs`.

### Fix

In the fallback branch, skip the `[No output generated]` sentinel so an output-less cell persists no output. The sentinel is still returned to the caller (the tool response is unchanged), and the cell still gets its execution count. The error, timeout, and progress strings are untouched.

### Verification

Reproduced on HEAD `a043d85` in a clean `python:3.12-slim` container (`pip install -e .`), driving `execute_via_execution_stack` with an ExecutionStack reporting no outputs, then persisting via `_write_outputs_to_cell`: the `.ipynb` gained an `execute_result` carrying `[No output generated]`. With the fix, `cell.outputs == []`.

Tests added to `tests/test_execute_cell_output_fidelity.py`, one per scenario named above:

- `test_no_output_sentinel_is_not_persisted`: the sentinel yields `cell.outputs == []`, execution count still set. Fails on `main`, passes here.
- `test_error_string_still_persisted_without_raw_outputs`: an `[ERROR: ...]` string is still written as a stream output.
- the existing `test_falls_back_to_formatted_strings_without_raw_outputs` covers the timeout string still being written.

Full `tests/test_execute_cell_output_fidelity.py` module passes (12 tests). Not driven end-to-end against a live kernel: the empty-cell to sentinel step (`utils.py:562`) is exercised with a stub ExecutionStack, and the persisted-output defect is exercised directly through `_write_outputs_to_cell`, which is where the sentinel was written.
