### PR TITLE
fix(notebook): bound the notebook disconnect so a stuck teardown cannot hang a tool call forever

### DIFF
--- a/jupyter_mcp_server/notebook_manager.py
+++ b/jupyter_mcp_server/notebook_manager.py
@@ -9,6 +9,8 @@ This module provides centralized management for Jupyter notebooks and kernels,
 replacing the scattered global variable approach with a unified architecture.
 """
 
+import asyncio
+import logging
 from typing import Dict, Any, Optional, Callable, Union
 from types import TracebackType
 
@@ -16,6 +18,15 @@ from jupyter_nbmodel_client import NbModelClient, get_notebook_websocket_url
 from jupyter_kernel_client import KernelClient
 
 from .config import get_config
+
+logger = logging.getLogger(__name__)
+
+# Bounds NbModelClient.__aexit__ (the notebook websocket disconnect). The client's own
+# teardown already bounds propagating queued changes to REQUEST_TIMEOUT (10s default),
+# but a stuck cancellation of its background sender task past that point has no further
+# bound of its own, so a hang there was blocking every tool call that opened this
+# connection forever with no response ever reaching the MCP client (#160).
+DISCONNECT_TIMEOUT = 20
 
 
 class NotebookConnection:
@@ -57,9 +68,24 @@ class NotebookConnection:
         exc_val: Optional[BaseException], 
         exc_tb: Optional[TracebackType]
     ) -> None:
-        """Exit context, clean up connection."""
+        """Exit context, clean up connection.
+
+        Bounded by DISCONNECT_TIMEOUT so a stuck disconnect cannot hang the tool call
+        that owns this connection forever; any exception being propagated through this
+        context manager still surfaces normally either way.
+        """
         if self._notebook:
-            await self._notebook.__aexit__(exc_type, exc_val, exc_tb)
+            try:
+                await asyncio.wait_for(
+                    self._notebook.__aexit__(exc_type, exc_val, exc_tb),
+                    timeout=DISCONNECT_TIMEOUT,
+                )
+            except asyncio.TimeoutError:
+                logger.warning(
+                    "Notebook client disconnect did not finish within %ss; "
+                    "continuing without waiting for its cleanup.",
+                    DISCONNECT_TIMEOUT,
+                )
 
 
 class NotebookManager:

--- a/tests/test_notebook_connection_disconnect_timeout.py
+++ b/tests/test_notebook_connection_disconnect_timeout.py
@@ -1,0 +1,90 @@
+# Copyright (c) 2024- Datalayer, Inc.
+#
+# BSD 3-Clause License
+
+"""Regression tests for NotebookConnection.__aexit__ hanging forever (#160).
+
+Under PYTHONDEVMODE=1, NbModelClient.__aexit__ can get stuck cancelling its
+background sender task and never return. Since NotebookConnection.__aexit__
+awaited it with no timeout of its own, every tool call that opens a notebook
+connection (insert_execute_code_cell, execute_cell, ...) hung forever with no
+response ever reaching the MCP client. These tests stand in a fake NbModelClient
+whose __aexit__ never completes, so the behavior is exercised deterministically
+without needing PYTHONDEVMODE or a live CRDT race.
+"""
+
+import asyncio
+
+import pytest
+
+from jupyter_mcp_server import notebook_manager as notebook_manager_module
+from jupyter_mcp_server.notebook_manager import NotebookConnection
+
+
+class HangingNotebook:
+    """Stands in for an NbModelClient whose disconnect never completes."""
+
+    def __init__(self):
+        self.aexit_called = False
+
+    async def __aexit__(self, exc_type, exc_val, exc_tb):
+        self.aexit_called = True
+        await asyncio.Event().wait()  # never set: simulates the stuck disconnect
+
+
+class FastNotebook:
+    """Stands in for the normal case: disconnect completes right away."""
+
+    def __init__(self):
+        self.aexit_called = False
+
+    async def __aexit__(self, exc_type, exc_val, exc_tb):
+        self.aexit_called = True
+
+
+def _connection_wrapping(fake_notebook):
+    conn = NotebookConnection(notebook_info={})
+    conn._notebook = fake_notebook
+    return conn
+
+
+@pytest.mark.asyncio
+async def test_aexit_does_not_hang_when_disconnect_is_stuck(monkeypatch):
+    """A stuck NbModelClient.__aexit__ must not hang the connection's own
+    __aexit__ forever; it should give up after DISCONNECT_TIMEOUT.
+
+    raising=False: on unpatched code there is no DISCONNECT_TIMEOUT to patch,
+    __aexit__ awaits the stuck disconnect with no bound of its own, and this
+    test's own outer wait_for is what then fails with asyncio.TimeoutError,
+    demonstrating the actual hang rather than an unrelated AttributeError.
+    """
+    monkeypatch.setattr(notebook_manager_module, "DISCONNECT_TIMEOUT", 0.05, raising=False)
+    fake_notebook = HangingNotebook()
+    conn = _connection_wrapping(fake_notebook)
+
+    await asyncio.wait_for(conn.__aexit__(None, None, None), timeout=2)
+
+    assert fake_notebook.aexit_called
+
+
+@pytest.mark.asyncio
+async def test_aexit_still_completes_normally_when_disconnect_is_fast(monkeypatch):
+    """The timeout must not interfere with the ordinary fast-disconnect path."""
+    monkeypatch.setattr(notebook_manager_module, "DISCONNECT_TIMEOUT", 0.05, raising=False)
+    fake_notebook = FastNotebook()
+    conn = _connection_wrapping(fake_notebook)
+
+    await asyncio.wait_for(conn.__aexit__(None, None, None), timeout=2)
+
+    assert fake_notebook.aexit_called
+
+
+@pytest.mark.asyncio
+async def test_aexit_logs_a_warning_when_disconnect_times_out(monkeypatch, caplog):
+    monkeypatch.setattr(notebook_manager_module, "DISCONNECT_TIMEOUT", 0.05, raising=False)
+    conn = _connection_wrapping(HangingNotebook())
+
+    with caplog.at_level("WARNING", logger=notebook_manager_module.__name__):
+        await asyncio.wait_for(conn.__aexit__(None, None, None), timeout=2)
+
+    assert any("disconnect" in record.message.lower() for record in caplog.records)


### PR DESCRIPTION
`insert_execute_code_cell`/`execute_cell` can hang forever when the MCP server process runs under `PYTHONDEVMODE=1`, as reported in #160.

## Root cause

`NotebookConnection.__aexit__` (`jupyter_mcp_server/notebook_manager.py`) awaits `NbModelClient.__aexit__()` with no timeout of its own. Under `PYTHONDEVMODE=1` I could reliably reproduce a case where the client's teardown (`jupyter_nbmodel_client/client.py`, `NbModelClient.stop()`) gets past its own bounded step (propagating queued changes, bounded by `REQUEST_TIMEOUT`, 10s default) and then stalls indefinitely cancelling its background sender task. Since every tool call that opens a notebook connection goes through `async with notebook_manager.get_current_connection() as notebook:`, Python's `async with` protocol has to wait for `__aexit__` to finish before the call can return (or propagate its exception); the stall there hangs the whole tool call with no response ever reaching the MCP client, matching the reported symptom exactly.

I did not track down why the client's own cancellation stalls specifically under dev mode (that path lives in the `jupyter-nbmodel-client` dependency, not in this repo), but the fix here does not depend on knowing that: no matter the cause, a stuck disconnect should never be able to block a tool call forever.

## Fix

Bound the disconnect with `asyncio.wait_for(..., timeout=DISCONNECT_TIMEOUT)` (20s). On timeout, log a warning and let the original result/exception continue propagating normally instead of blocking on cleanup.

## Verification

Reproduced end to end in a clean Docker container (Python 3.13, matching the reporter's version): a real JupyterLab server plus `jupyter-mcp-server` run over the actual `stdio` transport, driven by a scripted MCP client calling `insert_execute_code_cell`.

- On HEAD (`38dbcb0`), with `PYTHONDEVMODE=1`: the tool call never returns (60s+ with no response); without it, the same call completes in ~1.7s.
- With this fix, under `PYTHONDEVMODE=1`: the call now returns within the 20s bound, as an error result (`isError=True`) instead of hanging.
- Added `tests/test_notebook_connection_disconnect_timeout.py`, which stands in a fake client whose `__aexit__` never completes, so the fix is exercised deterministically without needing `PYTHONDEVMODE` or the underlying race. Confirmed it fails on unpatched `main` (the connection's own `__aexit__` hangs past the test's outer timeout) and passes on this branch.
- Ran the full existing suite (`pytest tests/`); all relevant execute/notebook-manager tests pass, plus the real end-to-end `test_execute_code[mcp_server]` integration test.

Not verified: the exact mechanism inside `jupyter-nbmodel-client`/`pycrdt` that stalls the cancellation under dev mode. This fix bounds the symptom in this repo; I have not opened an issue upstream since I could not pin the precise root cause there.
