### PR TITLE
feat(tools): add clear_cell_output tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,7 @@ For more details on each tool, their parameters, and return values, please refer
 | `insert_cell`              | Insert a new code or markdown cell at a specified position.                      |
 | `delete_cell`              | Delete a cell at a specified index.                                              |
 | `move_cell`                | Move a cell from one position to another within a notebook.                      |
+| `clear_cell_output`        | Clear the outputs and execution count of a single code cell.                     |
 | `overwrite_cell_source`    | Overwrite the source code of an existing cell.                                   |
 | `edit_cell_source`         | Apply surgical find-and-replace edits to a cell's source without full rewrite.   |
 | `execute_cell`             | Execute a cell with timeout, supports multimodal output including images.        |

--- a/docs/docs/reference/tools/index.mdx
+++ b/docs/docs/reference/tools/index.mdx
@@ -1,6 +1,6 @@
 # Tools
 
-The server currently offers 15 tools organized into 3 categories:
+The server currently offers 16 tools organized into 3 categories:
 
 ## Server Management (3 tools)
 
@@ -105,7 +105,7 @@ When `use_notebook` starts a new kernel for a notebook, the kernel is started wi
   - `limit`(int, optional): Maximum number of items to return (0 means no limit, default: 20)
 - Returns: Notebook content in the requested format with cell details, metadata, and pagination information
 
-## Cell Tools (7 tools)
+## Cell Tools (8 tools)
 
 #### 9. `insert_cell`
 
@@ -183,3 +183,10 @@ When `use_notebook` starts a new kernel for a notebook, the kernel is started wi
 :::tip
 `execute_code` can now target a specific existing kernel (including raw kernels not attached to a notebook) by passing `kernel_id`.
 :::
+
+#### 16. `clear_cell_output`
+
+- Clear the outputs and execution count of a single code cell in the currently activated notebook, without deleting the cell itself.
+- Input:
+  - `cell_index`(int): Index of the code cell to clear (0-based)
+- Returns: Success message with the number of outputs removed

--- a/jupyter_mcp_server/server.py
+++ b/jupyter_mcp_server/server.py
@@ -52,6 +52,7 @@ from jupyter_mcp_server.tools import (
     EditCellSourceTool,
     DeleteCellTool,
     MoveCellTool,
+    ClearCellOutputTool,
     # Cell Execution
     ExecuteCellTool,
     # Other Tools
@@ -731,6 +732,30 @@ async def delete_cell(
             notebook_manager=notebook_manager,
             cell_indices=cell_indices,
             include_source=include_source,
+        )
+    )
+
+
+@mcp.tool(
+    annotations=ToolAnnotations(
+        title="Clear Cell Output",
+        destructiveHint=True,
+    ),
+)
+@with_hooks("clear_cell_output")
+async def clear_cell_output(
+    cell_index: Annotated[int, Field(description="Index of the code cell to clear (0-based)", ge=0)],
+) -> Annotated[str, Field(description="Success message with the number of outputs removed")]:
+    """Clear the outputs and execution count of a single code cell in the currently
+    activated notebook, without deleting the cell itself."""
+    return await safe_notebook_operation(
+        lambda: ClearCellOutputTool().execute(
+            mode=server_context.mode,
+            server_client=server_context.server_client,
+            contents_manager=server_context.contents_manager,
+            kernel_manager=server_context.kernel_manager,
+            notebook_manager=notebook_manager,
+            cell_index=cell_index,
         )
     )
 

--- a/jupyter_mcp_server/tools/__init__.py
+++ b/jupyter_mcp_server/tools/__init__.py
@@ -26,6 +26,7 @@ from jupyter_mcp_server.tools.overwrite_cell_source_tool import OverwriteCellSou
 from jupyter_mcp_server.tools.edit_cell_source_tool import EditCellSourceTool
 from jupyter_mcp_server.tools.delete_cell_tool import DeleteCellTool
 from jupyter_mcp_server.tools.move_cell_tool import MoveCellTool
+from jupyter_mcp_server.tools.clear_cell_output_tool import ClearCellOutputTool
 
 # Import tool implementations - Cell Execution
 from jupyter_mcp_server.tools.execute_cell_tool import ExecuteCellTool
@@ -56,6 +57,7 @@ __all__ = [
     "EditCellSourceTool",
     "DeleteCellTool",
     "MoveCellTool",
+    "ClearCellOutputTool",
     # Cell Execution
     "ExecuteCellTool",
     # Other Tools

--- a/jupyter_mcp_server/tools/clear_cell_output_tool.py
+++ b/jupyter_mcp_server/tools/clear_cell_output_tool.py
@@ -1,0 +1,199 @@
+# Copyright (c) 2024- Datalayer, Inc.
+#
+# BSD 3-Clause License
+
+"""Clear cell output tool implementation."""
+
+from pathlib import Path
+from typing import Any, Optional
+import nbformat
+from jupyter_server_client import JupyterServerClient
+from jupyter_mcp_server.tools._base import BaseTool, ServerMode
+from jupyter_mcp_server.notebook_manager import NotebookManager
+from jupyter_mcp_server.utils import get_current_notebook_context, get_notebook_model, clean_notebook_outputs
+
+
+class ClearCellOutputTool(BaseTool):
+    """Tool to clear the outputs and execution count of a single code cell."""
+
+    def _clear_notebook_model_cell(self, nb: Any, cell_index: int) -> int:
+        """Clear outputs/execution_count on a NotebookModel-backed cell.
+
+        Used for both the local YDoc (JUPYTER_SERVER) and remote WebSocket
+        (MCP_SERVER) modes: NbModelClient subclasses NotebookModel and shares
+        this same sequence protocol. NotebookModel exposes no dedicated
+        clear-output method, so this reads the cell via __getitem__, mutates
+        the two fields, and writes it back via __setitem__, which performs
+        the update inside NotebookModel's own lock and YDoc transaction.
+
+        Returns:
+            Number of outputs that were cleared.
+        """
+        if cell_index < 0 or cell_index >= len(nb):
+            raise ValueError(
+                f"Cell index {cell_index} is out of range. Notebook has {len(nb)} cells."
+            )
+
+        cell = nb[cell_index]
+        if cell.get("cell_type") != "code":
+            raise ValueError(f"Cell {cell_index} is not a code cell, cannot clear output.")
+
+        cleared_count = len(cell.get("outputs") or [])
+        cell["outputs"] = []
+        cell["execution_count"] = None
+        nb[cell_index] = cell
+        return cleared_count
+
+    async def _clear_cell_output_ydoc(
+        self,
+        serverapp: Any,
+        notebook_path: str,
+        cell_index: int
+    ) -> int:
+        """Clear cell output using YDoc (collaborative editing mode).
+
+        Args:
+            serverapp: Jupyter ServerApp instance
+            notebook_path: Path to the notebook
+            cell_index: Index of the cell to clear (0-based)
+
+        Returns:
+            Number of outputs that were cleared.
+        """
+        nb = await get_notebook_model(serverapp, notebook_path)
+        if nb:
+            return self._clear_notebook_model_cell(nb, cell_index)
+        else:
+            # YDoc not available, use file operations
+            return await self._clear_cell_output_file(notebook_path, cell_index)
+
+    async def _clear_cell_output_file(
+        self,
+        notebook_path: str,
+        cell_index: int
+    ) -> int:
+        """Clear cell output using file operations (non-collaborative mode).
+
+        Args:
+            notebook_path: Absolute path to the notebook
+            cell_index: Index of the cell to clear (0-based)
+
+        Returns:
+            Number of outputs that were cleared.
+
+        Raises:
+            ValueError: When cell_index is out of range or the cell is not code.
+        """
+        with open(notebook_path, "r", encoding="utf-8") as f:
+            notebook = nbformat.read(f, as_version=4)
+        clean_notebook_outputs(notebook)
+
+        if cell_index < 0 or cell_index >= len(notebook.cells):
+            raise ValueError(
+                f"Cell index {cell_index} is out of range. Notebook has {len(notebook.cells)} cells."
+            )
+
+        cell = notebook.cells[cell_index]
+        if cell.cell_type != "code":
+            raise ValueError(f"Cell {cell_index} is not a code cell, cannot clear output.")
+
+        cleared_count = len(cell.outputs)
+        cell.outputs = []
+        cell.execution_count = None
+
+        with open(notebook_path, "w", encoding="utf-8") as f:
+            nbformat.write(notebook, f)
+
+        return cleared_count
+
+    async def _clear_cell_output_websocket(
+        self,
+        notebook_manager: NotebookManager,
+        cell_index: int
+    ) -> int:
+        """Clear cell output using WebSocket connection (MCP_SERVER mode).
+
+        Args:
+            notebook_manager: Notebook manager instance
+            cell_index: Index of the cell to clear (0-based)
+
+        Returns:
+            Number of outputs that were cleared.
+        """
+        async with notebook_manager.get_current_connection() as notebook:
+            return self._clear_notebook_model_cell(notebook, cell_index)
+
+    async def execute(
+        self,
+        mode: ServerMode,
+        server_client: Optional[JupyterServerClient] = None,
+        kernel_client: Optional[Any] = None,
+        contents_manager: Optional[Any] = None,
+        kernel_manager: Optional[Any] = None,
+        kernel_spec_manager: Optional[Any] = None,
+        notebook_manager: Optional[NotebookManager] = None,
+        # Tool-specific parameters
+        cell_index: int = None,
+        **kwargs
+    ) -> str:
+        """Execute the clear_cell_output tool.
+
+        This tool supports three modes of operation:
+
+        1. JUPYTER_SERVER mode with YDoc (collaborative):
+           - Checks if notebook is open in a collaborative session
+           - Uses YDoc for real-time collaborative editing
+           - Changes are immediately visible to all connected users
+
+        2. JUPYTER_SERVER mode without YDoc (file-based):
+           - Falls back to direct file operations using nbformat
+           - Suitable when notebook is not actively being edited
+
+        3. MCP_SERVER mode (WebSocket):
+           - Uses WebSocket connection to remote Jupyter server
+           - Accesses YDoc through NbModelClient
+
+        Args:
+            mode: Server mode (MCP_SERVER or JUPYTER_SERVER)
+            server_client: HTTP client for MCP_SERVER mode
+            contents_manager: Direct API access for JUPYTER_SERVER mode
+            notebook_manager: Notebook manager instance
+            cell_index: Index of the code cell to clear (0-based)
+            **kwargs: Additional parameters
+
+        Returns:
+            Success message
+
+        Raises:
+            ValueError: When mode is invalid, cell_index is out of range, or the
+                cell is not a code cell.
+        """
+        if mode == ServerMode.JUPYTER_SERVER and contents_manager is not None:
+            # JUPYTER_SERVER mode: Try YDoc first, fall back to file operations
+            from jupyter_mcp_server.jupyter_extension.context import get_server_context
+
+            context = get_server_context()
+            serverapp = context.serverapp
+            notebook_path, _ = get_current_notebook_context(notebook_manager)
+
+            # Resolve to absolute path
+            if serverapp and not Path(notebook_path).is_absolute():
+                root_dir = serverapp.root_dir
+                notebook_path = str(Path(root_dir) / notebook_path)
+
+            if serverapp:
+                # Try YDoc approach first
+                cleared_count = await self._clear_cell_output_ydoc(serverapp, notebook_path, cell_index)
+            else:
+                # Fall back to file operations
+                cleared_count = await self._clear_cell_output_file(notebook_path, cell_index)
+
+        elif mode == ServerMode.MCP_SERVER and notebook_manager is not None:
+            # MCP_SERVER mode: Use WebSocket connection
+            cleared_count = await self._clear_cell_output_websocket(notebook_manager, cell_index)
+        else:
+            raise ValueError(f"Invalid mode or missing required clients: mode={mode}")
+
+        if cleared_count == 0:
+            return f"Cell {cell_index} had no output to clear."
+        return f"Cell {cell_index} output cleared successfully ({cleared_count} output(s) removed)."

--- a/tests/test_clear_cell_output.py
+++ b/tests/test_clear_cell_output.py
@@ -1,0 +1,186 @@
+# Copyright (c) 2024- Datalayer, Inc.
+#
+# BSD 3-Clause License
+
+"""
+Tests for the clear_cell_output MCP tool.
+
+File-based tests exercising _clear_cell_output_file end-to-end on a real
+notebook file written to a tmp_path (no server needed), plus unit tests for
+_clear_notebook_model_cell against a NotebookModel-shaped fake (covers the
+YDoc/WebSocket code path without a live collaborative session).
+
+Launch the tests:
+```
+$ pytest tests/test_clear_cell_output.py -v
+```
+"""
+
+import nbformat
+import pytest
+
+from jupyter_mcp_server.tools.clear_cell_output_tool import ClearCellOutputTool
+
+
+def _write_notebook(path, cell_specs):
+    """Write a notebook to *path* from a list of (cell_type, source, outputs, execution_count)."""
+    nb = nbformat.v4.new_notebook()
+    for cell_type, source, outputs, execution_count in cell_specs:
+        if cell_type == "code":
+            cell = nbformat.v4.new_code_cell(source=source)
+            cell.outputs = outputs
+            cell.execution_count = execution_count
+        else:
+            cell = nbformat.v4.new_markdown_cell(source=source)
+        nb.cells.append(cell)
+    with open(path, "w", encoding="utf-8") as f:
+        nbformat.write(nb, f)
+
+
+def _read_notebook(path):
+    with open(path, "r", encoding="utf-8") as f:
+        return nbformat.read(f, as_version=4)
+
+
+###############################################################################
+# Section A — File-based behaviour (no server needed)
+###############################################################################
+
+
+class TestClearCellOutputFile:
+    def setup_method(self):
+        self.tool = ClearCellOutputTool()
+
+    @pytest.mark.asyncio
+    async def test_clears_outputs_and_execution_count(self, tmp_path):
+        """A code cell with real output loses both outputs and execution_count."""
+        path = str(tmp_path / "nb.ipynb")
+        stream_output = nbformat.v4.new_output(output_type="stream", name="stdout", text="hi\n")
+        _write_notebook(path, [("code", "print('hi')", [stream_output], 3)])
+
+        cleared_count = await self.tool._clear_cell_output_file(path, 0)
+
+        assert cleared_count == 1
+        notebook = _read_notebook(path)
+        assert notebook.cells[0].outputs == []
+        assert notebook.cells[0].execution_count is None
+
+    @pytest.mark.asyncio
+    async def test_no_output_cell_returns_zero(self, tmp_path):
+        """Clearing a cell that already has no output reports 0, and stays a no-op."""
+        path = str(tmp_path / "nb.ipynb")
+        _write_notebook(path, [("code", "1 + 1", [], None)])
+
+        cleared_count = await self.tool._clear_cell_output_file(path, 0)
+
+        assert cleared_count == 0
+        notebook = _read_notebook(path)
+        assert notebook.cells[0].outputs == []
+        assert notebook.cells[0].execution_count is None
+
+    @pytest.mark.asyncio
+    async def test_only_targeted_cell_is_touched(self, tmp_path):
+        """Clearing cell 1 must not disturb cell 0's output/execution_count."""
+        path = str(tmp_path / "nb.ipynb")
+        out0 = nbformat.v4.new_output(output_type="stream", name="stdout", text="a\n")
+        out1 = nbformat.v4.new_output(output_type="stream", name="stdout", text="b\n")
+        _write_notebook(path, [
+            ("code", "print('a')", [out0], 1),
+            ("code", "print('b')", [out1], 2),
+        ])
+
+        cleared_count = await self.tool._clear_cell_output_file(path, 1)
+
+        assert cleared_count == 1
+        notebook = _read_notebook(path)
+        assert len(notebook.cells[0].outputs) == 1
+        assert notebook.cells[0].execution_count == 1
+        assert notebook.cells[1].outputs == []
+        assert notebook.cells[1].execution_count is None
+
+    @pytest.mark.asyncio
+    async def test_markdown_cell_rejected(self, tmp_path):
+        """Clearing a non-code cell raises rather than silently no-op'ing."""
+        path = str(tmp_path / "nb.ipynb")
+        _write_notebook(path, [("markdown", "# title", None, None)])
+
+        with pytest.raises(ValueError, match="not a code cell"):
+            await self.tool._clear_cell_output_file(path, 0)
+
+    @pytest.mark.asyncio
+    async def test_out_of_range_index_raises(self, tmp_path):
+        path = str(tmp_path / "nb.ipynb")
+        _write_notebook(path, [("code", "1", [], None)])
+
+        with pytest.raises(ValueError, match="out of range"):
+            await self.tool._clear_cell_output_file(path, 5)
+
+    @pytest.mark.asyncio
+    async def test_negative_index_raises(self, tmp_path):
+        """Same class of bug as delete_cell's negative-index guard: reject
+        rather than silently resolving via Python's negative indexing."""
+        path = str(tmp_path / "nb.ipynb")
+        _write_notebook(path, [("code", "1", [], None)])
+
+        with pytest.raises(ValueError, match="out of range"):
+            await self.tool._clear_cell_output_file(path, -1)
+
+
+###############################################################################
+# Section B — NotebookModel-shaped fake (covers the YDoc/WebSocket branch)
+###############################################################################
+
+
+class _FakeNotebookModel:
+    """Minimal stand-in for jupyter_nbmodel_client.NotebookModel's sequence
+    protocol (__len__/__getitem__/__setitem__), which is all
+    _clear_notebook_model_cell relies on."""
+
+    def __init__(self, cells):
+        self._cells = cells
+
+    def __len__(self):
+        return len(self._cells)
+
+    def __getitem__(self, index):
+        return dict(self._cells[index])
+
+    def __setitem__(self, index, value):
+        self._cells[index] = value
+
+
+class TestClearCellOutputNotebookModel:
+    def setup_method(self):
+        self.tool = ClearCellOutputTool()
+
+    def test_clears_outputs_and_execution_count(self):
+        nb = _FakeNotebookModel([
+            {
+                "cell_type": "code",
+                "source": "print(1)",
+                "outputs": [{"output_type": "stream"}],
+                "execution_count": 2,
+            },
+        ])
+
+        cleared_count = self.tool._clear_notebook_model_cell(nb, 0)
+
+        assert cleared_count == 1
+        assert nb._cells[0]["outputs"] == []
+        assert nb._cells[0]["execution_count"] is None
+        # Untouched fields survive the read-modify-write round trip.
+        assert nb._cells[0]["source"] == "print(1)"
+
+    def test_markdown_cell_rejected(self):
+        nb = _FakeNotebookModel([{"cell_type": "markdown", "source": "# hi"}])
+
+        with pytest.raises(ValueError, match="not a code cell"):
+            self.tool._clear_notebook_model_cell(nb, 0)
+
+    def test_out_of_range_index_raises(self):
+        nb = _FakeNotebookModel([
+            {"cell_type": "code", "source": "1", "outputs": [], "execution_count": None},
+        ])
+
+        with pytest.raises(ValueError, match="out of range"):
+            self.tool._clear_notebook_model_cell(nb, 5)

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -41,6 +41,7 @@ JUPYTER_TOOLS = [
     "execute_cell",
     "read_cell",
     "delete_cell",
+    "clear_cell_output",
     "move_cell",
     "execute_code",
     # Server Management Tools


### PR DESCRIPTION
jupyter_nbmodel_client's own `NotebookModel` carries a standing FIXME ("add API to clear code cell; aka execution count and outputs"), and this server had no way to clear a single cell's outputs and execution count without deleting and re-inserting the cell. Requested in #141 by a collaborator building on top of the read/clear-output split from #139.

`ClearCellOutputTool` follows the existing three-mode pattern (YDoc, file, WebSocket). For the YDoc and WebSocket paths it goes through `NotebookModel`'s own sequence protocol (`__getitem__`/`__setitem__`, shared by `NbModelClient` since it subclasses `NotebookModel`): read the cell, clear outputs and execution count, write it back under `NotebookModel`'s own lock and transaction. The file path mirrors `delete_cell_tool`'s nbformat read/modify/write shape.

Verified in a clean Docker container this session, against current `main` (`667d59a`):
- `tests/test_clear_cell_output.py` (9 cases: file-mode read/modify/write against a real notebook file, plus unit tests for `_clear_notebook_model_cell` against a `NotebookModel`-shaped fake) collection fails with `ModuleNotFoundError` when the source changes are reverted to `main` and passes on this branch (9/9).
- Full module import sweep and `jupyter-mcp-server --help` succeed.
- A live end-to-end smoke check (insert a cell, execute it for a real output, clear_cell_output, read_cell) passed through the real MCP protocol in both server modes: JUPYTER_SERVER (YDoc, live jupyter-collaboration session) and MCP_SERVER (WebSocket, NbModelClient). Not part of the committed suite since the closest precedent, `delete_cell_tool`'s own test file, is file-mode only; noted here as manual verification, not automated.

Not verified: the repo's macOS/Windows CI legs (this session ran Linux only) and the `test_lint` job's exact toolchain (this file matches the existing style of `delete_cell_tool.py`, which already carries the same two patterns a naive local ruff/mypy run flags: an implicit-Optional `int = None` default and `BaseTool.execute`'s return-type inference).

Fixes #141
