### PR TITLE
fix(execute): track a timed-out execute_cell's background task so is_kernel_busy sees it

### DIFF
--- a/jupyter_mcp_server/tools/execute_cell_tool.py
+++ b/jupyter_mcp_server/tools/execute_cell_tool.py
@@ -23,6 +23,7 @@ from jupyter_mcp_server.utils import (
     wait_for_kernel_idle,
     safe_extract_outputs,
     execute_cell_with_forced_sync,
+    track_pending_execution,
     extract_output
 )
 
@@ -303,6 +304,7 @@ class ExecuteCellTool(BaseTool):
                     execution_task = asyncio.create_task(
                         asyncio.to_thread(notebook.execute_cell, cell_index, kernel)
                     )
+                    track_pending_execution(kernel, execution_task)
 
                     start_time = time.time()
                     last_output_count = 0

--- a/jupyter_mcp_server/utils.py
+++ b/jupyter_mcp_server/utils.py
@@ -502,17 +502,38 @@ def ensure_kernel_alive(notebook_manager, current_notebook, create_kernel_fn):
     return notebook_manager.ensure_kernel_alive(current_notebook, create_kernel_fn)
 
 
+def track_pending_execution(kernel, task):
+    """Remember a background execute_cell task on the kernel so is_kernel_busy
+    can see it, and forget it once the task actually finishes.
+
+    asyncio.Task.cancel() on a task wrapping asyncio.to_thread() cannot stop the
+    underlying OS thread: the thread keeps running notebook.execute_cell() (and
+    mutating the shared notebook/kernel state) until it returns on its own,
+    regardless of the cancellation request. Recording the task here lets a
+    later call see that a previous execution is still in flight instead of
+    assuming the kernel is free the moment a timeout is raised.
+    """
+    kernel._mcp_pending_execution = task
+
+    def _clear(finished_task, kernel=kernel):
+        if getattr(kernel, "_mcp_pending_execution", None) is finished_task:
+            kernel._mcp_pending_execution = None
+
+    task.add_done_callback(_clear)
+
+
 async def execute_cell_with_forced_sync(notebook, cell_index, kernel, timeout_seconds = 300):
     """Execute cell with forced real-time synchronization."""
     from jupyter_mcp_server.log import logger
-    
+
     start_time = time.time()
-    
+
     # Start execution
     execution_future = asyncio.create_task(
         asyncio.to_thread(notebook.execute_cell, cell_index, kernel)
     )
-    
+    track_pending_execution(kernel, execution_future)
+
     last_output_count = 0
     
     while not execution_future.done():
@@ -566,14 +587,16 @@ async def execute_cell_with_forced_sync(notebook, cell_index, kernel, timeout_se
 
 
 def is_kernel_busy(kernel):
-    """Check if kernel is currently executing something."""
-    try:
-        # This is a simple check - you might need to adapt based on your kernel client
-        if hasattr(kernel, '_client') and hasattr(kernel._client, 'is_alive'):
-            return kernel._client.is_alive()
-        return False
-    except Exception:
-        return False
+    """Check if kernel is currently executing something.
+
+    Reflects the task recorded by track_pending_execution, not
+    kernel._client.is_alive(): KernelClient (jupyter_kernel_client) has no
+    _client attribute, so that check always fell through to `return False`
+    and a timed-out execution's orphaned background thread was never seen
+    as "busy" by wait_for_kernel_idle.
+    """
+    task = getattr(kernel, "_mcp_pending_execution", None)
+    return task is not None and not task.done()
 
 
 async def wait_for_kernel_idle(kernel, max_wait_seconds=60):

--- a/tests/test_execute_orphaned_timeout.py
+++ b/tests/test_execute_orphaned_timeout.py
@@ -1,0 +1,143 @@
+# Copyright (c) 2024- Datalayer, Inc.
+#
+# BSD 3-Clause License
+
+"""Regression tests for the timeout path abandoning its background execution.
+
+asyncio.Task.cancel() on a task wrapping asyncio.to_thread() cannot stop the
+underlying OS thread: notebook.execute_cell() keeps running (and mutating the
+shared notebook/kernel state) after a timeout has already been raised back to
+the caller. is_kernel_busy() must reflect that so a subsequent call waits for
+the orphaned execution instead of starting a second one against the same
+kernel/notebook connection.
+"""
+
+import asyncio
+import contextlib
+import time
+
+import pytest
+
+from jupyter_mcp_server.tools._base import ServerMode
+from jupyter_mcp_server.tools.execute_cell_tool import ExecuteCellTool
+from jupyter_mcp_server.utils import (
+    execute_cell_with_forced_sync,
+    is_kernel_busy,
+    wait_for_kernel_idle,
+)
+
+
+class FakeKernel:
+    """Minimal stand-in covering the surface the execution paths use."""
+
+    def __init__(self):
+        self.interrupted = False
+
+    def interrupt(self):
+        self.interrupted = True
+
+
+class FakeNotebook:
+    """Single-cell notebook whose execute_cell runs a caller-supplied callable."""
+
+    def __init__(self, cell, execute_impl):
+        self._cell = cell
+        self._execute_impl = execute_impl
+
+    def __len__(self):
+        return 1
+
+    def __getitem__(self, index):
+        return self._cell
+
+    def execute_cell(self, cell_index, kernel):
+        return self._execute_impl()
+
+
+class FakeNotebookManager:
+    def __init__(self, notebook):
+        self._notebook = notebook
+
+    def get_current_notebook(self):
+        return "default"
+
+    def get_kernel_id(self, notebook_name):
+        return "kernel-1"
+
+    @contextlib.asynccontextmanager
+    async def _connection(self):
+        yield self._notebook
+
+    def get_current_connection(self):
+        return self._connection()
+
+
+async def _run_stream(cell, execute_impl, timeout_seconds, kernel):
+    manager = FakeNotebookManager(FakeNotebook(cell, execute_impl))
+    return await ExecuteCellTool().execute(
+        mode=ServerMode.MCP_SERVER,
+        server_client=None,
+        contents_manager=None,
+        kernel_manager=None,
+        kernel_spec_manager=None,
+        notebook_manager=manager,
+        serverapp=None,
+        cell_index=0,
+        timeout_seconds=timeout_seconds,
+        stream=True,
+        progress_interval=1,
+        ensure_kernel_alive_fn=lambda: kernel,
+    )
+
+
+@pytest.mark.asyncio
+async def test_streaming_timeout_leaves_kernel_marked_busy_until_thread_finishes():
+    """Regression for the timeout path abandoning its background thread with no
+    way for anyone to see it is still running."""
+    cell = {"source": "time.sleep(60)", "outputs": []}
+    kernel = FakeKernel()
+
+    await _run_stream(cell, lambda: time.sleep(0.3), timeout_seconds=0, kernel=kernel)
+
+    # The tool already returned its [TIMEOUT ...] result, but the fake
+    # execute_cell is still asleep in its background thread.
+    assert is_kernel_busy(kernel) is True
+
+    await asyncio.sleep(0.5)
+
+    assert is_kernel_busy(kernel) is False
+
+
+@pytest.mark.asyncio
+async def test_wait_for_kernel_idle_blocks_until_orphaned_stream_task_finishes():
+    """The guard every execute_cell/execute_code call makes before starting a
+    new execution must actually wait for a prior timed-out one to finish,
+    not read a kernel object that never reports busy."""
+    cell = {"source": "time.sleep(60)", "outputs": []}
+    kernel = FakeKernel()
+
+    await _run_stream(cell, lambda: time.sleep(0.3), timeout_seconds=0, kernel=kernel)
+
+    start = time.time()
+    await wait_for_kernel_idle(kernel, max_wait_seconds=5)
+    elapsed = time.time() - start
+
+    assert elapsed >= 0.3
+    assert is_kernel_busy(kernel) is False
+
+
+@pytest.mark.asyncio
+async def test_forced_sync_timeout_leaves_kernel_marked_busy_until_thread_finishes():
+    """Same defect, non-streaming path (execute_cell_with_forced_sync)."""
+    cell = {"source": "time.sleep(60)", "outputs": []}
+    notebook = FakeNotebook(cell, lambda: time.sleep(0.3))
+    kernel = FakeKernel()
+
+    with pytest.raises(asyncio.TimeoutError):
+        await execute_cell_with_forced_sync(notebook, 0, kernel, timeout_seconds=0)
+
+    assert is_kernel_busy(kernel) is True
+
+    await asyncio.sleep(0.5)
+
+    assert is_kernel_busy(kernel) is False

--- a/tests/test_execute_orphaned_timeout.py
+++ b/tests/test_execute_orphaned_timeout.py
@@ -90,6 +90,17 @@ async def _run_stream(cell, execute_impl, timeout_seconds, kernel):
     )
 
 
+# The monitoring loops in execute_cell_tool.py and execute_cell_with_forced_sync
+# poll in whole-second (`await asyncio.sleep(1)`) increments, so a timed-out
+# call can easily burn a real second or more of wall clock before the tool
+# returns control to us. The background execute_impl below must sleep long
+# enough to still be running after that overhead on a slow/loaded CI runner,
+# or the orphaned task looks finished by the time we make our first
+# assertion (observed on a macOS runner: elapsed 2e-5s against a 0.3s sleep,
+# https://github.com/datalayer/jupyter-mcp-server/actions/runs/30021842755).
+_ORPHANED_TASK_SLEEP = 2.0
+
+
 @pytest.mark.asyncio
 async def test_streaming_timeout_leaves_kernel_marked_busy_until_thread_finishes():
     """Regression for the timeout path abandoning its background thread with no
@@ -97,13 +108,15 @@ async def test_streaming_timeout_leaves_kernel_marked_busy_until_thread_finishes
     cell = {"source": "time.sleep(60)", "outputs": []}
     kernel = FakeKernel()
 
-    await _run_stream(cell, lambda: time.sleep(0.3), timeout_seconds=0, kernel=kernel)
+    await _run_stream(
+        cell, lambda: time.sleep(_ORPHANED_TASK_SLEEP), timeout_seconds=0, kernel=kernel
+    )
 
     # The tool already returned its [TIMEOUT ...] result, but the fake
     # execute_cell is still asleep in its background thread.
     assert is_kernel_busy(kernel) is True
 
-    await asyncio.sleep(0.5)
+    await asyncio.sleep(_ORPHANED_TASK_SLEEP + 0.5)
 
     assert is_kernel_busy(kernel) is False
 
@@ -116,13 +129,15 @@ async def test_wait_for_kernel_idle_blocks_until_orphaned_stream_task_finishes()
     cell = {"source": "time.sleep(60)", "outputs": []}
     kernel = FakeKernel()
 
-    await _run_stream(cell, lambda: time.sleep(0.3), timeout_seconds=0, kernel=kernel)
+    await _run_stream(
+        cell, lambda: time.sleep(_ORPHANED_TASK_SLEEP), timeout_seconds=0, kernel=kernel
+    )
 
     start = time.time()
-    await wait_for_kernel_idle(kernel, max_wait_seconds=5)
+    await wait_for_kernel_idle(kernel, max_wait_seconds=10)
     elapsed = time.time() - start
 
-    assert elapsed >= 0.3
+    assert elapsed >= 0.5
     assert is_kernel_busy(kernel) is False
 
 
@@ -130,7 +145,7 @@ async def test_wait_for_kernel_idle_blocks_until_orphaned_stream_task_finishes()
 async def test_forced_sync_timeout_leaves_kernel_marked_busy_until_thread_finishes():
     """Same defect, non-streaming path (execute_cell_with_forced_sync)."""
     cell = {"source": "time.sleep(60)", "outputs": []}
-    notebook = FakeNotebook(cell, lambda: time.sleep(0.3))
+    notebook = FakeNotebook(cell, lambda: time.sleep(_ORPHANED_TASK_SLEEP))
     kernel = FakeKernel()
 
     with pytest.raises(asyncio.TimeoutError):
@@ -138,6 +153,6 @@ async def test_forced_sync_timeout_leaves_kernel_marked_busy_until_thread_finish
 
     assert is_kernel_busy(kernel) is True
 
-    await asyncio.sleep(0.5)
+    await asyncio.sleep(_ORPHANED_TASK_SLEEP + 0.5)
 
     assert is_kernel_busy(kernel) is False


### PR DESCRIPTION
### Root cause

`execute_cell` runs `notebook.execute_cell(cell_index, kernel)` in a background task wrapping `asyncio.to_thread(...)` (both the streaming branch in `execute_cell_tool.py` and `execute_cell_with_forced_sync` in `utils.py`). On timeout it calls `.cancel()` and `kernel.interrupt()`, then returns the timeout result without ever awaiting the task.

`asyncio.Task.cancel()` on a task wrapping `asyncio.to_thread()` cannot stop the underlying OS thread once it has started: the cancellation only takes effect at the next `await` inside the coroutine, and the wrapped call has none. The thread keeps running `notebook.execute_cell()`, and keeps mutating the shared notebook/kernel state, after the caller already received a `TimeoutError`.

The intended guard against a second call racing that orphaned execution is `wait_for_kernel_idle()` / `is_kernel_busy()`, called before every `execute_cell`/`execute_code`. `is_kernel_busy()` checked `kernel._client.is_alive()`, but `KernelClient` (`jupyter_kernel_client`) has no `_client` attribute, so it always fell into `except Exception: return False`. It was a silent no-op: a subsequent call never waited for a previous timed-out execution to finish.

### Fix

`track_pending_execution(kernel, task)` (new, in `utils.py`) records the background task on the kernel when it is created, and clears it via a done callback once the task actually finishes, whichever way. `is_kernel_busy()` now reports that task's state instead of the nonexistent `_client` attribute. `wait_for_kernel_idle()` was otherwise unchanged, so it now correctly blocks a subsequent call until a previous timed-out execution finishes, instead of racing it on the same kernel/notebook connection.

### Verified

In a clean `python:3.12-slim` container, editable install, HEAD `d33f0b6`:

- New `tests/test_execute_orphaned_timeout.py` (3 tests, fake kernel/notebook, same style as `tests/test_execute_cell_stream.py`): fail on unfixed `utils.py`/`execute_cell_tool.py` (`is_kernel_busy` stays `False` right after a timeout; `wait_for_kernel_idle` returns in ~0s instead of waiting for the still-running background thread), pass on this branch. `__file__`-checked on both sides to confirm the installed package pointed at the file under test.
- `TEST_MCP_SERVER=true TEST_JUPYTER_SERVER=false pytest` and `TEST_MCP_SERVER=false TEST_JUPYTER_SERVER=true pytest` (the two `make test-*` targets): same pass/fail counts as main plus these 3, no new failures. The pre-existing `test_span_log_summary` failure and the ~55 `JupyterLab failed to start` errors (tests needing a live server) reproduce identically on unmodified main, unrelated to this change.
- `ruff check` / `mypy` on the two changed source files against a pristine `origin/main` worktree already return hundreds of pre-existing findings unrelated to this diff (matches this repo's known `lint.sh` local/CI mismatch); mypy's error count on these two files is identical before and after this change (26), and none of ruff's new findings touch the lines this PR adds.
- Bare-install smoke test from `test.yml` (`pip install .`, import every submodule, `jupyter-mcp-server --help`): clean.

Not verified: a live Jupyter server with a real kernel, end to end. The fake-kernel tests exercise the exact control-flow path (`.cancel()` without awaiting, then a subsequent `is_kernel_busy`/`wait_for_kernel_idle` check) that both call sites share with the real kernel client.

Fixes #307
