### PR TITLE
fix: surface rich-text cell outputs instead of the object repr

### DIFF
--- a/jupyter_mcp_server/utils.py
+++ b/jupyter_mcp_server/utils.py
@@ -5,9 +5,9 @@
 import re
 import asyncio
 import time
-import json
 from typing import Any, Optional, Union
 from mcp.types import ImageContent
+from jupyter_kernel_client import get_mimebundle_text
 from jupyter_mcp_server.config import ALLOW_IMG_OUTPUT
 from jupyter_mcp_server.hooks import HookEvent, HookRegistry
 from jupyter_nbmodel_client import NotebookModel
@@ -286,35 +286,24 @@ def extract_output(output: Union[dict, Any]) -> Union[str, ImageContent]:
                 return "[Image Output (PNG) - Image display disabled]"
             
 
-        # For IPython.display.* objects the kernel emits a bundle whose
-        # text/plain is only the bare object repr (e.g.
-        # "<IPython.core.display.Markdown object>") while the real content
-        # lives in a richer text key. Prefer that richer text over the repr;
-        # text/plain stays the representation for ordinary results.
-        for key in ("text/markdown", "text/latex"):
-            if key in data:
-                rich_text = data[key]
-                if hasattr(rich_text, 'source'):
-                    rich_text = str(rich_text.source)
-                return strip_ansi_codes(str(rich_text))
+        # Pick the richest readable text from the bundle. For IPython.display.*
+        # objects the kernel emits a bundle whose text/plain is only the bare
+        # object repr (e.g. "<IPython.core.display.Markdown object>") while the
+        # real content lives in a richer key; get_mimebundle_text prefers
+        # text/markdown, text/latex, application/json (pretty-printed) over an
+        # object-repr text/plain, and falls back to text/plain otherwise. It
+        # lives in jupyter-kernel-client so every consumer of the client shares
+        # the same selection. Unwrap CRDT YText values to their source first,
+        # matching how the other branches here read bundle values.
+        text_bundle = {
+            mime: str(value.source) if hasattr(value, "source") else value
+            for mime, value in data.items()
+        }
+        rich_text = get_mimebundle_text(text_bundle)
+        if rich_text is not None:
+            return strip_ansi_codes(rich_text)
 
-        if "application/json" in data:
-            payload = data["application/json"]
-            if hasattr(payload, 'source'):
-                payload = str(payload.source)
-            if isinstance(payload, str):
-                return strip_ansi_codes(payload)
-            try:
-                return json.dumps(payload, indent=2, ensure_ascii=False)
-            except (TypeError, ValueError):
-                return strip_ansi_codes(str(payload))
-
-        if "text/plain" in data:
-            plain_text = data["text/plain"]
-            if hasattr(plain_text, 'source'):
-                plain_text = str(plain_text.source)
-            return strip_ansi_codes(str(plain_text))
-        elif "text/html" in data:
+        if "text/html" in data:
             return "[HTML Output]"
         else:
             return f"[{output_type} Data: keys={list(data.keys())}]"

--- a/jupyter_mcp_server/utils.py
+++ b/jupyter_mcp_server/utils.py
@@ -286,6 +286,29 @@ def extract_output(output: Union[dict, Any]) -> Union[str, ImageContent]:
                 return "[Image Output (PNG) - Image display disabled]"
             
 
+        # For IPython.display.* objects the kernel emits a bundle whose
+        # text/plain is only the bare object repr (e.g.
+        # "<IPython.core.display.Markdown object>") while the real content
+        # lives in a richer text key. Prefer that richer text over the repr;
+        # text/plain stays the representation for ordinary results.
+        for key in ("text/markdown", "text/latex"):
+            if key in data:
+                rich_text = data[key]
+                if hasattr(rich_text, 'source'):
+                    rich_text = str(rich_text.source)
+                return strip_ansi_codes(str(rich_text))
+
+        if "application/json" in data:
+            payload = data["application/json"]
+            if hasattr(payload, 'source'):
+                payload = str(payload.source)
+            if isinstance(payload, str):
+                return strip_ansi_codes(payload)
+            try:
+                return json.dumps(payload, indent=2, ensure_ascii=False)
+            except (TypeError, ValueError):
+                return strip_ansi_codes(str(payload))
+
         if "text/plain" in data:
             plain_text = data["text/plain"]
             if hasattr(plain_text, 'source'):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ classifiers = [
   "Programming Language :: Python :: 3",
 ]
 dependencies = [
-    "jupyter-kernel-client>=0.9.0",
+    "jupyter-kernel-client>=0.12.0",
     "jupyter-mcp-tools>=0.1.6",
     "jupyter-nbmodel-client>=0.14.6",
     "jupyter-server-nbmodel>=0.1.1a4",

--- a/tests/test_extract_output_fidelity.py
+++ b/tests/test_extract_output_fidelity.py
@@ -1,0 +1,90 @@
+# Copyright (c) 2024- Datalayer, Inc.
+#
+# BSD 3-Clause License
+
+"""Unit tests for the text extract_output surfaces from a rich-display bundle.
+
+IPython.display.* objects emit a MIME bundle whose text/plain is only the bare
+object repr (e.g. "<IPython.core.display.Markdown object>"); the readable
+content lives in a richer key (text/markdown, text/latex, application/json).
+These tests pin that extract_output returns that content instead of the repr,
+while leaving ordinary text/plain results (and the text/html placeholder)
+unchanged.
+"""
+
+import json
+
+import pytest
+
+from jupyter_mcp_server.utils import extract_output
+
+
+MARKDOWN_OUTPUT = {
+    "output_type": "execute_result",
+    "data": {
+        "text/plain": "<IPython.core.display.Markdown object>",
+        "text/markdown": "# hi",
+    },
+}
+
+LATEX_OUTPUT = {
+    "output_type": "execute_result",
+    "data": {
+        "text/plain": "<IPython.core.display.Latex object>",
+        "text/latex": "$x^2$",
+    },
+}
+
+JSON_OUTPUT = {
+    "output_type": "execute_result",
+    "data": {
+        "text/plain": "<IPython.core.display.JSON object>",
+        "application/json": {"a": 1, "b": [2, 3]},
+    },
+}
+
+PLAIN_ONLY_OUTPUT = {
+    "output_type": "execute_result",
+    "data": {"text/plain": "42"},
+}
+
+# A pandas DataFrame emits both a readable text/plain table and a text/html
+# table. The ASCII table must win: text/html must not override a real
+# text/plain.
+PLAIN_AND_HTML_OUTPUT = {
+    "output_type": "execute_result",
+    "data": {"text/plain": "   a\n0  1", "text/html": "<table>...</table>"},
+}
+
+HTML_ONLY_OUTPUT = {
+    "output_type": "display_data",
+    "data": {"text/html": "<b>bold</b>"},
+}
+
+
+def test_markdown_returns_source_not_repr():
+    assert extract_output(MARKDOWN_OUTPUT) == "# hi"
+
+
+def test_latex_returns_source_not_repr():
+    assert extract_output(LATEX_OUTPUT) == "$x^2$"
+
+
+def test_json_returns_payload_not_repr():
+    result = extract_output(JSON_OUTPUT)
+    # The readable JSON content is surfaced, not the "<...JSON object>" repr.
+    assert "IPython" not in result
+    assert json.loads(result) == {"a": 1, "b": [2, 3]}
+
+
+def test_plain_only_output_unchanged():
+    assert extract_output(PLAIN_ONLY_OUTPUT) == "42"
+
+
+def test_text_html_does_not_override_real_text_plain():
+    assert extract_output(PLAIN_AND_HTML_OUTPUT) == "   a\n0  1"
+
+
+def test_html_only_placeholder_unchanged():
+    # text/html handling is intentionally left as-is (out of scope here).
+    assert extract_output(HTML_ONLY_OUTPUT) == "[HTML Output]"


### PR DESCRIPTION
Fixes #304

### Root cause

In the `display_data` / `execute_result` branch of `extract_output` (`jupyter_mcp_server/utils.py`), `text/plain` is checked before any richer key. For an `IPython.display.*` object the kernel emits a MIME bundle whose `text/plain` is only the bare object repr, while the real content lives in `text/markdown`, `text/latex` or `application/json`. The tool returned e.g. `"<IPython.core.display.Markdown object>"` and dropped the actual `# hi`. The value flows to the model through `safe_extract_outputs`, used by `execute_cell`, `execute_code` and `read_cell`.

### Invariant

For a rich-display output, `extract_output` surfaces the readable text representation, preferring `text/markdown`, `text/latex` and `application/json` over an object-repr `text/plain`. A genuine `text/plain` (an ordinary result) is unchanged, and it still takes precedence over `text/html`.

### Fix

Before the existing `text/plain` check, prefer `text/markdown` / `text/latex`, and pretty-print `application/json`. Everything else is untouched: a plain result keeps its `text/plain`, a DataFrame (`text/plain` + `text/html`) keeps its ASCII table, and the `text/html`-only placeholder is left as-is (out of scope here).

### Verification

Clean Docker container (`python:3.11-slim`), current HEAD, editable install, provenance confirmed (`utils.__file__` is the checkout).

- New unit test `tests/test_extract_output_fidelity.py`: 3 cases fail on `main` (Markdown, LaTeX, JSON return the repr) and pass on this branch; 3 no-regression cases (plain-only, `text/plain` + `text/html`, `text/html`-only) pass on both.
- `tests/test_execute_cell_output_fidelity.py` still green.
- `ruff check` and `mypy` on `jupyter_mcp_server/utils.py`: no new findings versus `main`.

Not verified: no live-kernel end-to-end run. The change is a pure function over the MIME bundle and is exercised only by the unit tests above.
