### PR TITLE
fix(execute): MCP progress keepalive for long cell runs (#298)

### DIFF
--- a/docs/docs/reference/tools/index.mdx
+++ b/docs/docs/reference/tools/index.mdx
@@ -196,7 +196,7 @@ When `use_notebook` starts a new kernel for a notebook, the kernel is started wi
 - Input:
   - `cell_index`(int): Index of the cell to execute (0-based)
   - `timeout`(int, optional): Maximum seconds to wait for execution (0 = use config default, default: 0). Configurable via `JUPYTER_MCP_EXECUTION_TIMEOUT` env var (default: 120s, max: 3600s via `JUPYTER_MCP_MAX_EXECUTION_TIMEOUT`)
-  - `stream`(bool, optional): Enable streaming progress updates for long-running cells (default: false)
+  - `stream`(bool, optional): Enable streaming progress updates for long-running cells (default: true)
   - `progress_interval`(int, optional): Seconds between MCP progress keepalive updates (and optional stream log lines). Default: 5. Progress is emitted even when `stream=false` so MCP clients do not idle-timeout during long cells.
 - Returns: `list[Union[str, ImageContent]]` - List of outputs from the executed cell including text, HTML, and images. Supports streaming mode with progress updates for long-running cells.
 
@@ -208,7 +208,7 @@ When `use_notebook` starts a new kernel for a notebook, the kernel is started wi
   - `cell_index`(int): Index of the cell to insert and execute (0-based)
   - `cell_source`(string): Code source for the cell
   - `timeout`(int, optional): Maximum seconds to wait for execution (0 = use config default, default: 0). Configurable via `JUPYTER_MCP_EXECUTION_TIMEOUT` env var (default: 120s, max: 3600s)
-  - `stream`(bool, optional): Enable streaming progress updates for long-running cells (default: false)
+  - `stream`(bool, optional): Enable streaming progress updates for long-running cells (default: true)
   - `progress_interval`(int, optional): Seconds between MCP progress keepalive updates (default: 5)
 - Returns: `list[Union[str, ImageContent]]` - List of outputs from the executed cell including text, HTML, and images. Returns both insertion confirmation and execution results.
 

--- a/docs/docs/reference/tools/index.mdx
+++ b/docs/docs/reference/tools/index.mdx
@@ -198,7 +198,7 @@ When `use_notebook` starts a new kernel for a notebook, the kernel is started wi
   - `timeout`(int, optional): Maximum seconds to wait for execution (0 = use config default, default: 0). Configurable via `JUPYTER_MCP_EXECUTION_TIMEOUT` env var (default: 120s, max: 3600s via `JUPYTER_MCP_MAX_EXECUTION_TIMEOUT`)
   - `stream`(bool, optional): Enable streaming progress updates for long-running cells (default: true)
   - `progress_interval`(int, optional): Seconds between MCP progress keepalive updates (and optional stream log lines). Default: 5. Progress is emitted even when `stream=false` so MCP clients do not idle-timeout during long cells.
-- Returns: `list[Union[str, ImageContent]]` - List of outputs from the executed cell including text, HTML, and images. Supports streaming mode with progress updates for long-running cells.
+- Returns: `list[Union[str, ImageContent]]` - List of outputs from the executed cell including text, HTML, and images. With `stream=true` the cell outputs come first, unchanged, followed by timeline entries (`[PROGRESS: ...]`, `[COMPLETED in ...]`, `[TIMEOUT at ...]`).
 
 #### 17. `insert_execute_code_cell`
 
@@ -210,7 +210,7 @@ When `use_notebook` starts a new kernel for a notebook, the kernel is started wi
   - `timeout`(int, optional): Maximum seconds to wait for execution (0 = use config default, default: 0). Configurable via `JUPYTER_MCP_EXECUTION_TIMEOUT` env var (default: 120s, max: 3600s)
   - `stream`(bool, optional): Enable streaming progress updates for long-running cells (default: true)
   - `progress_interval`(int, optional): Seconds between MCP progress keepalive updates (default: 5)
-- Returns: `list[Union[str, ImageContent]]` - List of outputs from the executed cell including text, HTML, and images. Returns both insertion confirmation and execution results.
+- Returns: `list[Union[str, ImageContent]]` - List of outputs from the executed cell including text, HTML, and images. Returns both insertion confirmation and execution results. With `stream=true` the cell outputs come first, unchanged, followed by timeline entries.
 
 #### 18. `read_cell`
 

--- a/docs/docs/reference/tools/index.mdx
+++ b/docs/docs/reference/tools/index.mdx
@@ -195,9 +195,9 @@ When `use_notebook` starts a new kernel for a notebook, the kernel is started wi
 - Execute a cell from the currently activated notebook with timeout and return it's outputs
 - Input:
   - `cell_index`(int): Index of the cell to execute (0-based)
-  - `timeout`(int, optional): Maximum seconds to wait for execution (0 = use config default, default: 0). Configurable via `JUPYTER_MCP_EXECUTION_TIMEOUT` env var (default: 120s, max: 3600s)
+  - `timeout`(int, optional): Maximum seconds to wait for execution (0 = use config default, default: 0). Configurable via `JUPYTER_MCP_EXECUTION_TIMEOUT` env var (default: 120s, max: 3600s via `JUPYTER_MCP_MAX_EXECUTION_TIMEOUT`)
   - `stream`(bool, optional): Enable streaming progress updates for long-running cells (default: false)
-  - `progress_interval`(int, optional): Seconds between progress updates when stream=true (default: 5)
+  - `progress_interval`(int, optional): Seconds between MCP progress keepalive updates (and optional stream log lines). Default: 5. Progress is emitted even when `stream=false` so MCP clients do not idle-timeout during long cells.
 - Returns: `list[Union[str, ImageContent]]` - List of outputs from the executed cell including text, HTML, and images. Supports streaming mode with progress updates for long-running cells.
 
 #### 17. `insert_execute_code_cell`
@@ -208,6 +208,8 @@ When `use_notebook` starts a new kernel for a notebook, the kernel is started wi
   - `cell_index`(int): Index of the cell to insert and execute (0-based)
   - `cell_source`(string): Code source for the cell
   - `timeout`(int, optional): Maximum seconds to wait for execution (0 = use config default, default: 0). Configurable via `JUPYTER_MCP_EXECUTION_TIMEOUT` env var (default: 120s, max: 3600s)
+  - `stream`(bool, optional): Enable streaming progress updates for long-running cells (default: false)
+  - `progress_interval`(int, optional): Seconds between MCP progress keepalive updates (default: 5)
 - Returns: `list[Union[str, ImageContent]]` - List of outputs from the executed cell including text, HTML, and images. Returns both insertion confirmation and execution results.
 
 #### 18. `read_cell`
@@ -252,8 +254,9 @@ When `use_notebook` starts a new kernel for a notebook, the kernel is started wi
   2. Execute dangerous code that may harm the Jupyter server or the user's data without permission
 - Input:
   - `code`(string): Code to execute (supports magic commands with %, shell commands with !)
-  - `timeout`(int, optional): Execution timeout in seconds (default: 30, max: 3600)
+  - `timeout`(int, optional): Execution timeout in seconds (default: 30, 0 = use config default, max via `JUPYTER_MCP_MAX_EXECUTION_TIMEOUT`)
   - `kernel_id`(string, optional): Target an existing kernel by ID. If omitted, the current notebook kernel is used.
+  - `progress_interval`(int, optional): Seconds between MCP progress keepalive updates during long-running execution (default: 5)
 - Returns: `list[Union[str, ImageContent]]` - List of outputs from the executed code including text, HTML, images, and shell command results. Supports magic commands and shell commands with ! prefix. For streaming-capable sandboxes (for example Kaggle batch mode), includes progress/status text emitted during execution.
 
 :::tip

--- a/jupyter_mcp_server/server.py
+++ b/jupyter_mcp_server/server.py
@@ -753,7 +753,7 @@ async def execute_cell(
         Field(
             description="Enable streaming progress (including time indicator) updates for long-running cells"
         ),
-    ] = False,
+    ] = True,
     progress_interval: Annotated[
         int,
         Field(description="Seconds between progress updates (MCP keepalive + optional stream log)"),
@@ -809,7 +809,7 @@ async def insert_execute_code_cell(
         Field(
             description="Enable streaming progress (including time indicator) updates for long-running cells"
         ),
-    ] = False,
+    ] = True,
     progress_interval: Annotated[
         int,
         Field(description="Seconds between progress updates (MCP keepalive + optional stream log)"),

--- a/jupyter_mcp_server/server.py
+++ b/jupyter_mcp_server/server.py
@@ -15,6 +15,7 @@ from code_sandboxes.interfaces import ISandboxClient
 from fastapi import Request
 from mcp.server import FastMCP
 from mcp.server.auth.provider import AccessToken
+from mcp.server.fastmcp import Context
 from mcp.types import ImageContent, ToolAnnotations
 from pydantic import Field
 from starlette.applications import Starlette
@@ -219,6 +220,43 @@ def __ensure_kernel_alive() -> ISandboxClient:
 
     current_notebook = notebook_manager.get_current_notebook() or "default"
     return ensure_kernel_alive(notebook_manager, current_notebook, __create_kernel)
+
+
+def __make_execution_progress_callback(ctx: Context | None):
+    """Build an MCP progress/log keepalive callback for long-running executions.
+
+    Many MCP clients idle-timeout tool calls after a few minutes when the server
+    is silent. ``report_progress`` and ``info`` keep protocol traffic flowing so
+    a long cell (with ``--execution-timeout`` / tool ``timeout`` raised) can
+    finish without the client abandoning the call while notebook outputs still
+    land afterwards (issue #298).
+    """
+
+    async def progress_callback(
+        *,
+        elapsed: float,
+        timeout_seconds: float,
+        output_count: int = 0,
+        message: str | None = None,
+    ):
+        if ctx is None:
+            return
+        msg = message or (
+            f"Execution in progress: {elapsed:.0f}s / {timeout_seconds}s"
+            + (f", {output_count} outputs" if output_count else "")
+        )
+        try:
+            total = float(timeout_seconds) if timeout_seconds else None
+            progress_value = min(elapsed, float(timeout_seconds)) if timeout_seconds else elapsed
+            await ctx.report_progress(progress=progress_value, total=total, message=msg)
+        except Exception:
+            pass
+        try:
+            await ctx.info(msg)
+        except Exception:
+            pass
+
+    return progress_callback
 
 
 ###############################################################################
@@ -717,8 +755,10 @@ async def execute_cell(
         ),
     ] = False,
     progress_interval: Annotated[
-        int, Field(description="Seconds between progress updates when stream=True")
+        int,
+        Field(description="Seconds between progress updates (MCP keepalive + optional stream log)"),
     ] = 5,
+    ctx: Context | None = None,
 ) -> Annotated[
     list[str | ImageContent], Field(description="List of outputs from the executed cell")
 ]:
@@ -728,6 +768,7 @@ async def execute_cell(
     effective_timeout = (
         config.execution_timeout if timeout == 0 else min(timeout, config.max_execution_timeout)
     )
+    progress_callback = __make_execution_progress_callback(ctx)
 
     return await safe_notebook_operation(
         lambda: ExecuteCellTool().execute(
@@ -741,6 +782,7 @@ async def execute_cell(
             stream=stream,
             progress_interval=progress_interval,
             ensure_kernel_alive_fn=__ensure_kernel_alive,
+            progress_callback=progress_callback,
         ),
         max_retries=1,
     )
@@ -762,6 +804,17 @@ async def insert_execute_code_cell(
     timeout: Annotated[
         int, Field(description="Maximum seconds to wait for execution (0 = use config default)")
     ] = 0,
+    stream: Annotated[
+        bool,
+        Field(
+            description="Enable streaming progress (including time indicator) updates for long-running cells"
+        ),
+    ] = False,
+    progress_interval: Annotated[
+        int,
+        Field(description="Seconds between progress updates (MCP keepalive + optional stream log)"),
+    ] = 5,
+    ctx: Context | None = None,
 ) -> Annotated[
     list[str | ImageContent], Field(description="List of outputs from the executed cell")
 ]:
@@ -771,6 +824,7 @@ async def insert_execute_code_cell(
     effective_timeout = (
         config.execution_timeout if timeout == 0 else min(timeout, config.max_execution_timeout)
     )
+    progress_callback = __make_execution_progress_callback(ctx)
 
     insert_result = await safe_notebook_operation(
         lambda: InsertCellTool().execute(
@@ -803,9 +857,10 @@ async def insert_execute_code_cell(
             notebook_manager=notebook_manager,
             cell_index=execute_index,
             timeout_seconds=effective_timeout,
-            stream=False,
-            progress_interval=0,
+            stream=stream,
+            progress_interval=progress_interval,
             ensure_kernel_alive_fn=__ensure_kernel_alive,
+            progress_callback=progress_callback,
         ),
         max_retries=1,
     )
@@ -990,6 +1045,13 @@ async def execute_code(
             description="Target an existing kernel by ID (e.g. a raw kernel with no notebook). If omitted, uses the current notebook's kernel."
         ),
     ] = None,
+    progress_interval: Annotated[
+        int,
+        Field(
+            description="Seconds between MCP progress keepalive updates during long-running execution"
+        ),
+    ] = 5,
+    ctx: Context | None = None,
 ) -> Annotated[
     list[str | ImageContent], Field(description="List of outputs from the executed code")
 ]:
@@ -1019,6 +1081,7 @@ async def execute_code(
     effective_timeout = (
         config.execution_timeout if timeout == 0 else min(timeout, config.max_execution_timeout)
     )
+    progress_callback = __make_execution_progress_callback(ctx)
 
     intercepted = await extension_manager.intercept_execute_code(code, effective_timeout)
     if intercepted is not None:
@@ -1040,6 +1103,8 @@ async def execute_code(
             ensure_kernel_alive_fn=__ensure_kernel_alive,
             wait_for_kernel_idle_fn=wait_for_kernel_idle,
             safe_extract_outputs_fn=safe_extract_outputs,
+            progress_callback=progress_callback,
+            progress_interval=progress_interval,
         ),
         max_retries=1,
     )

--- a/jupyter_mcp_server/tools/execute_cell_tool.py
+++ b/jupyter_mcp_server/tools/execute_cell_tool.py
@@ -24,6 +24,8 @@ from jupyter_mcp_server.utils import (
     safe_extract_outputs,
     wait_for_kernel_idle,
     track_pending_execution,
+    settle_timed_out_execution,
+    emit_execution_progress,
 )
 
 logger = logging.getLogger(__name__)
@@ -223,6 +225,7 @@ class ExecuteCellTool(BaseTool):
         stream: bool = False,
         progress_interval: int = 5,
         ensure_kernel_alive_fn=None,
+        progress_callback=None,
         **kwargs,
     ) -> list[str | ImageContent]:
         """Execute a cell with configurable timeout and optional streaming progress updates.
@@ -235,8 +238,9 @@ class ExecuteCellTool(BaseTool):
             cell_index: Index of the cell to execute (0-based)
             timeout_seconds: Maximum seconds to wait for execution
             stream: Enable streaming progress updates for long-running cells
-            progress_interval: Seconds between progress updates when stream=True
+            progress_interval: Seconds between progress updates (MCP keepalive + stream log)
             ensure_kernel_alive_fn: Function to ensure kernel is alive (MCP_SERVER)
+            progress_callback: Optional async callback for MCP progress/keepalive
 
         Returns:
             List of outputs from the executed cell
@@ -325,6 +329,8 @@ class ExecuteCellTool(BaseTool):
                         document_id=document_id,
                         cell_id=cell_id,
                         timeout=timeout_seconds,
+                        progress_callback=progress_callback,
+                        progress_interval=progress_interval,
                     )
                 except Exception as error:
                     error_text = str(error).lower()
@@ -343,6 +349,8 @@ class ExecuteCellTool(BaseTool):
                             document_id=document_id,
                             cell_id=cell_id,
                             timeout=timeout_seconds,
+                            progress_callback=progress_callback,
+                            progress_interval=progress_interval,
                         )
                     else:
                         raise
@@ -379,6 +387,8 @@ class ExecuteCellTool(BaseTool):
                         timeout=timeout_seconds,
                         raw_outputs=raw_outputs,
                         execution_count_out=execution_count_out,
+                        progress_callback=progress_callback,
+                        progress_interval=progress_interval,
                     )
                 except Exception as error:
                     error_text = str(error).lower()
@@ -399,6 +409,8 @@ class ExecuteCellTool(BaseTool):
                             timeout=timeout_seconds,
                             raw_outputs=raw_outputs,
                             execution_count_out=execution_count_out,
+                            progress_callback=progress_callback,
+                            progress_interval=progress_interval,
                         )
                     else:
                         raise
@@ -452,6 +464,7 @@ class ExecuteCellTool(BaseTool):
 
                     start_time = time.time()
                     last_output_count = 0
+                    last_progress_emit = 0.0
                     timed_out = False
 
                     # Monitor progress
@@ -460,14 +473,14 @@ class ExecuteCellTool(BaseTool):
 
                         # Check timeout
                         if elapsed > timeout_seconds:
-                            execution_task.cancel()
                             timed_out = True
-                            outputs_log.append(f"[TIMEOUT at {elapsed:.1f}s: Cancelling execution]")
+                            outputs_log.append(f"[TIMEOUT at {elapsed:.1f}s: Interrupting execution]")
                             try:
                                 kernel.interrupt()
                                 outputs_log.append("[Sent interrupt signal to kernel]")
                             except Exception:
                                 pass
+                            # Do not cancel execution_task: see settle_timed_out_execution.
                             break
 
                         # Check for new outputs
@@ -487,10 +500,23 @@ class ExecuteCellTool(BaseTool):
                         except Exception as e:
                             outputs_log.append(f"[{elapsed:.1f}s] Error checking outputs: {e}")
 
-                        # Progress update
-                        if int(elapsed) % progress_interval == 0 and elapsed > 0:
+                        # Progress update (tool log + MCP keepalive). Use wall-clock
+                        # gating so we emit once per interval, not on every poll
+                        # where int(elapsed) % interval happens to be 0.
+                        if (
+                            progress_interval > 0
+                            and elapsed > 0
+                            and (elapsed - last_progress_emit) >= progress_interval
+                        ):
+                            last_progress_emit = elapsed
                             outputs_log.append(
                                 f"[PROGRESS: {elapsed:.1f}s elapsed, {last_output_count} outputs so far]"
+                            )
+                            await emit_execution_progress(
+                                progress_callback,
+                                elapsed=elapsed,
+                                timeout_seconds=timeout_seconds,
+                                output_count=last_output_count,
                             )
 
                         await asyncio.sleep(1)
@@ -498,7 +524,22 @@ class ExecuteCellTool(BaseTool):
                     # Get final result. On timeout the task was cancelled above, so
                     # awaiting it would raise CancelledError, which is a BaseException
                     # and is not caught below, discarding the timeout log just built.
-                    if not timed_out:
+                    if timed_out:
+                        await settle_timed_out_execution(execution_task)
+                        try:
+                            final_outputs = notebook[cell_index].get("outputs", [])
+                            if len(final_outputs) > last_output_count:
+                                remaining = final_outputs[last_output_count:]
+                                for output in remaining:
+                                    extracted = extract_output(output)
+                                    if not isinstance(extracted, str):
+                                        outputs_log.append(extracted)
+                                    elif extracted.strip():
+                                        outputs_log.append(extracted)
+                                last_output_count = len(final_outputs)
+                        except Exception as e:
+                            outputs_log.append(f"[ERROR reading post-timeout outputs: {e}]")
+                    else:
                         try:
                             await execution_task
                             final_outputs = notebook[cell_index].get("outputs", [])
@@ -538,7 +579,12 @@ class ExecuteCellTool(BaseTool):
                     try:
                         # Use the forced sync function
                         await execute_cell_with_forced_sync(
-                            notebook, cell_index, kernel, timeout_seconds
+                            notebook,
+                            cell_index,
+                            kernel,
+                            timeout_seconds,
+                            progress_callback=progress_callback,
+                            progress_interval=progress_interval,
                         )
 
                         # Get final outputs
@@ -561,6 +607,10 @@ class ExecuteCellTool(BaseTool):
 
                     except asyncio.TimeoutError as e:
                         logger.error(f"Cell {cell_index} execution timed out: {e}")
+                        # Interrupt already attempted inside execute_cell_with_forced_sync;
+                        # settle so the notebook snapshot matches post-timeout writes.
+                        pending = getattr(kernel, "_mcp_pending_execution", None)
+                        await settle_timed_out_execution(pending)
                         try:
                             if kernel and hasattr(kernel, "interrupt"):
                                 kernel.interrupt()

--- a/jupyter_mcp_server/tools/execute_cell_tool.py
+++ b/jupyter_mcp_server/tools/execute_cell_tool.py
@@ -18,7 +18,6 @@ from jupyter_mcp_server.utils import (
     clean_notebook_outputs,
     execute_cell_with_forced_sync,
     execute_via_execution_stack,
-    extract_output,
     get_current_notebook_context,
     get_jupyter_ydoc,
     safe_extract_outputs,
@@ -454,7 +453,11 @@ class ExecuteCellTool(BaseTool):
                         f"Executing cell {cell_index} in streaming mode (timeout: {timeout_seconds}s, interval: {progress_interval}s)"
                     )
 
-                    outputs_log = []
+                    # Streaming only adds a timeline; the cell's own outputs are
+                    # snapshotted at the end so the response keeps the same shape
+                    # as the non-streaming path (structured outputs first, in
+                    # kernel order), with these log lines appended after them.
+                    timeline: list[str] = []
 
                     # Start execution in background
                     execution_task = asyncio.create_task(
@@ -480,31 +483,30 @@ class ExecuteCellTool(BaseTool):
                         # when elapsed is still 0.0 on a coarse clock tick.
                         if elapsed >= timeout_seconds:
                             timed_out = True
-                            outputs_log.append(f"[TIMEOUT at {elapsed:.1f}s: Interrupting execution]")
+                            timeline.append(f"[TIMEOUT at {elapsed:.1f}s: Interrupting execution]")
                             try:
                                 kernel.interrupt()
-                                outputs_log.append("[Sent interrupt signal to kernel]")
+                                timeline.append("[Sent interrupt signal to kernel]")
                             except Exception:
                                 pass
                             # Do not cancel execution_task: see settle_timed_out_execution.
                             break
 
-                        # Check for new outputs
+                        # Record when new outputs appear. Only the arrival is
+                        # logged: copying the payload here would duplicate it,
+                        # and re-formatting it as a string would drop images.
                         try:
                             current_outputs = notebook[cell_index].get("outputs", [])
                             if len(current_outputs) > last_output_count:
-                                new_outputs = current_outputs[last_output_count:]
-                                for output in new_outputs:
-                                    extracted = extract_output(output)
-                                    if isinstance(extracted, str):
-                                        outputs_log.append(f"[{elapsed:.1f}s] {extracted}")
-                                    else:
-                                        outputs_log.append(f"[{elapsed:.1f}s]")
-                                        outputs_log.append(extracted)
+                                new_count = len(current_outputs) - last_output_count
                                 last_output_count = len(current_outputs)
+                                timeline.append(
+                                    f"[{elapsed:.1f}s] {new_count} new output(s), "
+                                    f"{last_output_count} total"
+                                )
 
                         except Exception as e:
-                            outputs_log.append(f"[{elapsed:.1f}s] Error checking outputs: {e}")
+                            timeline.append(f"[{elapsed:.1f}s] Error checking outputs: {e}")
 
                         # Progress update (tool log + MCP keepalive). Use wall-clock
                         # gating so we emit once per interval, not on every poll
@@ -515,7 +517,7 @@ class ExecuteCellTool(BaseTool):
                             and (elapsed - last_progress_emit) >= progress_interval
                         ):
                             last_progress_emit = elapsed
-                            outputs_log.append(
+                            timeline.append(
                                 f"[PROGRESS: {elapsed:.1f}s elapsed, {last_output_count} outputs so far]"
                             )
                             await emit_execution_progress(
@@ -530,44 +532,30 @@ class ExecuteCellTool(BaseTool):
                         remaining = timeout_seconds - elapsed
                         await asyncio.sleep(min(1.0, max(remaining, 0.0)))
 
-                    # Get final result. On timeout the task was cancelled above, so
-                    # awaiting it would raise CancelledError, which is a BaseException
-                    # and is not caught below, discarding the timeout log just built.
+                    # Wait for the execution to settle before snapshotting. On
+                    # timeout the task is not cancelled (see
+                    # settle_timed_out_execution), so awaiting it directly would
+                    # block for the full cell.
                     if timed_out:
                         await settle_timed_out_execution(execution_task)
-                        try:
-                            final_outputs = notebook[cell_index].get("outputs", [])
-                            if len(final_outputs) > last_output_count:
-                                remaining = final_outputs[last_output_count:]
-                                for output in remaining:
-                                    extracted = extract_output(output)
-                                    if not isinstance(extracted, str):
-                                        outputs_log.append(extracted)
-                                    elif extracted.strip():
-                                        outputs_log.append(extracted)
-                                last_output_count = len(final_outputs)
-                        except Exception as e:
-                            outputs_log.append(f"[ERROR reading post-timeout outputs: {e}]")
                     else:
                         try:
                             await execution_task
-                            final_outputs = notebook[cell_index].get("outputs", [])
-                            outputs_log.append(f"[COMPLETED in {time.perf_counter() - start_time:.1f}s]")
-
-                            # Add any final outputs not captured during monitoring
-                            if len(final_outputs) > last_output_count:
-                                remaining = final_outputs[last_output_count:]
-                                for output in remaining:
-                                    extracted = extract_output(output)
-                                    if not isinstance(extracted, str):
-                                        outputs_log.append(extracted)
-                                    elif extracted.strip():
-                                        outputs_log.append(extracted)
-
+                            timeline.append(
+                                f"[COMPLETED in {time.perf_counter() - start_time:.1f}s]"
+                            )
                         except Exception as e:
-                            outputs_log.append(f"[ERROR: {e}]")
+                            timeline.append(f"[ERROR: {e}]")
 
-                    result = outputs_log if outputs_log else ["[No output generated]"]
+                    # Same extraction as the non-streaming path, so streaming
+                    # does not change the outputs a client receives.
+                    try:
+                        outputs = safe_extract_outputs(notebook[cell_index].get("outputs", []))
+                    except Exception as e:
+                        outputs = []
+                        timeline.append(f"[ERROR reading outputs: {e}]")
+
+                    result = (outputs + timeline) or ["[No output generated]"]
                     await hooks.fire(
                         HookEvent.AFTER_EXECUTE,
                         code=cell_source,
@@ -616,16 +604,10 @@ class ExecuteCellTool(BaseTool):
 
                     except asyncio.TimeoutError as e:
                         logger.error(f"Cell {cell_index} execution timed out: {e}")
-                        # Interrupt already attempted inside execute_cell_with_forced_sync;
-                        # settle so the notebook snapshot matches post-timeout writes.
-                        pending = getattr(kernel, "_mcp_pending_execution", None)
-                        await settle_timed_out_execution(pending)
-                        try:
-                            if kernel and hasattr(kernel, "interrupt"):
-                                kernel.interrupt()
-                                logger.info("Sent interrupt signal to kernel")
-                        except Exception as interrupt_err:
-                            logger.error(f"Failed to interrupt kernel: {interrupt_err}")
+                        # execute_cell_with_forced_sync already interrupted the
+                        # kernel and awaited the settle window before raising.
+                        # Repeating either here interrupts the kernel twice and
+                        # doubles the time the tool call takes to return.
 
                         # Return partial outputs if available
                         try:

--- a/jupyter_mcp_server/tools/execute_cell_tool.py
+++ b/jupyter_mcp_server/tools/execute_cell_tool.py
@@ -462,17 +462,23 @@ class ExecuteCellTool(BaseTool):
                     )
                     track_pending_execution(kernel, execution_task)
 
-                    start_time = time.time()
+                    # perf_counter: high-res and monotonic. time.time() on Windows
+                    # (esp. older CPython) can return the same value twice, so
+                    # elapsed stays 0 and ``elapsed > 0`` misses an immediate
+                    # timeout; the 1s poll then lets a short cell finish as
+                    # COMPLETED instead of TIMEOUT (CI: windows-latest, 3.10).
+                    start_time = time.perf_counter()
                     last_output_count = 0
                     last_progress_emit = 0.0
                     timed_out = False
 
                     # Monitor progress
                     while not execution_task.done():
-                        elapsed = time.time() - start_time
+                        elapsed = time.perf_counter() - start_time
 
-                        # Check timeout
-                        if elapsed > timeout_seconds:
+                        # >= so timeout_seconds=0 means immediate timeout even
+                        # when elapsed is still 0.0 on a coarse clock tick.
+                        if elapsed >= timeout_seconds:
                             timed_out = True
                             outputs_log.append(f"[TIMEOUT at {elapsed:.1f}s: Interrupting execution]")
                             try:
@@ -519,7 +525,10 @@ class ExecuteCellTool(BaseTool):
                                 output_count=last_output_count,
                             )
 
-                        await asyncio.sleep(1)
+                        # Do not sleep past the remaining timeout budget (short
+                        # timeouts used to wait a full second before re-check).
+                        remaining = timeout_seconds - elapsed
+                        await asyncio.sleep(min(1.0, max(remaining, 0.0)))
 
                     # Get final result. On timeout the task was cancelled above, so
                     # awaiting it would raise CancelledError, which is a BaseException
@@ -543,7 +552,7 @@ class ExecuteCellTool(BaseTool):
                         try:
                             await execution_task
                             final_outputs = notebook[cell_index].get("outputs", [])
-                            outputs_log.append(f"[COMPLETED in {time.time() - start_time:.1f}s]")
+                            outputs_log.append(f"[COMPLETED in {time.perf_counter() - start_time:.1f}s]")
 
                             # Add any final outputs not captured during monitoring
                             if len(final_outputs) > last_output_count:

--- a/jupyter_mcp_server/tools/execute_code_tool.py
+++ b/jupyter_mcp_server/tools/execute_code_tool.py
@@ -15,7 +15,11 @@ from mcp.types import ImageContent
 from jupyter_mcp_server.hooks import HookEvent, HookRegistry
 from jupyter_mcp_server.notebook_manager import NotebookManager
 from jupyter_mcp_server.tools._base import BaseTool, ServerMode
-from jupyter_mcp_server.utils import track_pending_execution
+from jupyter_mcp_server.utils import (
+    emit_execution_progress,
+    settle_timed_out_execution,
+    track_pending_execution,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -97,6 +101,8 @@ class ExecuteCodeTool(BaseTool):
         safe_extract_outputs_fn,
         kernel_id: str = None,
         server_client=None,
+        progress_callback=None,
+        progress_interval: int = 5,
     ) -> list[str | ImageContent]:
         """Execute code using notebook_manager (MCP_SERVER mode - original logic).
 
@@ -141,6 +147,8 @@ class ExecuteCodeTool(BaseTool):
                 timeout=timeout,
                 wait_for_kernel_idle_fn=wait_for_kernel_idle_fn,
                 safe_extract_outputs_fn=safe_extract_outputs_fn,
+                progress_callback=progress_callback,
+                progress_interval=progress_interval,
             )
         finally:
             if borrowed_sandbox is not None:
@@ -157,6 +165,8 @@ class ExecuteCodeTool(BaseTool):
         timeout: int,
         wait_for_kernel_idle_fn,
         safe_extract_outputs_fn,
+        progress_callback=None,
+        progress_interval: int = 5,
     ) -> list[str | ImageContent]:
         """Run code on an already-resolved sandbox client (MCP_SERVER mode)."""
         # Wait for kernel to be idle before executing
@@ -173,44 +183,54 @@ class ExecuteCodeTool(BaseTool):
         )
 
         try:
-            # Execute code directly with kernel
             execution_task = asyncio.create_task(asyncio.to_thread(sandbox_client.execute, code))
             track_pending_execution(sandbox_client, execution_task)
 
-            # asyncio.wait_for() would also work for the happy path, but on
-            # timeout it cancels the task and then awaits it until asyncio
-            # settles it as done -- which happens immediately even though
-            # the underlying OS thread (started via to_thread) keeps running
-            # kernel.execute() in the background, since the wrapping Future
-            # can be marked cancelled without the thread actually stopping.
-            # That makes execution_task.done() report True right away,
-            # defeating track_pending_execution above. asyncio.wait() does
-            # not auto-cancel, so leaving the task un-awaited past cancel()
-            # below keeps it accurately pending until the real thread returns.
-            _, pending = await asyncio.wait({execution_task}, timeout=timeout)
+            start_time = asyncio.get_event_loop().time()
+            last_progress_emit = 0.0
 
-            if execution_task in pending:
-                execution_task.cancel()
-                try:
-                    if sandbox_client and hasattr(sandbox_client, "interrupt"):
-                        sandbox_client.interrupt()
-                        logger.info("Sent interrupt signal to kernel due to timeout")
-                except Exception as interrupt_err:
-                    logger.error(f"Failed to interrupt kernel: {interrupt_err}")
+            # Wait for execution with timeout, emitting MCP keepalive progress
+            # so clients do not idle-timeout on long-running cells.
+            while not execution_task.done():
+                elapsed = asyncio.get_event_loop().time() - start_time
+                if elapsed > timeout:
+                    try:
+                        if sandbox_client and hasattr(sandbox_client, "interrupt"):
+                            sandbox_client.interrupt()
+                            logger.info("Sent interrupt signal to kernel due to timeout")
+                    except Exception as interrupt_err:
+                        logger.error(f"Failed to interrupt kernel: {interrupt_err}")
+                    # Do not cancel execution_task: see settle_timed_out_execution.
+                    await settle_timed_out_execution(execution_task)
+                    result = [
+                        f"[TIMEOUT ERROR: IPython execution exceeded {timeout} seconds and was interrupted]"
+                    ]
+                    await hooks.fire(
+                        HookEvent.AFTER_EXECUTE,
+                        code=code,
+                        kernel_id=kid,
+                        metadata={},
+                        outputs=result,
+                        error=asyncio.TimeoutError(),
+                        context=hook_ctx,
+                    )
+                    return result
 
-                result = [
-                    f"[TIMEOUT ERROR: IPython execution exceeded {timeout} seconds and was interrupted]"
-                ]
-                await hooks.fire(
-                    HookEvent.AFTER_EXECUTE,
-                    code=code,
-                    kernel_id=kid,
-                    metadata={},
-                    outputs=result,
-                    error=asyncio.TimeoutError(),
-                    context=hook_ctx,
+                if (
+                    progress_interval > 0
+                    and elapsed > 0
+                    and (elapsed - last_progress_emit) >= progress_interval
+                ):
+                    last_progress_emit = elapsed
+                    await emit_execution_progress(
+                        progress_callback,
+                        elapsed=elapsed,
+                        timeout_seconds=timeout,
+                    )
+
+                await asyncio.sleep(
+                    min(1.0, max(0.05, progress_interval / 5 if progress_interval else 1.0))
                 )
-                return result
 
             outputs = execution_task.result()
 
@@ -260,6 +280,8 @@ class ExecuteCodeTool(BaseTool):
         ensure_kernel_alive_fn=None,
         wait_for_kernel_idle_fn=None,
         safe_extract_outputs_fn=None,
+        progress_callback=None,
+        progress_interval: int = 5,
         **kwargs,
     ) -> list[str | ImageContent]:
         """Execute IPython code directly in the kernel.
@@ -277,6 +299,8 @@ class ExecuteCodeTool(BaseTool):
             ensure_kernel_alive_fn: Function to ensure kernel is alive (for MCP_SERVER mode)
             wait_for_kernel_idle_fn: Function to wait for kernel idle state (for MCP_SERVER mode)
             safe_extract_outputs_fn: Function to safely extract outputs
+            progress_callback: Optional async callback for MCP progress/keepalive
+            progress_interval: Seconds between progress callback invocations
 
         Returns:
             List of outputs from the executed code
@@ -336,6 +360,8 @@ class ExecuteCodeTool(BaseTool):
                 safe_extract_outputs_fn=safe_extract_outputs_fn,
                 kernel_id=kernel_id,
                 server_client=server_client,
+                progress_callback=progress_callback,
+                progress_interval=progress_interval,
             )
 
         else:

--- a/jupyter_mcp_server/tools/execute_code_tool.py
+++ b/jupyter_mcp_server/tools/execute_code_tool.py
@@ -191,9 +191,10 @@ class ExecuteCodeTool(BaseTool):
 
             # Wait for execution with timeout, emitting MCP keepalive progress
             # so clients do not idle-timeout on long-running cells.
+            # Use >= so timeout=0 is an immediate timeout even if elapsed is 0.
             while not execution_task.done():
                 elapsed = asyncio.get_event_loop().time() - start_time
-                if elapsed > timeout:
+                if elapsed >= timeout:
                     try:
                         if sandbox_client and hasattr(sandbox_client, "interrupt"):
                             sandbox_client.interrupt()
@@ -228,9 +229,9 @@ class ExecuteCodeTool(BaseTool):
                         timeout_seconds=timeout,
                     )
 
-                await asyncio.sleep(
-                    min(1.0, max(0.05, progress_interval / 5 if progress_interval else 1.0))
-                )
+                remaining = timeout - elapsed
+                poll = min(1.0, max(0.05, progress_interval / 5 if progress_interval else 1.0))
+                await asyncio.sleep(min(poll, max(remaining, 0.0)))
 
             outputs = execution_task.result()
 

--- a/jupyter_mcp_server/utils.py
+++ b/jupyter_mcp_server/utils.py
@@ -723,7 +723,8 @@ async def execute_cell_with_forced_sync(
     """Execute cell with forced real-time synchronization."""
     from jupyter_mcp_server.log import logger
 
-    start_time = time.time()
+    # High-res monotonic clock: see execute_cell_tool streaming monitor.
+    start_time = time.perf_counter()
 
     # Start execution
     execution_future = asyncio.create_task(
@@ -735,9 +736,9 @@ async def execute_cell_with_forced_sync(
     last_progress_emit = 0.0
 
     while not execution_future.done():
-        elapsed = time.time() - start_time
+        elapsed = time.perf_counter() - start_time
 
-        if elapsed > timeout_seconds:
+        if elapsed >= timeout_seconds:
             try:
                 if hasattr(kernel, "interrupt"):
                     kernel.interrupt()
@@ -794,7 +795,8 @@ async def execute_cell_with_forced_sync(
                 output_count=last_output_count,
             )
 
-        await asyncio.sleep(1)  # Check every second
+        remaining = timeout_seconds - elapsed
+        await asyncio.sleep(min(1.0, max(remaining, 0.0)))
 
     # Get final result
     try:

--- a/jupyter_mcp_server/utils.py
+++ b/jupyter_mcp_server/utils.py
@@ -658,7 +658,68 @@ def track_pending_execution(kernel, task):
     task.add_done_callback(_clear)
 
 
-async def execute_cell_with_forced_sync(notebook, cell_index, kernel, timeout_seconds=300):
+# After a timeout + interrupt, the background to_thread work can still mutate
+# notebook outputs for a short window. Wait briefly before snapshotting so the
+# tool response matches what lands in the notebook (issue #298).
+TIMEOUT_OUTPUT_SETTLE_SECONDS = 1.0
+
+
+async def settle_timed_out_execution(
+    execution_task,
+    settle_seconds: float = TIMEOUT_OUTPUT_SETTLE_SECONDS,
+):
+    """Briefly await a still-running background execution before reading outputs.
+
+    Callers should interrupt the kernel first and must not cancel the asyncio
+    Task beforehand: cancelling a Task wrapping ``asyncio.to_thread`` marks the
+    Task done without stopping the OS thread, which clears
+    ``track_pending_execution`` and makes this settle a no-op.
+
+    Uses ``asyncio.shield`` so a settle timeout does not cancel the underlying
+    Task either (``wait_for`` would otherwise cancel it and clear the busy flag).
+    """
+    if execution_task is None or execution_task.done():
+        return
+    try:
+        await asyncio.wait_for(asyncio.shield(execution_task), timeout=settle_seconds)
+    except (asyncio.TimeoutError, asyncio.CancelledError):
+        pass
+    except Exception:
+        pass
+
+
+async def emit_execution_progress(
+    progress_callback,
+    *,
+    elapsed: float,
+    timeout_seconds: float,
+    output_count: int = 0,
+    message: str | None = None,
+):
+    """Invoke an optional progress callback; never let callback errors abort execution."""
+    if progress_callback is None:
+        return
+    try:
+        await progress_callback(
+            elapsed=elapsed,
+            timeout_seconds=timeout_seconds,
+            output_count=output_count,
+            message=message,
+        )
+    except Exception as e:
+        from jupyter_mcp_server.log import logger
+
+        logger.debug(f"Execution progress callback failed: {e}")
+
+
+async def execute_cell_with_forced_sync(
+    notebook,
+    cell_index,
+    kernel,
+    timeout_seconds=300,
+    progress_callback=None,
+    progress_interval: int = 5,
+):
     """Execute cell with forced real-time synchronization."""
     from jupyter_mcp_server.log import logger
 
@@ -671,17 +732,22 @@ async def execute_cell_with_forced_sync(notebook, cell_index, kernel, timeout_se
     track_pending_execution(kernel, execution_future)
 
     last_output_count = 0
+    last_progress_emit = 0.0
 
     while not execution_future.done():
         elapsed = time.time() - start_time
 
         if elapsed > timeout_seconds:
-            execution_future.cancel()
             try:
                 if hasattr(kernel, "interrupt"):
                     kernel.interrupt()
             except Exception:
                 pass
+            # Do not cancel the asyncio Task: cancel completes the wrapper
+            # without stopping the OS thread, which clears
+            # track_pending_execution early and skips real notebook settles.
+            # Interrupt the kernel, briefly wait for the thread, then raise.
+            await settle_timed_out_execution(execution_future)
             raise asyncio.TimeoutError(f"Cell execution timed out after {timeout_seconds} seconds")
 
         # Check for new outputs and try to trigger sync
@@ -712,6 +778,21 @@ async def execute_cell_with_forced_sync(notebook, cell_index, kernel, timeout_se
 
         except Exception as e:
             logger.debug(f"Output check failed: {e}")
+
+        # MCP clients often idle-timeout around a few minutes with no protocol
+        # traffic. Emit keepalive progress even when stream=False.
+        if (
+            progress_interval > 0
+            and elapsed > 0
+            and (elapsed - last_progress_emit) >= progress_interval
+        ):
+            last_progress_emit = elapsed
+            await emit_execution_progress(
+                progress_callback,
+                elapsed=elapsed,
+                timeout_seconds=timeout_seconds,
+                output_count=last_output_count,
+            )
 
         await asyncio.sleep(1)  # Check every second
 
@@ -800,6 +881,8 @@ async def execute_via_execution_stack(
     logger=None,
     raw_outputs: list | None = None,
     execution_count_out: list | None = None,
+    progress_callback=None,
+    progress_interval: int = 5,
 ) -> list[str | ImageContent]:
     """Execute code using ExecutionStack (JUPYTER_SERVER mode with jupyter-server-nbmodel).
 
@@ -825,6 +908,8 @@ async def execute_via_execution_stack(
             reply execution_count is appended to it (once), so callers that
             persist the cell to disk can use the kernel's real counter instead
             of re-deriving it by scanning the notebook's existing cells.
+        progress_callback: Optional async callback for MCP progress/keepalive
+        progress_interval: Seconds between progress callback invocations
 
     Returns:
         List of formatted outputs (strings or ImageContent)
@@ -872,6 +957,7 @@ async def execute_via_execution_stack(
         # The try/except ensures we cancel the kernel execution on any
         # abnormal exit.
         start_time = asyncio.get_event_loop().time()
+        last_progress_emit = 0.0
         try:
             while True:
                 elapsed = asyncio.get_event_loop().time() - start_time
@@ -957,6 +1043,18 @@ async def execute_via_execution_stack(
                         context=hook_ctx,
                     )
                     return formatted if formatted else ["[No output generated]"]
+
+                if (
+                    progress_interval > 0
+                    and elapsed > 0
+                    and (elapsed - last_progress_emit) >= progress_interval
+                ):
+                    last_progress_emit = elapsed
+                    await emit_execution_progress(
+                        progress_callback,
+                        elapsed=elapsed,
+                        timeout_seconds=timeout,
+                    )
 
                 # Still pending, wait before next poll
                 await asyncio.sleep(poll_interval)

--- a/tests/test_execute_orphaned_timeout.py
+++ b/tests/test_execute_orphaned_timeout.py
@@ -93,12 +93,13 @@ async def _run_stream(cell, execute_impl, timeout_seconds, kernel):
 # The monitoring loops in execute_cell_tool.py and execute_cell_with_forced_sync
 # poll in whole-second (`await asyncio.sleep(1)`) increments, so a timed-out
 # call can easily burn a real second or more of wall clock before the tool
-# returns control to us. The background execute_impl below must sleep long
-# enough to still be running after that overhead on a slow/loaded CI runner,
-# or the orphaned task looks finished by the time we make our first
+# returns control to us. After timeout we also briefly settle (about 1s) so
+# notebook outputs can catch up. The background execute_impl below must sleep
+# long enough to still be running after that overhead on a slow/loaded CI
+# runner, or the orphaned task looks finished by the time we make our first
 # assertion (observed on a macOS runner: elapsed 2e-5s against a 0.3s sleep,
 # https://github.com/datalayer/jupyter-mcp-server/actions/runs/30021842755).
-_ORPHANED_TASK_SLEEP = 2.0
+_ORPHANED_TASK_SLEEP = 3.0
 
 
 @pytest.mark.asyncio

--- a/tests/test_execute_orphaned_timeout.py
+++ b/tests/test_execute_orphaned_timeout.py
@@ -32,9 +32,11 @@ class FakeKernel:
 
     def __init__(self):
         self.interrupted = False
+        self.interrupt_count = 0
 
     def interrupt(self):
         self.interrupted = True
+        self.interrupt_count += 1
 
 
 class FakeNotebook:
@@ -140,6 +142,50 @@ async def test_wait_for_kernel_idle_blocks_until_orphaned_stream_task_finishes()
 
     assert elapsed >= 0.5
     assert is_kernel_busy(kernel) is False
+
+
+@pytest.mark.asyncio
+async def test_non_stream_timeout_interrupts_kernel_once():
+    """execute_cell_with_forced_sync interrupts the kernel and awaits the settle
+    window itself before raising TimeoutError. The tool's except block used to
+    repeat both, so a timed-out call interrupted twice and waited two settle
+    windows instead of the single one TIMEOUT_OUTPUT_SETTLE_SECONDS implies.
+    Reported by @AmirF194 in review of #309."""
+    cell = {"source": "time.sleep(60)", "outputs": []}
+    kernel = FakeKernel()
+    manager = FakeNotebookManager(
+        FakeNotebook(cell, lambda: time.sleep(_ORPHANED_TASK_SLEEP))
+    )
+
+    result = await ExecuteCellTool().execute(
+        mode=ServerMode.MCP_SERVER,
+        notebook_manager=manager,
+        cell_index=0,
+        timeout_seconds=0,
+        stream=False,
+        progress_interval=1,
+        ensure_kernel_alive_fn=lambda: kernel,
+    )
+
+    assert kernel.interrupt_count == 1, (
+        f"timeout path should interrupt once, got {kernel.interrupt_count}"
+    )
+    assert any(
+        isinstance(entry, str) and "[TIMEOUT ERROR" in entry for entry in result
+    ), f"expected a timeout marker in the result, got {result!r}"
+
+
+@pytest.mark.asyncio
+async def test_stream_timeout_interrupts_kernel_once():
+    """The streaming branch owns its own interrupt; it must not double up either."""
+    cell = {"source": "time.sleep(60)", "outputs": []}
+    kernel = FakeKernel()
+
+    await _run_stream(
+        cell, lambda: time.sleep(_ORPHANED_TASK_SLEEP), timeout_seconds=0, kernel=kernel
+    )
+
+    assert kernel.interrupt_count == 1
 
 
 @pytest.mark.asyncio

--- a/tests/test_execute_progress_keepalive.py
+++ b/tests/test_execute_progress_keepalive.py
@@ -142,12 +142,18 @@ async def test_forced_sync_path_emits_progress_callback_during_long_cell():
 async def test_timeout_settle_includes_late_notebook_output_in_stream_result():
     """After timeout, settle briefly so outputs that land in the notebook are
     included in the tool response instead of appearing only as stray notebook
-    writes after the client already timed out."""
+    writes after the client already timed out.
+
+    timeout_seconds=0 must fire on the first monitor poll even when elapsed is
+    still 0.0 (Windows time.time() coarse ticks used to miss ``elapsed > 0``,
+    sleep a full second, and let a short background cell finish as COMPLETED).
+    """
     cell = {"source": "time.sleep(60)", "outputs": []}
     kernel = FakeKernel()
 
     def execute_impl():
         # Land an output shortly after the tool hits timeout_seconds=0.
+        # Must finish within TIMEOUT_OUTPUT_SETTLE_SECONDS (~1s).
         time.sleep(0.3)
         cell["outputs"] = [
             {"output_type": "stream", "name": "stdout", "text": "late-output\n"}
@@ -169,6 +175,45 @@ async def test_timeout_settle_includes_late_notebook_output_in_stream_result():
         isinstance(entry, str) and "late-output" in entry for entry in result
     ), f"expected settled notebook output in tool result, got {result!r}"
     assert cell["outputs"], "notebook cell should still hold the late output"
+
+
+@pytest.mark.asyncio
+async def test_immediate_timeout_with_frozen_perf_counter(monkeypatch):
+    """Regression: timeout_seconds=0 must interrupt even if the elapsed clock
+    never advances (same value returned twice), which is how Windows coarse
+    time.time() made the settle test flake on CI (3.10)."""
+    cell = {"source": "time.sleep(60)", "outputs": []}
+    kernel = FakeKernel()
+    frozen = {"t": 1000.0}
+
+    def frozen_perf_counter():
+        return frozen["t"]
+
+    monkeypatch.setattr(time, "perf_counter", frozen_perf_counter)
+
+    def execute_impl():
+        time.sleep(0.3)
+        cell["outputs"] = [
+            {"output_type": "stream", "name": "stdout", "text": "late-output\n"}
+        ]
+
+    manager = FakeNotebookManager(FakeNotebook(cell, execute_impl))
+    result = await ExecuteCellTool().execute(
+        mode=ServerMode.MCP_SERVER,
+        notebook_manager=manager,
+        cell_index=0,
+        timeout_seconds=0,
+        stream=True,
+        progress_interval=1,
+        ensure_kernel_alive_fn=lambda: kernel,
+    )
+
+    assert any("[TIMEOUT at" in entry for entry in result if isinstance(entry, str)), (
+        f"expected TIMEOUT with frozen clock, got {result!r}"
+    )
+    assert any(
+        isinstance(entry, str) and "late-output" in entry for entry in result
+    ), f"expected settled notebook output in tool result, got {result!r}"
 
 
 @pytest.mark.asyncio

--- a/tests/test_execute_progress_keepalive.py
+++ b/tests/test_execute_progress_keepalive.py
@@ -1,0 +1,197 @@
+# Copyright (c) 2024- Datalayer, Inc.
+#
+# BSD 3-Clause License
+
+"""Regression tests for long-running cell MCP progress keepalive (issue #298).
+
+MCP clients often idle-timeout around a few minutes when a tool call is silent.
+Raising ``--execution-timeout`` alone does not emit protocol traffic. These
+tests assert that execute_cell (stream and non-stream) and execute_code invoke
+the progress callback while a long cell is still running, and that a timed-out
+stream path snapshots notebook outputs that land during the short settle window.
+"""
+
+import contextlib
+import time
+
+import pytest
+
+from jupyter_mcp_server.tools._base import ServerMode
+from jupyter_mcp_server.tools.execute_cell_tool import ExecuteCellTool
+from jupyter_mcp_server.tools.execute_code_tool import ExecuteCodeTool
+from jupyter_mcp_server.utils import execute_cell_with_forced_sync
+
+
+class FakeKernel:
+    def __init__(self):
+        self.interrupted = False
+
+    def interrupt(self):
+        self.interrupted = True
+
+    def execute(self, code):
+        time.sleep(2.2)
+        return {"outputs": [{"output_type": "stream", "name": "stdout", "text": "done\n"}]}
+
+
+class FakeNotebook:
+    def __init__(self, cell, execute_impl):
+        self._cell = cell
+        self._execute_impl = execute_impl
+
+    def __len__(self):
+        return 1
+
+    def __getitem__(self, index):
+        return self._cell
+
+    def execute_cell(self, cell_index, kernel):
+        return self._execute_impl()
+
+
+class FakeNotebookManager:
+    def __init__(self, notebook, kernel=None):
+        self._notebook = notebook
+        self._kernel = kernel
+
+    def get_current_notebook(self):
+        return "default"
+
+    def get_kernel_id(self, notebook_name):
+        return "kernel-1"
+
+    def get_kernel(self, notebook_name):
+        return self._kernel
+
+    @contextlib.asynccontextmanager
+    async def _connection(self):
+        yield self._notebook
+
+    def get_current_connection(self):
+        return self._connection()
+
+
+class ProgressRecorder:
+    def __init__(self):
+        self.events = []
+
+    async def __call__(self, *, elapsed, timeout_seconds, output_count=0, message=None):
+        self.events.append(
+            {
+                "elapsed": elapsed,
+                "timeout_seconds": timeout_seconds,
+                "output_count": output_count,
+                "message": message,
+            }
+        )
+
+
+@pytest.mark.asyncio
+async def test_stream_path_emits_progress_callback_during_long_cell():
+    """Long streaming execute_cell must call progress_callback before completion."""
+    cell = {"source": "time.sleep(3)", "outputs": []}
+    kernel = FakeKernel()
+    progress = ProgressRecorder()
+
+    def execute_impl():
+        time.sleep(2.2)
+        cell["outputs"] = [
+            {"output_type": "stream", "name": "stdout", "text": "hello\n"}
+        ]
+
+    manager = FakeNotebookManager(FakeNotebook(cell, execute_impl))
+    result = await ExecuteCellTool().execute(
+        mode=ServerMode.MCP_SERVER,
+        notebook_manager=manager,
+        cell_index=0,
+        timeout_seconds=30,
+        stream=True,
+        progress_interval=1,
+        ensure_kernel_alive_fn=lambda: kernel,
+        progress_callback=progress,
+    )
+
+    assert progress.events, "expected at least one MCP progress keepalive event"
+    assert all(event["elapsed"] > 0 for event in progress.events)
+    assert any("[COMPLETED" in entry for entry in result if isinstance(entry, str))
+    assert any("[PROGRESS:" in entry for entry in result if isinstance(entry, str))
+
+
+@pytest.mark.asyncio
+async def test_forced_sync_path_emits_progress_callback_during_long_cell():
+    """Non-stream execute_cell (forced sync) must also emit keepalive progress."""
+    cell = {"source": "time.sleep(3)", "outputs": []}
+    notebook = FakeNotebook(cell, lambda: time.sleep(2.2))
+    kernel = FakeKernel()
+    progress = ProgressRecorder()
+
+    await execute_cell_with_forced_sync(
+        notebook,
+        0,
+        kernel,
+        timeout_seconds=30,
+        progress_callback=progress,
+        progress_interval=1,
+    )
+
+    assert progress.events, "expected progress keepalive on the non-stream path"
+    assert progress.events[0]["timeout_seconds"] == 30
+
+
+@pytest.mark.asyncio
+async def test_timeout_settle_includes_late_notebook_output_in_stream_result():
+    """After timeout, settle briefly so outputs that land in the notebook are
+    included in the tool response instead of appearing only as stray notebook
+    writes after the client already timed out."""
+    cell = {"source": "time.sleep(60)", "outputs": []}
+    kernel = FakeKernel()
+
+    def execute_impl():
+        # Land an output shortly after the tool hits timeout_seconds=0.
+        time.sleep(0.3)
+        cell["outputs"] = [
+            {"output_type": "stream", "name": "stdout", "text": "late-output\n"}
+        ]
+
+    manager = FakeNotebookManager(FakeNotebook(cell, execute_impl))
+    result = await ExecuteCellTool().execute(
+        mode=ServerMode.MCP_SERVER,
+        notebook_manager=manager,
+        cell_index=0,
+        timeout_seconds=0,
+        stream=True,
+        progress_interval=1,
+        ensure_kernel_alive_fn=lambda: kernel,
+    )
+
+    assert any("[TIMEOUT at" in entry for entry in result if isinstance(entry, str))
+    assert any(
+        isinstance(entry, str) and "late-output" in entry for entry in result
+    ), f"expected settled notebook output in tool result, got {result!r}"
+    assert cell["outputs"], "notebook cell should still hold the late output"
+
+
+@pytest.mark.asyncio
+async def test_execute_code_emits_progress_callback_during_long_run():
+    """execute_code sibling path must emit keepalive progress too."""
+    kernel = FakeKernel()
+    progress = ProgressRecorder()
+    manager = FakeNotebookManager(FakeNotebook({"source": "", "outputs": []}, lambda: None), kernel=kernel)
+
+    async def wait_idle(kernel, max_wait_seconds=30):
+        return None
+
+    result = await ExecuteCodeTool().execute(
+        mode=ServerMode.MCP_SERVER,
+        notebook_manager=manager,
+        code="import time; time.sleep(2)",
+        timeout=30,
+        ensure_kernel_alive_fn=lambda: kernel,
+        wait_for_kernel_idle_fn=wait_idle,
+        safe_extract_outputs_fn=lambda outputs: [o.get("text", "") for o in outputs],
+        progress_callback=progress,
+        progress_interval=1,
+    )
+
+    assert progress.events, "expected progress keepalive from execute_code"
+    assert any("done" in entry for entry in result if isinstance(entry, str))


### PR DESCRIPTION
## Summary

Long-running `execute_cell` / `execute_code` calls were silent on the MCP wire until they finished. Raising `--execution-timeout` / `JUPYTER_MCP_EXECUTION_TIMEOUT` alone does not send protocol traffic, so many MCP clients idle-timeout around a few minutes while the kernel keeps writing notebook outputs afterward (issue #298).

This change:

- Emits MCP `report_progress` + `info` keepalives on a configurable `progress_interval` during `execute_cell` (stream and non-stream), `insert_execute_code_cell`, and `execute_code`
- After a timeout + kernel interrupt, briefly settles the background `to_thread` work (without cancelling the asyncio Task) so the tool response can include notebook outputs that land in that window, instead of leaving them as stray notebook-only writes
- Documents the keepalive behavior next to the existing timeout config

Related: #308 already tracks orphaned post-timeout tasks for `is_kernel_busy`; this builds on that for the client-visible long-cell path.

## AI assistance

This PR was prepared with AI assistance (Cursor/Grok). I reviewed the change, ran the tests below, and am responsible for the submission.

## Evidence

`	ext
python -m pytest tests/test_execute_progress_keepalive.py tests/test_execute_orphaned_timeout.py tests/test_execute_cell_stream.py tests/test_execute_code_timeout.py -v --tb=line

...
13 passed in ~54s
`

Long-cell path covered by `test_stream_path_emits_progress_callback_during_long_cell`, `test_forced_sync_path_emits_progress_callback_during_long_cell`, and `test_execute_code_emits_progress_callback_during_long_run` (progress callback invoked while a multi-second fake cell is still running). Timeout + notebook output sibling covered by `test_timeout_settle_includes_late_notebook_output_in_stream_result` plus the existing orphaned-timeout suite.

## What was not tested

- Live Cursor/Claude Desktop idle-timeout against a real 3+ minute kernel cell (depends on client progressToken support; keepalive no-ops if the client omits a progress token, though `info` logs still go out)
- Full JupyterLab UI click-through of notebook outputs after a live timeout

## How to use

`ash
# raise the server-side ceiling (already supported)
jupyter-mcp start --execution-timeout 600 --max-execution-timeout 3600
# or
export JUPYTER_MCP_EXECUTION_TIMEOUT=600
`

Call `execute_cell` with a matching `timeout` (or `0` for the config default). Progress keepalives fire every `progress_interval` seconds (default 5) even when `stream=false`.