### PR TITLE
fix: keep a notebook's binding when ensure_kernel_alive regenerates a dead kernel

### DIFF
--- a/jupyter_mcp_server/notebook_manager.py
+++ b/jupyter_mcp_server/notebook_manager.py
@@ -279,7 +279,15 @@ class NotebookManager:
         if kernel is None or not hasattr(kernel, 'is_alive') or not kernel.is_alive():
             # Create new kernel
             new_kernel = kernel_factory()
-            self.add_notebook(name, new_kernel)
+            if name in self._notebooks:
+                # Swap only the kernel: a restart replaces the kernel, never the
+                # notebook the entry points at. Re-adding via add_notebook without
+                # the original server_url/token/path would reset notebook_info to
+                # the config defaults (see add_notebook) and silently rebind this
+                # notebook to the default document.
+                self._notebooks[name]["kernel"] = new_kernel
+            else:
+                self.add_notebook(name, new_kernel)
             return new_kernel
         return kernel
     

--- a/tests/test_notebook_manager_ensure_kernel_alive.py
+++ b/tests/test_notebook_manager_ensure_kernel_alive.py
@@ -1,0 +1,90 @@
+# Copyright (c) 2024- Datalayer, Inc.
+#
+# BSD 3-Clause License
+
+"""Unit tests for NotebookManager.ensure_kernel_alive kernel regeneration.
+
+These tests use an in-memory NotebookManager with minimal KernelClient
+stand-ins, so no running Jupyter server is required.
+"""
+
+from jupyter_mcp_server.notebook_manager import NotebookManager
+
+# A non-default binding, as use_notebook records in MCP_SERVER mode. Held in
+# constants (not call-site literals) so the "token" argument reads as data.
+RUNTIME_URL = "https://runtime.example/"
+RUNTIME_AUTH = "runtime-token"
+NB_PATH = "work/analysis.ipynb"
+
+
+class FakeKernel:
+    """Minimal KernelClient stand-in exposing only the liveness surface that
+    ensure_kernel_alive checks (`is_alive`), plus an id for identity asserts."""
+
+    def __init__(self, kernel_id, alive=True):
+        self.id = kernel_id
+        self._alive = alive
+
+    def is_alive(self):
+        return self._alive
+
+
+def _manager_with_bound_notebook():
+    """A notebook bound to an explicit (non-default) server_url/token/path,
+    as use_notebook does in MCP_SERVER mode, with a dead kernel."""
+    nm = NotebookManager()
+    nm.add_notebook(
+        "nb",
+        FakeKernel("dead-kernel", alive=False),
+        server_url=RUNTIME_URL,
+        token=RUNTIME_AUTH,
+        path=NB_PATH,
+    )
+    return nm
+
+
+def test_ensure_kernel_alive_preserves_binding_on_restart():
+    """Regenerating a dead kernel must keep the notebook's server_url/token/path
+    binding, and swap in the fresh kernel."""
+    nm = _manager_with_bound_notebook()
+
+    new_kernel = nm.ensure_kernel_alive("nb", lambda: FakeKernel("fresh-kernel"))
+
+    # The fresh kernel is installed and returned.
+    assert new_kernel.id == "fresh-kernel"
+    assert nm.get_kernel_id("nb") == "fresh-kernel"
+
+    # The binding survives the restart (this is what regressed): it must NOT
+    # fall back to the config defaults.
+    info = nm.get_notebook_connection("nb").notebook_info
+    assert info["server_url"] == RUNTIME_URL
+    assert info["token"] == RUNTIME_AUTH
+    assert info["path"] == NB_PATH
+    assert nm.get_notebook_path("nb") == NB_PATH
+
+
+def test_ensure_kernel_alive_keeps_live_kernel():
+    """A live kernel is returned unchanged, and the binding is untouched."""
+    nm = NotebookManager()
+    live = FakeKernel("live-kernel", alive=True)
+    nm.add_notebook(
+        "nb", live,
+        server_url=RUNTIME_URL, token=RUNTIME_AUTH, path=NB_PATH,
+    )
+
+    result = nm.ensure_kernel_alive("nb", lambda: FakeKernel("should-not-be-used"))
+
+    assert result is live
+    assert nm.get_notebook_path("nb") == NB_PATH
+
+
+def test_ensure_kernel_alive_adds_notebook_when_absent():
+    """When the notebook is not yet tracked, a kernel is provisioned via the
+    normal add_notebook path (fallback branch)."""
+    nm = NotebookManager()
+
+    new_kernel = nm.ensure_kernel_alive("fresh", lambda: FakeKernel("k1"))
+
+    assert new_kernel.id == "k1"
+    assert "fresh" in nm
+    assert nm.get_kernel_id("fresh") == "k1"


### PR DESCRIPTION
## Root cause

In MCP_SERVER mode, `use_notebook` records a notebook's binding through `add_notebook(name, kernel, server_url=runtime_url, token=runtime_token, path=notebook_path)`, which stores `notebook_info = {server_url, token, path}`.

When that kernel later dies, `ensure_kernel_alive` regenerated it with a bare `self.add_notebook(name, new_kernel)` (notebook_manager.py:282). `add_notebook` rebuilds the whole entry, and with no `server_url`/`token`/`path` it falls back to the config defaults (`config.document_url`, `config.document_token`, `config.document_id`). The original binding is overwritten, so the next `get_current_connection()` builds a `NotebookConnection` against the default document. Reads, edits and executes then run on the wrong notebook with no error.

The sibling reprovision path in `restart_notebook_tool.py:31-38` already re-passes `path=notebook_path` for exactly this reason; `ensure_kernel_alive` did not.

## Invariant

Regenerating a dead kernel replaces only the kernel. It must never change which server/document the notebook entry points at.

`notebook_info` has a single writer in the package: `add_notebook` (notebook_manager.py:109). Every caller either establishes a fresh binding (`use_notebook_tool.py:261/269`), re-passes `path` on reprovision (`restart_notebook_tool.py:33`), or operates on the `default`/local notebook (`enroll.py`, `extension.py`, `execute_*_tool.py`, `utils.py`). The only site that rebound an already-bound, non-default notebook to the defaults was `ensure_kernel_alive`. This is the fix.

## Fix

When the notebook is already tracked, swap only the kernel field in place; otherwise fall back to `add_notebook`:

```python
if name in self._notebooks:
    self._notebooks[name]["kernel"] = new_kernel
else:
    self.add_notebook(name, new_kernel)
```

## Verification

Ran in a clean `python:3.12-slim` Docker container at HEAD e56e7d1 (`pip install -e .`, `__file__` confirmed as the repo tree):

- New `tests/test_notebook_manager_ensure_kernel_alive.py` (pure in-memory `NotebookManager`, no server): the binding-preservation test **fails on unmodified HEAD** (`server_url` comes back as the `http://localhost:8888` default) and **passes with the fix**. Three tests total (binding preserved on restart; live kernel returned untouched; absent-notebook fallback still uses `add_notebook`).
- `tests/test_restart_notebook_tool.py` still passes (the sibling path).
- `ruff check` and `mypy` on the changed lines are clean.

Not verified: I did not reproduce the downstream wrong-document read/edit end-to-end against a live remote RTC server; the trace from `get_current_connection` to a misdirected operation is read from code. The state corruption itself (`notebook_info` reset to defaults) is what the test asserts directly.


Fixes #287
