### PR TITLE
fix(deps): require jupyter-collaboration so JUPYTER_SERVER cell tools work on a plain install

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,7 @@ dependencies = [
     "jupyter-server-nbmodel>=0.1.1a4",
     "jupyter-server-client>=0.1.1",
     "jupyter_server>=1.6,<3",
+    "jupyter-collaboration",
     "tornado>=6.1",
     "traitlets>=5.0",
     "mcp[cli]>=1.10.1",
@@ -40,13 +41,12 @@ dependencies = [
 
 [project.optional-dependencies]
 test = [
-    "ipykernel", 
-    "jupyter_server>=1.6,<3", 
-    "pytest>=7.0", 
+    "ipykernel",
+    "jupyter_server>=1.6,<3",
+    "pytest>=7.0",
     "pytest-asyncio",
     "pytest-timeout>=2.1.0",
     "jupyterlab",
-    "jupyter-collaboration",
     "pillow>=10.0.0"
 ]
 lint = ["mdformat>0.7", "mdformat-gfm>=0.3.5", "ruff"]

--- a/tests/test_cli_typer_config.py
+++ b/tests/test_cli_typer_config.py
@@ -320,3 +320,23 @@ def test_execution_timeout_config():
 
     reset_config()
     assert get_config().execution_timeout == 120
+
+
+def test_jupyter_collaboration_is_a_required_dependency():
+    """jupyter-collaboration must be a hard dependency, not test-only.
+
+    Without it, JUPYTER_SERVER mode has no file_id_manager, so insert_cell,
+    overwrite_cell_source, execute_cell and insert_execute_code_cell all fail
+    with "file_id_manager not available in serverapp" on a plain install
+    (see #259).
+    """
+    import importlib.metadata as metadata
+    from packaging.requirements import Requirement
+
+    requires = metadata.requires("jupyter_mcp_server") or []
+    matching = [Requirement(r) for r in requires if Requirement(r).name == "jupyter-collaboration"]
+
+    assert matching, "jupyter-collaboration is missing from the distribution's requirements"
+    assert all(
+        r.marker is None or not r.marker.evaluate({"extra": "test"}) for r in matching
+    ), "jupyter-collaboration must not be gated behind the 'test' extra"


### PR DESCRIPTION
Fixes #259

## Root cause

`jupyter-collaboration` was listed only under the `test` optional-dependency
extra, never in `[project.dependencies]` (it landed there in #50, test-only
from the start). In JUPYTER_SERVER mode, `insert_cell`, `overwrite_cell_source`,
`execute_cell` and `insert_execute_code_cell` all call `get_notebook_model()`
(`jupyter_mcp_server/utils.py`), which reads `file_id_manager` from
`serverapp.web_app.settings` and raises `RuntimeError("file_id_manager not
available in serverapp")` if it is missing. `file_id_manager` is registered
by `jupyter-server-fileid`, which is only pulled in transitively through
`jupyter-collaboration`. A plain `pip install jupyter-mcp-server` never
installs it, so those four tools fail on a fresh install; only `execute_code`
avoids this code path, matching the report.

## Fix

Move `jupyter-collaboration` from the `test` extra into `[project.dependencies]`.

## Verification

In a clean `python:3.13-slim` Docker container, this session, against current
`main` (`9c1edf9`), running as a non-root user (JupyterLab refuses to start as
root):

- Installed only the package's main dependencies (no test extra) plus
  `jupyterlab`/`ipykernel` to run the extension, and ran the repo's own
  `tests/test_tools.py::test_cell_manipulation[jupyter_extension]`: it fails
  with `Internal error calling tool: Error executing tool insert_cell:
  file_id_manager not available in serverapp`, the exact error from #259.
- Installed `jupyter-collaboration` into the same venv, no other change, and
  reran the same test: it passes.
- Added `test_jupyter_collaboration_is_a_required_dependency`
  (`tests/test_cli_typer_config.py`), which inspects the installed
  distribution's metadata via `importlib.metadata.requires`. It fails on
  unpatched main (`jupyter-collaboration` is gated behind `extra == "test"`)
  and passes on this branch.
- On the branch, a bare `pip install -e .` (no test extra) pulls in
  `jupyter-collaboration` automatically and `test_cell_manipulation` passes
  under both transport modes.
- Full suite via the repo's own `make test-mcp-server` and
  `make test-jupyter-server`: 215 passed / 7 skipped and 210 passed / 12
  skipped, 0 failures (skips are the other transport mode, gated by
  `TEST_MCP_SERVER`/`TEST_JUPYTER_SERVER`).
- `mypy .`: 297 pre-existing errors, identical count on main and on this
  branch, none attributable to this change.
- `ruff check .`: 2552 on main vs 2555 on branch. The 3 new hits are all in
  the new test function (2x `S101` for its `assert` statements, 1x `I001` for
  its local import block), matching this file's and this repo's own existing
  style (in-function imports and bare `assert` are already used throughout
  `tests/test_cli_typer_config.py` and the wider suite).
- `validate-pyproject` accepts the changed `pyproject.toml`.

Not verified: the bare-install smoke test in `.github/workflows/test.yml`
across its macOS/Windows/Python 3.13 matrix (this session only ran Linux on
Python 3.13), so I cannot confirm `jupyter-collaboration`'s compiled
dependency (`pycrdt`) has prebuilt wheels for every combination in that
matrix.
