### PR TITLE
fix(delete_cell): reject negative and out-of-range cell indices

### DIFF
--- a/jupyter_mcp_server/tools/delete_cell_tool.py
+++ b/jupyter_mcp_server/tools/delete_cell_tool.py
@@ -24,6 +24,26 @@ class DeleteCellTool(BaseTool):
         else:
             return str(cell_source)
 
+    def _validate_indices(self, cell_indices: list[int], total_cells: int) -> None:
+        """Validate that every index is a valid 0-based cell position.
+
+        Args:
+            cell_indices: Indices of cells to delete (0-based)
+            total_cells: Total number of cells in the notebook
+
+        Raises:
+            ValueError: When any index is negative or >= total_cells. Checking
+                each index (rather than only ``max(cell_indices)``) rejects
+                out-of-range negatives, which would otherwise raise a raw
+                IndexError or silently delete the wrong cell.
+        """
+        for cell_index in cell_indices:
+            if cell_index < 0 or cell_index >= total_cells:
+                raise ValueError(
+                    f"Cell index {cell_index} is out of range. "
+                    f"Notebook has {total_cells} cells."
+                )
+
     async def _delete_cell_ydoc(
         self,
         serverapp: Any,
@@ -42,11 +62,8 @@ class DeleteCellTool(BaseTool):
         """
         nb = await get_notebook_model(serverapp, notebook_path)
         if nb:
-            if max(cell_indices) >= len(nb):
-                raise ValueError(
-                    f"Cell index {max(cell_indices)} is out of range. Notebook has {len(nb)} cells."
-                )
-            
+            self._validate_indices(cell_indices, len(nb))
+
             cells = nb.delete_many_cells(cell_indices)
             return cells
         else:
@@ -72,12 +89,9 @@ class DeleteCellTool(BaseTool):
             notebook = nbformat.read(f, as_version=4)
         
         clean_notebook_outputs(notebook)
-        
-        if max(cell_indices) >= len(notebook.cells):
-            raise ValueError(
-                f"Cell index {max(cell_indices)} is out of range. Notebook has {len(notebook.cells)} cells."
-            )
-        
+
+        self._validate_indices(cell_indices, len(notebook.cells))
+
         deleted_cells = []
         for cell_index in cell_indices:
             cell = notebook.cells[cell_index]
@@ -113,10 +127,7 @@ class DeleteCellTool(BaseTool):
             List of deleted cell information
         """
         async with notebook_manager.get_current_connection() as notebook:
-            if max(cell_indices) >= len(notebook):
-                raise ValueError(
-                    f"Cell index {max(cell_indices)} is out of range. Notebook has {len(notebook)} cells."
-                )
+            self._validate_indices(cell_indices, len(notebook))
 
             cells = notebook.delete_many_cells(cell_indices)
             return cells

--- a/tests/test_delete_cell.py
+++ b/tests/test_delete_cell.py
@@ -1,0 +1,135 @@
+# Copyright (c) 2024- Datalayer, Inc.
+#
+# BSD 3-Clause License
+
+"""
+Tests for the delete_cell MCP tool.
+
+This module contains:
+- Section A: Unit tests for the pure Python validation logic
+  (no server needed, imports directly from the tool module)
+- Section B: File-based tests exercising _delete_cell_file end-to-end on a
+  real notebook file written to a tmp_path (no server needed)
+
+Launch the tests:
+```
+$ pytest tests/test_delete_cell.py -v
+```
+"""
+
+import nbformat
+import pytest
+
+from jupyter_mcp_server.tools.delete_cell_tool import DeleteCellTool
+
+
+def _write_notebook(path, n_cells):
+    """Write an *n_cells*-cell notebook to *path* and return the source list."""
+    nb = nbformat.v4.new_notebook()
+    sources = [f"cell {i}" for i in range(n_cells)]
+    for src in sources:
+        nb.cells.append(nbformat.v4.new_code_cell(source=src))
+    with open(path, "w", encoding="utf-8") as f:
+        nbformat.write(nb, f)
+    return sources
+
+
+def _read_sources(path):
+    with open(path, "r", encoding="utf-8") as f:
+        nb = nbformat.read(f, as_version=4)
+    return [c.source for c in nb.cells]
+
+
+###############################################################################
+# Section A — Unit tests for _validate_indices (no server needed)
+###############################################################################
+
+
+class TestDeleteCellValidation:
+    """Tests for _validate_indices(): input validation before deleting cells."""
+
+    def setup_method(self):
+        self.tool = DeleteCellTool()
+
+    @pytest.mark.parametrize("indices, total", [
+        ([-1], 5),        # in-range negative — 0-based tool must not accept it
+        ([-100], 5),      # out-of-range negative
+        ([0, -1], 5),     # mixed: max()==0 slips past an upper-bound-only check
+        ([5], 5),         # index == total_cells
+        ([999], 5),       # far out of range
+        ([0, 5], 5),      # one valid, one out of range
+    ])
+    def test_invalid_indices_raise_error(self, indices, total):
+        """Out-of-range indices (negative or too large) must be rejected."""
+        with pytest.raises((ValueError, IndexError)):
+            self.tool._validate_indices(indices, total)
+
+    @pytest.mark.parametrize("indices, total", [
+        ([0], 5),
+        ([4], 5),
+        ([0, 2, 4], 5),
+        ([0], 1),
+    ])
+    def test_valid_indices_pass(self, indices, total):
+        """In-range 0-based indices should not raise."""
+        self.tool._validate_indices(indices, total)
+
+
+###############################################################################
+# Section B — File-based behaviour (no server needed)
+###############################################################################
+
+
+class TestDeleteCellFileNegativeIndices:
+    """_delete_cell_file must reject negative indices instead of raising a raw
+    IndexError or silently deleting the wrong cell."""
+
+    def setup_method(self):
+        self.tool = DeleteCellTool()
+
+    @pytest.mark.asyncio
+    async def test_out_of_range_negative_raises_clean_error(self, tmp_path):
+        """A far-negative index must yield the clean 'out of range' ValueError,
+        not a raw IndexError leaking out of the tool."""
+        path = str(tmp_path / "nb.ipynb")
+        original = _write_notebook(path, 5)
+
+        with pytest.raises(ValueError, match="out of range"):
+            await self.tool._delete_cell_file(path, [-100])
+
+        assert _read_sources(path) == original  # notebook untouched
+
+    @pytest.mark.asyncio
+    async def test_in_range_negative_does_not_delete_wrong_cell(self, tmp_path):
+        """delete_cell is documented as 0-based; -1 must be rejected rather than
+        silently deleting the last cell."""
+        path = str(tmp_path / "nb.ipynb")
+        original = _write_notebook(path, 5)
+
+        with pytest.raises(ValueError, match="out of range"):
+            await self.tool._delete_cell_file(path, [-1])
+
+        assert _read_sources(path) == original  # last cell NOT deleted
+
+    @pytest.mark.asyncio
+    async def test_mixed_positive_and_negative_rejected(self, tmp_path):
+        """[0, -1] must be rejected as a whole; max()==0 previously slipped past
+        the upper-bound-only check and deleted cell 0 and the last cell."""
+        path = str(tmp_path / "nb.ipynb")
+        original = _write_notebook(path, 5)
+
+        with pytest.raises(ValueError, match="out of range"):
+            await self.tool._delete_cell_file(path, [0, -1])
+
+        assert _read_sources(path) == original
+
+    @pytest.mark.asyncio
+    async def test_valid_delete_still_works(self, tmp_path):
+        """Regression guard: a valid 0-based delete keeps working."""
+        path = str(tmp_path / "nb.ipynb")
+        _write_notebook(path, 5)
+
+        deleted = await self.tool._delete_cell_file(path, [1, 3])
+
+        assert {d["index"] for d in deleted} == {1, 3}
+        assert _read_sources(path) == ["cell 0", "cell 2", "cell 4"]


### PR DESCRIPTION
Fixes #293.

### Problem

`delete_cell` validated indices with `max(cell_indices) >= len(...)`, which checks the upper bound only. Because it is also the one cell-index tool whose schema lacks `ge=0`, negative indices reach the tool and either raise a raw `IndexError` (out of range) or silently delete the wrong cell (in range, for example `-1` deletes the last cell). `[0, -1]` slips past entirely since `max()==0`.

### Fix

Added `DeleteCellTool._validate_indices()`, mirroring `MoveCellTool._validate_move()`, which rejects any index `< 0` or `>= total_cells` with the existing `Cell index N is out of range. Notebook has M cells.` message, and replaced the `max(...) >= len` check in all three modes (YDoc, file, WebSocket). This keeps `delete_cell` consistent with the rest of the cell-index tools (all of which already reject negatives) and introduces no new behavior.

### Tests

New `tests/test_delete_cell.py`, following the `test_move_cell.py` structure:

- Section A: unit tests for `_validate_indices` (rejects negatives, out-of-range, and mixed lists; accepts valid 0-based indices).
- Section B: file-based tests confirming an out-of-range negative now raises the clean `ValueError` instead of `IndexError`, that `-1` no longer silently deletes the last cell, that `[0, -1]` is rejected as a whole, and that valid deletes still work.

These tests fail on `main` and pass with this change. The full suite is green in both modes:

```
TEST_MCP_SERVER=true TEST_JUPYTER_SERVER=true pytest
261 passed
```

### Scope

One source file (`delete_cell_tool.py`) plus one new test file. No dependency, schema, or unrelated changes.
