### PR TITLE
fix(mcpb): sync bundle version numbers with the package version

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -63,6 +63,9 @@ jobs:
       - name: Run Linters
         run: |
           bash ./.github/workflows/lint.sh
+      - name: Check mcpb version sync
+        run: |
+          python scripts/sync_mcpb_version.py --check
 
   test_sdist:
     needs: build

--- a/mcpb/manifest.json
+++ b/mcpb/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": "0.4",
   "name": "jupyter-mcp-server",
   "display_name": "Jupyter MCP Server",
-  "version": "0.22.1",
+  "version": "1.0.7",
   "description": "Connect AI agents to Jupyter Notebooks - execute code, manage notebooks, and interact with kernels in real-time",
   "long_description": "The Jupyter MCP Server enables AI agents like Claude to connect to and manage Jupyter Notebooks in real-time. It provides 14 tools to execute code, manage notebooks, read and write cells, and interact with Jupyter kernels through the standardized Model Context Protocol.\n\n**Requirements:** You need a running Jupyter server (JupyterLab or Jupyter Notebook) to connect to. Start one with:\n```\npip install jupyterlab\njupyter lab --port 8888 --IdentityProvider.token MY_TOKEN\n```",
   "author": {

--- a/mcpb/pyproject.toml
+++ b/mcpb/pyproject.toml
@@ -4,7 +4,7 @@
 
 [project]
 name = "jupyter-mcp-server-mcpb"
-version = "1.0.0"
+version = "1.0.7"
 description = "Jupyter MCP Server - MCPB bundle for one-click installation in Claude Desktop"
 requires-python = ">=3.10"
 dependencies = [

--- a/scripts/sync_mcpb_version.py
+++ b/scripts/sync_mcpb_version.py
@@ -1,0 +1,108 @@
+#!/usr/bin/env python3
+# Copyright (c) 2024- Datalayer, Inc.
+#
+# BSD 3-Clause License
+
+"""Sync mcpb/manifest.json and mcpb/pyproject.toml's version fields to
+jupyter_mcp_server/__version__.py, the single source of truth for the
+package version (see #236).
+
+Usage:
+    python scripts/sync_mcpb_version.py          # rewrite the mcpb files in place
+    python scripts/sync_mcpb_version.py --check  # exit 1 on drift, write nothing (for CI)
+"""
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+VERSION_FILE = ROOT / "jupyter_mcp_server" / "__version__.py"
+MANIFEST_FILE = ROOT / "mcpb" / "manifest.json"
+PYPROJECT_FILE = ROOT / "mcpb" / "pyproject.toml"
+
+PACKAGE_VERSION_RE = re.compile(r'__version__\s*=\s*"([^"]+)"')
+MANIFEST_VERSION_RE = re.compile(r'("version":\s*")[^"]+(")')
+PYPROJECT_VERSION_RE = re.compile(r'^version\s*=\s*"([^"]+)"', re.MULTILINE)
+
+
+def read_package_version(path: Path = VERSION_FILE) -> str:
+    match = PACKAGE_VERSION_RE.search(path.read_text())
+    if not match:
+        raise SystemExit(f"could not find __version__ in {path}")
+    return match.group(1)
+
+
+def read_manifest_version(path: Path = MANIFEST_FILE) -> str:
+    return json.loads(path.read_text())["version"]
+
+
+def read_pyproject_version(path: Path = PYPROJECT_FILE) -> str:
+    match = PYPROJECT_VERSION_RE.search(path.read_text())
+    if not match:
+        raise SystemExit(f"could not find version in {path}")
+    return match.group(1)
+
+
+def write_manifest_version(version: str, path: Path = MANIFEST_FILE) -> None:
+    text = path.read_text()
+    new_text, count = MANIFEST_VERSION_RE.subn(rf"\g<1>{version}\g<2>", text, count=1)
+    if count != 1:
+        raise SystemExit(f"could not find version in {path}")
+    path.write_text(new_text)
+
+
+def write_pyproject_version(version: str, path: Path = PYPROJECT_FILE) -> None:
+    text = path.read_text()
+    new_text, count = PYPROJECT_VERSION_RE.subn(f'version = "{version}"', text, count=1)
+    if count != 1:
+        raise SystemExit(f"could not find version in {path}")
+    path.write_text(new_text)
+
+
+def find_drift(package_version: str, manifest_version: str, pyproject_version: str) -> list:
+    """Return one message per mcpb file whose version does not match package_version."""
+    drift = []
+    if manifest_version != package_version:
+        drift.append(f"mcpb/manifest.json is {manifest_version}, expected {package_version}")
+    if pyproject_version != package_version:
+        drift.append(f"mcpb/pyproject.toml is {pyproject_version}, expected {package_version}")
+    return drift
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help="verify the mcpb files match the package version without writing",
+    )
+    args = parser.parse_args()
+
+    package_version = read_package_version()
+    manifest_version = read_manifest_version()
+    pyproject_version = read_pyproject_version()
+
+    if args.check:
+        drift = find_drift(package_version, manifest_version, pyproject_version)
+        if drift:
+            for line in drift:
+                print(line, file=sys.stderr)
+            print("run `python scripts/sync_mcpb_version.py` to fix", file=sys.stderr)
+            return 1
+        print(f"mcpb version files match package version {package_version}")
+        return 0
+
+    if manifest_version != package_version:
+        write_manifest_version(package_version)
+        print(f"mcpb/manifest.json: {manifest_version} -> {package_version}")
+    if pyproject_version != package_version:
+        write_pyproject_version(package_version)
+        print(f"mcpb/pyproject.toml: {pyproject_version} -> {package_version}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_mcpb_version_sync.py
+++ b/tests/test_mcpb_version_sync.py
@@ -1,0 +1,42 @@
+# Copyright (c) 2024- Datalayer, Inc.
+#
+# BSD 3-Clause License
+
+"""Regression test for #236: mcpb/manifest.json and mcpb/pyproject.toml must
+track jupyter_mcp_server/__version__.py rather than drift independently.
+"""
+
+import json
+import re
+from pathlib import Path
+
+from scripts.sync_mcpb_version import find_drift
+
+ROOT = Path(__file__).resolve().parent.parent
+
+
+def _package_version() -> str:
+    text = (ROOT / "jupyter_mcp_server" / "__version__.py").read_text()
+    return re.search(r'__version__\s*=\s*"([^"]+)"', text).group(1)
+
+
+def test_manifest_version_matches_package_version():
+    manifest = json.loads((ROOT / "mcpb" / "manifest.json").read_text())
+    assert manifest["version"] == _package_version()
+
+
+def test_mcpb_pyproject_version_matches_package_version():
+    text = (ROOT / "mcpb" / "pyproject.toml").read_text()
+    match = re.search(r'^version\s*=\s*"([^"]+)"', text, re.MULTILINE)
+    assert match.group(1) == _package_version()
+
+
+def test_find_drift_reports_each_mismatched_file():
+    assert find_drift("1.0.7", "1.0.7", "1.0.7") == []
+    assert find_drift("1.0.7", "0.22.1", "1.0.7") == [
+        "mcpb/manifest.json is 0.22.1, expected 1.0.7"
+    ]
+    assert find_drift("1.0.7", "0.22.1", "1.0.0") == [
+        "mcpb/manifest.json is 0.22.1, expected 1.0.7",
+        "mcpb/pyproject.toml is 1.0.0, expected 1.0.7",
+    ]


### PR DESCRIPTION
Root cause: `mcpb/manifest.json`'s `version` and `mcpb/pyproject.toml`'s `version` are independent, hand-maintained fields. Every release since #232 bumps `jupyter_mcp_server/__version__.py` only, so the three numbers have drifted apart: `__version__.py` is `1.0.7`, `mcpb/pyproject.toml` is `1.0.0`, and `mcpb/manifest.json` is `0.22.1`.

Fix: `scripts/sync_mcpb_version.py` reads `__version__.py` as the source of truth and rewrites the two mcpb files to match it; this PR runs it once to close the current gap. Its `--check` mode is wired into the `test_lint` CI job so a future release that forgets to run it fails the build instead of drifting again.

Verified in a clean Docker container (`python:3.10-slim`) against HEAD `38dbcb0`: `tests/test_mcpb_version_sync.py` fails on main (`0.22.1 != 1.0.7`, `1.0.0 != 1.0.7`) and passes after the fix, and `scripts/sync_mcpb_version.py --check` exits 0 on the fixed tree. Did not run the full `make test-mcp-server`/`make test-jupyter-server` suite, since it needs a live Jupyter/kernel stack this change does not touch; `pytest --collect-only` over the whole `tests/` directory confirms the new test file collects cleanly alongside the existing 287 tests, with no naming or fixture conflicts.

Fixes #236
