### PR TITLE
fix(auth): use constant-time comparison for the MCP bearer token

### DIFF
--- a/jupyter_mcp_server/server.py
+++ b/jupyter_mcp_server/server.py
@@ -6,6 +6,7 @@
 Jupyter MCP Server Layer
 """
 
+import hmac
 from typing import Annotated, Literal
 from urllib.parse import urlsplit
 
@@ -76,7 +77,7 @@ class RuntimeTokenVerifier:
         self._token = token
 
     async def verify_token(self, token: str) -> AccessToken | None:
-        if token != self._token:
+        if not hmac.compare_digest(token, self._token):
             return None
         return AccessToken(token=token, client_id="mcp-client", scopes=[])
 

--- a/tests/test_runtime_token_verifier.py
+++ b/tests/test_runtime_token_verifier.py
@@ -1,0 +1,58 @@
+# Copyright (c) 2024- Datalayer, Inc.
+#
+# BSD 3-Clause License
+
+"""
+Unit tests for RuntimeTokenVerifier (jupyter_mcp_server.server): no server needed,
+imports directly from the server module.
+
+Launch the tests:
+```
+$ pytest tests/test_runtime_token_verifier.py -v
+```
+"""
+
+import hmac
+from unittest.mock import patch
+
+import pytest
+
+from jupyter_mcp_server.server import RuntimeTokenVerifier
+
+
+class TestRuntimeTokenVerifier:
+    """verify_token() must accept the configured token, reject anything else,
+    and do the comparison in constant time (CWE-208: timing side-channel via `!=`)."""
+
+    @pytest.mark.asyncio
+    async def test_accepts_matching_token(self):
+        verifier = RuntimeTokenVerifier("secret-token")
+
+        access_token = await verifier.verify_token("secret-token")
+
+        assert access_token is not None
+        assert access_token.token == "secret-token"  # noqa: S105 (test fixture, not a real secret)
+
+    @pytest.mark.asyncio
+    async def test_rejects_mismatched_token(self):
+        verifier = RuntimeTokenVerifier("secret-token")
+
+        assert await verifier.verify_token("wrong-token") is None
+
+    @pytest.mark.asyncio
+    async def test_rejects_wrong_length_token(self):
+        verifier = RuntimeTokenVerifier("secret-token")
+
+        assert await verifier.verify_token("s") is None
+
+    @pytest.mark.asyncio
+    async def test_comparison_is_constant_time(self):
+        """Guards against regressing to a plain `!=`, which leaks byte-position
+        timing information on the configured token (CWE-208)."""
+        verifier = RuntimeTokenVerifier("secret-token")
+
+        target = "jupyter_mcp_server.server.hmac.compare_digest"
+        with patch(target, wraps=hmac.compare_digest) as spy:
+            await verifier.verify_token("wrong-token")
+
+        spy.assert_called_once_with("wrong-token", "secret-token")


### PR DESCRIPTION
`RuntimeTokenVerifier.verify_token` (`server.py:77-80`) is the sole check protecting the streamable-http MCP endpoint (execute_code/execute_cell and friends) when `--mcp-token`/`MCP_TOKEN` is set, and it is reused by `ManagementRouteSecurityMiddleware` for `/api/connect` and `/api/stop`. It compared the token with a plain `!=`, which short-circuits at the first mismatched byte and leaks timing information about how many leading bytes of a guessed token are correct (CWE-208).

Fix: use `hmac.compare_digest`, the standard constant-time comparison for secrets.

Verified: added `tests/test_runtime_token_verifier.py`, which patches `hmac.compare_digest` to confirm it is actually invoked on every check (fails on main, since main never calls it; passes here), plus accept/reject/wrong-length cases for the unchanged accept/reject behavior. Ran in a clean `python:3.12-slim` Docker container against both `main` and this branch. What I did not verify: an actual measurable timing side-channel against this server, a local 200k-rep timing check (byte-0 vs byte-63 mismatch on a 64-char token) showed no distinguishable difference at this string length, so this is defense-in-depth hardening (CWE-208), not a demonstrated exploit.

Fixes #301
