### PR TITLE
fix(read-tools): check the live YDoc before falling back to file

### DIFF
--- a/jupyter_mcp_server/tools/read_cell_tool.py
+++ b/jupyter_mcp_server/tools/read_cell_tool.py
@@ -4,12 +4,13 @@
 
 """Read cell tool implementation."""
 
+from pathlib import Path
 from typing import Any, Optional
 from jupyter_server_client import JupyterServerClient
 from jupyter_mcp_server.tools._base import BaseTool, ServerMode
 from jupyter_mcp_server.notebook_manager import NotebookManager
 from jupyter_mcp_server.models import Notebook
-from jupyter_mcp_server.utils import get_current_notebook_context
+from jupyter_mcp_server.utils import get_current_notebook_context, get_notebook_model
 from mcp.types import ImageContent
 from jupyter_core.utils import ensure_async
 
@@ -45,7 +46,9 @@ class ReadCellTool(BaseTool):
             Cell information dictionary
         """
         if mode == ServerMode.JUPYTER_SERVER and contents_manager is not None:
-            # Local mode: read notebook directly from file system.
+            # Local mode: try the live YDoc first (collaborative session), same
+            # as every cell-mutation tool, so a read right after our own write
+            # sees it instead of the on-disk copy the autosave hasn't flushed yet.
             # Guard against no active notebook — without this, a None path causes
             # 'quote_from_bytes() expected bytes' deep in the contents manager.
             notebook_path, _ = get_current_notebook_context(notebook_manager)
@@ -53,10 +56,22 @@ class ReadCellTool(BaseTool):
             if not notebook_path:
                 return ["No active notebook. Use the use_notebook tool to activate a notebook first."]
 
-            model = await ensure_async(contents_manager.get(notebook_path, content=True, type='notebook'))
-            if 'content' not in model:
-                raise ValueError(f"Could not read notebook content from {notebook_path}")
-            notebook = Notebook(**model['content'])
+            from jupyter_mcp_server.jupyter_extension.context import get_server_context
+
+            context = get_server_context()
+            serverapp = context.serverapp
+            ydoc_path = notebook_path
+            if serverapp and not Path(ydoc_path).is_absolute():
+                ydoc_path = str(Path(serverapp.root_dir) / ydoc_path)
+
+            nb_model = await get_notebook_model(serverapp, ydoc_path) if serverapp else None
+            if nb_model:
+                notebook = Notebook(**nb_model.as_dict())
+            else:
+                model = await ensure_async(contents_manager.get(notebook_path, content=True, type='notebook'))
+                if 'content' not in model:
+                    raise ValueError(f"Could not read notebook content from {notebook_path}")
+                notebook = Notebook(**model['content'])
         elif mode == ServerMode.MCP_SERVER and notebook_manager is not None:
             # Remote mode: use WebSocket connection to Y.js document.
             # get_current_connection() falls back to the default pre-configured

--- a/jupyter_mcp_server/tools/read_notebook_tool.py
+++ b/jupyter_mcp_server/tools/read_notebook_tool.py
@@ -4,11 +4,13 @@
 
 """List cells tool implementation."""
 
+from pathlib import Path
 from typing import Any, Optional, Literal
 from jupyter_server_client import JupyterServerClient
 from jupyter_mcp_server.tools._base import BaseTool, ServerMode
 from jupyter_mcp_server.notebook_manager import NotebookManager
 from jupyter_mcp_server.models import Notebook
+from jupyter_mcp_server.utils import get_notebook_model
 from jupyter_core.utils import ensure_async
 
 
@@ -46,13 +48,27 @@ class ReadNotebookTool(BaseTool):
             return f"Notebook '{notebook_name}' is not connected. All currently connected notebooks: {list(notebook_manager.list_all_notebooks().keys())}"
         
         if mode == ServerMode.JUPYTER_SERVER and contents_manager is not None:
-            # Local mode: read notebook directly from file system
+            # Local mode: try the live YDoc first (collaborative session), same
+            # as every cell-mutation tool, so a read right after our own write
+            # sees it instead of the on-disk copy the autosave hasn't flushed yet.
             notebook_path = notebook_manager.get_notebook_path(notebook_name)
-            
-            model = await ensure_async(contents_manager.get(notebook_path, content=True, type='notebook'))
-            if 'content' not in model:
-                raise ValueError(f"Could not read notebook content from {notebook_path}")
-            notebook = Notebook(**model['content'])
+
+            from jupyter_mcp_server.jupyter_extension.context import get_server_context
+
+            context = get_server_context()
+            serverapp = context.serverapp
+            ydoc_path = notebook_path
+            if serverapp and not Path(ydoc_path).is_absolute():
+                ydoc_path = str(Path(serverapp.root_dir) / ydoc_path)
+
+            nb_model = await get_notebook_model(serverapp, ydoc_path) if serverapp else None
+            if nb_model:
+                notebook = Notebook(**nb_model.as_dict())
+            else:
+                model = await ensure_async(contents_manager.get(notebook_path, content=True, type='notebook'))
+                if 'content' not in model:
+                    raise ValueError(f"Could not read notebook content from {notebook_path}")
+                notebook = Notebook(**model['content'])
         elif mode == ServerMode.MCP_SERVER and notebook_manager is not None:
             # Remote mode: use WebSocket connection to Y.js document
             async with notebook_manager.get_notebook_connection(notebook_name) as notebook_content:

--- a/tests/test_read_tools_ydoc.py
+++ b/tests/test_read_tools_ydoc.py
@@ -1,0 +1,225 @@
+# Copyright (c) 2024- Datalayer, Inc.
+#
+# BSD 3-Clause License
+
+"""
+Tests for read_cell and read_notebook tools' YDoc-first read path.
+
+Regression tests for #297: in JUPYTER_SERVER mode, read_cell/read_notebook
+unconditionally read the notebook file from disk, so a write that already
+landed in the live YDoc (via overwrite_cell_source or any other mutation
+tool, which all check the YDoc first through get_notebook_model()) is
+invisible to a read until the autosave debounce flushes it to disk.
+
+Follows this repo's own pattern (see test_clear_cell_output.py) of driving
+the tool's execute() directly with a NotebookModel-shaped fake, rather than
+requiring a live collaborative session.
+
+Launch the tests:
+```
+$ pytest tests/test_read_tools_ydoc.py -v
+```
+"""
+
+import nbformat
+import pytest
+
+from jupyter_mcp_server.tools._base import ServerMode
+from jupyter_mcp_server.tools.read_cell_tool import ReadCellTool
+from jupyter_mcp_server.tools.read_notebook_tool import ReadNotebookTool
+from jupyter_mcp_server.jupyter_extension.context import get_server_context
+import jupyter_mcp_server.tools.read_cell_tool as read_cell_tool_module
+import jupyter_mcp_server.tools.read_notebook_tool as read_notebook_tool_module
+
+
+def _write_notebook(path, sources):
+    nb = nbformat.v4.new_notebook()
+    for source in sources:
+        nb.cells.append(nbformat.v4.new_code_cell(source=source))
+    with open(path, "w", encoding="utf-8") as f:
+        nbformat.write(nb, f)
+
+
+class _FakeNotebookModel:
+    """Minimal stand-in for jupyter_nbmodel_client.NotebookModel: only the
+    as_dict() surface the read tools consume."""
+
+    def __init__(self, sources):
+        self._sources = sources
+
+    def as_dict(self):
+        return {
+            "cells": [
+                {
+                    "cell_type": "code",
+                    "source": source,
+                    "metadata": {},
+                    "execution_count": None,
+                    "outputs": [],
+                }
+                for source in self._sources
+            ],
+            "metadata": {},
+            "nbformat": 4,
+            "nbformat_minor": 5,
+        }
+
+
+class _NoContentsManager:
+    """contents_manager stand-in that fails the test if it is ever called,
+    proving the YDoc branch short-circuits the file read entirely."""
+
+    async def get(self, *args, **kwargs):
+        raise AssertionError(
+            "contents_manager.get() must not run when the live YDoc has an open room"
+        )
+
+
+class _FileContentsManager:
+    """contents_manager stand-in that reads the real file under tmp_path,
+    for the no-YDoc-room fallback path."""
+
+    def __init__(self, root):
+        self._root = root
+
+    async def get(self, path, content=True, type='notebook'):
+        with open(str(self._root / path), "r", encoding="utf-8") as f:
+            nb = nbformat.read(f, as_version=4)
+        return {"content": nb}
+
+
+def _fake_get_notebook_model(nb_model):
+    async def _fake(serverapp, notebook_path):
+        return nb_model
+    return _fake
+
+
+class _FakeServerApp:
+    def __init__(self, root_dir):
+        self.root_dir = root_dir
+
+
+@pytest.fixture(autouse=True)
+def _reset_context():
+    yield
+    get_server_context().reset()
+
+
+class TestReadCellToolYDocFirst:
+    def setup_method(self):
+        self.tool = ReadCellTool()
+
+    @pytest.mark.asyncio
+    async def test_reads_live_ydoc_over_stale_file(self, tmp_path, monkeypatch):
+        """A write already in the YDoc must be visible, not the stale file."""
+        _write_notebook(str(tmp_path / "nb.ipynb"), ["OLD_SOURCE"])
+        get_server_context().update(
+            context_type="JUPYTER_SERVER", serverapp=_FakeServerApp(str(tmp_path))
+        )
+        monkeypatch.setattr(
+            read_cell_tool_module, "get_current_notebook_context", lambda nm: ("nb.ipynb", None)
+        )
+        monkeypatch.setattr(
+            read_cell_tool_module,
+            "get_notebook_model",
+            _fake_get_notebook_model(_FakeNotebookModel(["NEW_SOURCE"])),
+        )
+
+        result = await self.tool.execute(
+            mode=ServerMode.JUPYTER_SERVER,
+            contents_manager=_NoContentsManager(),
+            notebook_manager=None,
+            cell_index=0,
+        )
+
+        joined = "\n".join(result)
+        assert "NEW_SOURCE" in joined
+        assert "OLD_SOURCE" not in joined
+
+    @pytest.mark.asyncio
+    async def test_falls_back_to_file_when_no_ydoc_room(self, tmp_path, monkeypatch):
+        """No collaborative session open -> unchanged fallback to the on-disk file."""
+        _write_notebook(str(tmp_path / "nb.ipynb"), ["FILE_SOURCE"])
+        get_server_context().update(
+            context_type="JUPYTER_SERVER", serverapp=_FakeServerApp(str(tmp_path))
+        )
+        monkeypatch.setattr(
+            read_cell_tool_module, "get_current_notebook_context", lambda nm: ("nb.ipynb", None)
+        )
+        monkeypatch.setattr(
+            read_cell_tool_module, "get_notebook_model", _fake_get_notebook_model(None)
+        )
+
+        result = await self.tool.execute(
+            mode=ServerMode.JUPYTER_SERVER,
+            contents_manager=_FileContentsManager(tmp_path),
+            notebook_manager=None,
+            cell_index=0,
+        )
+
+        assert "FILE_SOURCE" in "\n".join(result)
+
+
+class _FakeNotebookManager:
+    """Minimal stand-in covering only what read_notebook needs: membership
+    and path lookup for one fixed notebook name."""
+
+    def __init__(self, name, path):
+        self._name = name
+        self._path = path
+
+    def __contains__(self, name):
+        return name == self._name
+
+    def get_notebook_path(self, name):
+        return self._path
+
+
+class TestReadNotebookToolYDocFirst:
+    def setup_method(self):
+        self.tool = ReadNotebookTool()
+
+    @pytest.mark.asyncio
+    async def test_reads_live_ydoc_over_stale_file(self, tmp_path, monkeypatch):
+        """Same staleness regression as read_cell, for the whole-notebook read."""
+        _write_notebook(str(tmp_path / "nb.ipynb"), ["OLD_SOURCE"])
+        get_server_context().update(
+            context_type="JUPYTER_SERVER", serverapp=_FakeServerApp(str(tmp_path))
+        )
+        monkeypatch.setattr(
+            read_notebook_tool_module,
+            "get_notebook_model",
+            _fake_get_notebook_model(_FakeNotebookModel(["NEW_SOURCE"])),
+        )
+
+        result = await self.tool.execute(
+            mode=ServerMode.JUPYTER_SERVER,
+            contents_manager=_NoContentsManager(),
+            notebook_manager=_FakeNotebookManager("nb", "nb.ipynb"),
+            notebook_name="nb",
+            limit=100,
+        )
+
+        assert "NEW_SOURCE" in result
+        assert "OLD_SOURCE" not in result
+
+    @pytest.mark.asyncio
+    async def test_falls_back_to_file_when_no_ydoc_room(self, tmp_path, monkeypatch):
+        """No collaborative session open -> unchanged fallback to the on-disk file."""
+        _write_notebook(str(tmp_path / "nb.ipynb"), ["FILE_SOURCE"])
+        get_server_context().update(
+            context_type="JUPYTER_SERVER", serverapp=_FakeServerApp(str(tmp_path))
+        )
+        monkeypatch.setattr(
+            read_notebook_tool_module, "get_notebook_model", _fake_get_notebook_model(None)
+        )
+
+        result = await self.tool.execute(
+            mode=ServerMode.JUPYTER_SERVER,
+            contents_manager=_FileContentsManager(tmp_path),
+            notebook_manager=_FakeNotebookManager("nb", "nb.ipynb"),
+            notebook_name="nb",
+            limit=100,
+        )
+
+        assert "FILE_SOURCE" in result


### PR DESCRIPTION
`read_cell` and `read_notebook` unconditionally read the notebook from disk in JUPYTER_SERVER mode (`contents_manager.get(notebook_path, content=True, type='notebook')`), unlike every cell-mutation tool: `overwrite_cell_source`, `insert_cell`, `delete_cell`, `move_cell`, and `clear_cell_output` all call `get_notebook_model()` first and only fall back to file I/O when no collaborative session is open. A write that already landed in the live YDoc is invisible to a read until the autosave debounce flushes it to disk, so an agent reading its own just-made edit sees stale content. `#138` added the YDoc-first check to these two read tools; `#139`, merged the next day, removed it as part of an unrelated refactor and nothing has restored it since.

Both tools now call `get_notebook_model()` first, using the same `serverapp.root_dir` path resolution the write tools use, and fall back to the existing file read only when no YDoc room exists.

Verified in a clean Docker container this session (`python:3.13-slim`, non-root, bind-mounted clone at HEAD `076c669`):
- Two new regression tests per tool: one asserts a read returns YDoc content over a stale file (and that `contents_manager.get()` is never called when a YDoc room exists), the other confirms the fallback to file when no room is open is unchanged. All 4 fail on `076c669` (`AttributeError: module has no attribute 'get_notebook_model'`, since the import doesn't exist pre-fix) and pass on this branch.
- Full suite (`TEST_MCP_SERVER=true TEST_JUPYTER_SERVER=true pytest`, both transport modes): 274 passed, 1 skipped (`test_move_cell_preserves_outputs`, a pre-existing platform-timeout skip unrelated to this change), 0 failures.
- `header-license-fix` (skywalking-eyes) clean on the new file.

Not verified: the macOS/Windows CI legs (this session ran Linux only) and `test_lint`'s mypy/ruff output beyond a local run, since neither gates a merge in this repo's workflow (`lint.sh` has no `set -e`, so only its last command, `validate-pyproject`, determines the job's exit code).

Fixes #297
