### PR TITLE
fix(tools): let cell-level tools target an explicit notebook by name

### DIFF
--- a/jupyter_mcp_server/server.py
+++ b/jupyter_mcp_server/server.py
@@ -588,6 +588,12 @@ async def insert_cell(
     ],
     cell_type: Annotated[Literal["code", "markdown"], Field(description="Type of cell to insert")],
     cell_source: Annotated[str, Field(description="Source content for the cell")],
+    notebook_name: Annotated[
+        str | None,
+        Field(
+            description="Target this specific connected notebook instead of the currently activated one. Use when multiple clients share this server, to avoid racing the shared 'current notebook' pointer. Omit to use the currently activated notebook."
+        ),
+    ] = None,
 ) -> Annotated[
     str, Field(description="Success message and the structure of its surrounding cells")
 ]:
@@ -602,6 +608,7 @@ async def insert_cell(
             cell_index=cell_index,
             cell_source=cell_source,
             cell_type=cell_type,
+            notebook_name=notebook_name,
         )
     )
 
@@ -616,6 +623,12 @@ async def insert_cell(
 async def overwrite_cell_source(
     cell_index: Annotated[int, Field(description="Index of the cell to overwrite (0-based)", ge=0)],
     cell_source: Annotated[str, Field(description="New complete cell source")],
+    notebook_name: Annotated[
+        str | None,
+        Field(
+            description="Target this specific connected notebook instead of the currently activated one. Use when multiple clients share this server, to avoid racing the shared 'current notebook' pointer. Omit to use the currently activated notebook."
+        ),
+    ] = None,
 ) -> Annotated[str, Field(description="Success message with diff showing changes made")]:
     """Replace the entire source of a cell in the currently activated notebook.
     Returns a diff showing the changes made.
@@ -631,6 +644,7 @@ async def overwrite_cell_source(
             notebook_manager=notebook_manager,
             cell_index=cell_index,
             cell_source=cell_source,
+            notebook_name=notebook_name,
         )
     )
 
@@ -648,6 +662,12 @@ async def edit_cell_source(
     replace_all: Annotated[
         bool, Field(description="Replace all occurrences (default: first only)")
     ] = False,
+    notebook_name: Annotated[
+        str | None,
+        Field(
+            description="Target this specific connected notebook instead of the currently activated one. Use when multiple clients share this server, to avoid racing the shared 'current notebook' pointer. Omit to use the currently activated notebook."
+        ),
+    ] = None,
 ) -> Annotated[str, Field(description="Success message with diff showing changes made")]:
     """Perform a surgical find-and-replace within a cell's source (like an editor's Edit tool).
     Finds `old_string` in the cell and replaces it with `new_string`. Matching is literal
@@ -668,6 +688,7 @@ async def edit_cell_source(
             old_string=old_string,
             new_string=new_string,
             replace_all=replace_all,
+            notebook_name=notebook_name,
         )
     )
 
@@ -790,6 +811,12 @@ async def read_cell(
     include_outputs: Annotated[
         bool, Field(description="Include outputs in the response (only for code cells)")
     ] = True,
+    notebook_name: Annotated[
+        str | None,
+        Field(
+            description="Target this specific connected notebook instead of the currently activated one. Use when multiple clients share this server, to avoid racing the shared 'current notebook' pointer. Omit to use the currently activated notebook."
+        ),
+    ] = None,
 ) -> Annotated[
     list[str | ImageContent],
     Field(
@@ -805,6 +832,7 @@ async def read_cell(
             notebook_manager=notebook_manager,
             cell_index=cell_index,
             include_outputs=include_outputs,
+            notebook_name=notebook_name,
         )
     )
 
@@ -823,6 +851,12 @@ async def delete_cell(
     include_source: Annotated[
         bool, Field(description="Whether to include the source of deleted cells")
     ] = True,
+    notebook_name: Annotated[
+        str | None,
+        Field(
+            description="Target this specific connected notebook instead of the currently activated one. Use when multiple clients share this server, to avoid racing the shared 'current notebook' pointer. Omit to use the currently activated notebook."
+        ),
+    ] = None,
 ) -> Annotated[
     str,
     Field(
@@ -839,6 +873,7 @@ async def delete_cell(
             notebook_manager=notebook_manager,
             cell_indices=cell_indices,
             include_source=include_source,
+            notebook_name=notebook_name,
         )
     )
 
@@ -854,6 +889,12 @@ async def clear_cell_output(
     cell_index: Annotated[
         int, Field(description="Index of the code cell to clear (0-based)", ge=0)
     ],
+    notebook_name: Annotated[
+        str | None,
+        Field(
+            description="Target this specific connected notebook instead of the currently activated one. Use when multiple clients share this server, to avoid racing the shared 'current notebook' pointer. Omit to use the currently activated notebook."
+        ),
+    ] = None,
 ) -> Annotated[str, Field(description="Success message with the number of outputs removed")]:
     """Clear the outputs and execution count of a single code cell in the currently
     activated notebook, without deleting the cell itself."""
@@ -865,6 +906,7 @@ async def clear_cell_output(
             kernel_manager=server_context.kernel_manager,
             notebook_manager=notebook_manager,
             cell_index=cell_index,
+            notebook_name=notebook_name,
         )
     )
 
@@ -880,6 +922,12 @@ async def move_cell(
     target_index: Annotated[
         int, Field(description="Destination index where the cell will end up (0-based)", ge=0)
     ],
+    notebook_name: Annotated[
+        str | None,
+        Field(
+            description="Target this specific connected notebook instead of the currently activated one. Use when multiple clients share this server, to avoid racing the shared 'current notebook' pointer. Omit to use the currently activated notebook."
+        ),
+    ] = None,
 ) -> Annotated[
     str, Field(description="Success message with moved cell info and surrounding context")
 ]:
@@ -900,6 +948,7 @@ async def move_cell(
             notebook_manager=notebook_manager,
             source_index=source_index,
             target_index=target_index,
+            notebook_name=notebook_name,
         )
     )
 

--- a/jupyter_mcp_server/tools/clear_cell_output_tool.py
+++ b/jupyter_mcp_server/tools/clear_cell_output_tool.py
@@ -14,8 +14,9 @@ from jupyter_mcp_server.notebook_manager import NotebookManager
 from jupyter_mcp_server.tools._base import BaseTool, ServerMode
 from jupyter_mcp_server.utils import (
     clean_notebook_outputs,
-    get_current_notebook_context,
     get_notebook_model,
+    resolve_notebook_connection,
+    resolve_notebook_path,
 )
 
 
@@ -106,18 +107,22 @@ class ClearCellOutputTool(BaseTool):
         return cleared_count
 
     async def _clear_cell_output_websocket(
-        self, notebook_manager: NotebookManager, cell_index: int
+        self,
+        notebook_manager: NotebookManager,
+        cell_index: int,
+        notebook_name: str | None = None,
     ) -> int:
         """Clear cell output using WebSocket connection (MCP_SERVER mode).
 
         Args:
             notebook_manager: Notebook manager instance
             cell_index: Index of the cell to clear (0-based)
+            notebook_name: Notebook to target; the currently activated one if None
 
         Returns:
             Number of outputs that were cleared.
         """
-        async with notebook_manager.get_current_connection() as notebook:
+        async with resolve_notebook_connection(notebook_manager, notebook_name) as notebook:
             return self._clear_notebook_model_cell(notebook, cell_index)
 
     async def execute(
@@ -131,6 +136,7 @@ class ClearCellOutputTool(BaseTool):
         notebook_manager: NotebookManager | None = None,
         # Tool-specific parameters
         cell_index: int = None,
+        notebook_name: str | None = None,
         **kwargs,
     ) -> str:
         """Execute the clear_cell_output tool.
@@ -156,6 +162,7 @@ class ClearCellOutputTool(BaseTool):
             contents_manager: Direct API access for JUPYTER_SERVER mode
             notebook_manager: Notebook manager instance
             cell_index: Index of the code cell to clear (0-based)
+            notebook_name: Notebook to target explicitly; the currently activated one if omitted
             **kwargs: Additional parameters
 
         Returns:
@@ -171,7 +178,7 @@ class ClearCellOutputTool(BaseTool):
 
             context = get_server_context()
             serverapp = context.serverapp
-            notebook_path, _ = get_current_notebook_context(notebook_manager)
+            notebook_path, _ = resolve_notebook_path(notebook_manager, notebook_name)
 
             # Resolve to absolute path
             if serverapp and not Path(notebook_path).is_absolute():
@@ -189,7 +196,7 @@ class ClearCellOutputTool(BaseTool):
 
         elif mode == ServerMode.MCP_SERVER and notebook_manager is not None:
             # MCP_SERVER mode: Use WebSocket connection
-            cleared_count = await self._clear_cell_output_websocket(notebook_manager, cell_index)
+            cleared_count = await self._clear_cell_output_websocket(notebook_manager, cell_index, notebook_name)
         else:
             raise ValueError(f"Invalid mode or missing required clients: mode={mode}")
 

--- a/jupyter_mcp_server/tools/delete_cell_tool.py
+++ b/jupyter_mcp_server/tools/delete_cell_tool.py
@@ -14,8 +14,9 @@ from jupyter_mcp_server.notebook_manager import NotebookManager
 from jupyter_mcp_server.tools._base import BaseTool, ServerMode
 from jupyter_mcp_server.utils import (
     clean_notebook_outputs,
-    get_current_notebook_context,
     get_notebook_model,
+    resolve_notebook_connection,
+    resolve_notebook_path,
 )
 
 
@@ -112,18 +113,22 @@ class DeleteCellTool(BaseTool):
         return deleted_cells
 
     async def _delete_cell_websocket(
-        self, notebook_manager: NotebookManager, cell_indices: list[int]
+        self,
+        notebook_manager: NotebookManager,
+        cell_indices: list[int],
+        notebook_name: str | None = None,
     ) -> list:
         """Delete cell using WebSocket connection (MCP_SERVER mode).
 
         Args:
             notebook_manager: Notebook manager instance
             cell_indices: List of indices of cells to delete
+            notebook_name: Notebook to target; the currently activated one if None
 
         Returns:
             List of deleted cell information
         """
-        async with notebook_manager.get_current_connection() as notebook:
+        async with resolve_notebook_connection(notebook_manager, notebook_name) as notebook:
             self._validate_indices(cell_indices, len(notebook))
 
             cells = notebook.delete_many_cells(cell_indices)
@@ -141,6 +146,7 @@ class DeleteCellTool(BaseTool):
         # Tool-specific parameters
         cell_indices: list[int] = None,
         include_source: bool = True,
+        notebook_name: str | None = None,
         **kwargs,
     ) -> str:
         """Execute the delete_cell tool.
@@ -166,6 +172,7 @@ class DeleteCellTool(BaseTool):
             contents_manager: Direct API access for JUPYTER_SERVER mode
             notebook_manager: Notebook manager instance
             cell_index: Index of the cell to delete (0-based)
+            notebook_name: Notebook to target explicitly; the currently activated one if omitted
             **kwargs: Additional parameters
 
         Returns:
@@ -177,7 +184,7 @@ class DeleteCellTool(BaseTool):
 
             context = get_server_context()
             serverapp = context.serverapp
-            notebook_path, _ = get_current_notebook_context(notebook_manager)
+            notebook_path, _ = resolve_notebook_path(notebook_manager, notebook_name)
 
             # Resolve to absolute path
             if serverapp and not Path(notebook_path).is_absolute():
@@ -193,7 +200,7 @@ class DeleteCellTool(BaseTool):
 
         elif mode == ServerMode.MCP_SERVER and notebook_manager is not None:
             # MCP_SERVER mode: Use WebSocket connection
-            cells = await self._delete_cell_websocket(notebook_manager, cell_indices)
+            cells = await self._delete_cell_websocket(notebook_manager, cell_indices, notebook_name)
         else:
             raise ValueError(f"Invalid mode or missing required clients: mode={mode}")
 

--- a/jupyter_mcp_server/tools/edit_cell_source_tool.py
+++ b/jupyter_mcp_server/tools/edit_cell_source_tool.py
@@ -15,8 +15,9 @@ from jupyter_mcp_server.notebook_manager import NotebookManager
 from jupyter_mcp_server.tools._base import BaseTool, ServerMode
 from jupyter_mcp_server.utils import (
     clean_notebook_outputs,
-    get_current_notebook_context,
     get_notebook_model,
+    resolve_notebook_connection,
+    resolve_notebook_path,
 )
 
 
@@ -153,8 +154,9 @@ class EditCellSourceTool(BaseTool):
         old_string: str,
         new_string: str,
         replace_all: bool,
+        notebook_name: str | None = None,
     ) -> str:
-        async with notebook_manager.get_current_connection() as notebook:
+        async with resolve_notebook_connection(notebook_manager, notebook_name) as notebook:
             if cell_index >= len(notebook):
                 raise ValueError(f"Cell index {cell_index} out of range")
 
@@ -184,6 +186,7 @@ class EditCellSourceTool(BaseTool):
         old_string: str = None,
         new_string: str = None,
         replace_all: bool = False,
+        notebook_name: str | None = None,
         **kwargs,
     ) -> str:
         """Execute the edit_cell_source tool.
@@ -191,13 +194,16 @@ class EditCellSourceTool(BaseTool):
         Performs a surgical find-and-replace within a single cell's source,
         delegating the actual write to the appropriate backend (YDoc, file, or
         WebSocket) depending on the server mode.
+
+        Args:
+            notebook_name: Notebook to target explicitly; the currently activated one if omitted
         """
         if mode == ServerMode.JUPYTER_SERVER and contents_manager is not None:
             from jupyter_mcp_server.jupyter_extension.context import get_server_context
 
             context = get_server_context()
             serverapp = context.serverapp
-            notebook_path, _ = get_current_notebook_context(notebook_manager)
+            notebook_path, _ = resolve_notebook_path(notebook_manager, notebook_name)
 
             if serverapp and not Path(notebook_path).is_absolute():
                 root_dir = serverapp.root_dir
@@ -228,6 +234,7 @@ class EditCellSourceTool(BaseTool):
                 old_string,
                 new_string,
                 replace_all,
+                notebook_name,
             )
         else:
             raise ValueError(f"Invalid mode or missing required clients: mode={mode}")

--- a/jupyter_mcp_server/tools/insert_cell_tool.py
+++ b/jupyter_mcp_server/tools/insert_cell_tool.py
@@ -15,8 +15,9 @@ from jupyter_mcp_server.notebook_manager import NotebookManager
 from jupyter_mcp_server.tools._base import BaseTool, ServerMode
 from jupyter_mcp_server.utils import (
     clean_notebook_outputs,
-    get_current_notebook_context,
     get_notebook_model,
+    resolve_notebook_connection,
+    resolve_notebook_path,
 )
 
 
@@ -146,6 +147,7 @@ class InsertCellTool(BaseTool):
         cell_index: int,
         cell_type: Literal["code", "markdown"],
         cell_source: str,
+        notebook_name: str | None = None,
     ) -> tuple[Notebook, int, int]:
         """Insert cell using WebSocket connection (MCP_SERVER mode).
 
@@ -154,6 +156,7 @@ class InsertCellTool(BaseTool):
             cell_index: Index to insert at (-1 for append)
             cell_type: Type of cell to insert ("code", "markdown")
             cell_source: Source content for the cell
+            notebook_name: Notebook to target; the currently activated one if None
 
         Returns:
             Tuple of (notebook, actual_index, total_cells_after_insertion)
@@ -162,7 +165,7 @@ class InsertCellTool(BaseTool):
             IndexError: When cell_index is out of range
             ValueError: When cell_type is invalid
         """
-        async with notebook_manager.get_current_connection() as notebook:
+        async with resolve_notebook_connection(notebook_manager, notebook_name) as notebook:
             total_cells = len(notebook)
 
             # Validate insertion parameters
@@ -187,6 +190,7 @@ class InsertCellTool(BaseTool):
         cell_index: int = None,
         cell_type: Literal["code", "markdown"] = None,
         cell_source: str = None,
+        notebook_name: str | None = None,
         **kwargs,
     ) -> str:
         """Execute the insert_cell tool.
@@ -220,6 +224,7 @@ class InsertCellTool(BaseTool):
             cell_index: Target index for insertion (0-based, -1 to append)
             cell_type: Type of cell ("code", "markdown")
             cell_source: Source content for the cell
+            notebook_name: Notebook to target explicitly; the currently activated one if omitted
             **kwargs: Additional parameters
 
         Returns:
@@ -236,7 +241,7 @@ class InsertCellTool(BaseTool):
 
             context = get_server_context()
             serverapp = context.serverapp
-            notebook_path, _ = get_current_notebook_context(notebook_manager)
+            notebook_path, _ = resolve_notebook_path(notebook_manager, notebook_name)
 
             # Resolve to absolute path
             if serverapp and not Path(notebook_path).is_absolute():
@@ -257,7 +262,7 @@ class InsertCellTool(BaseTool):
         elif mode == ServerMode.MCP_SERVER and notebook_manager is not None:
             # MCP_SERVER mode: Use WebSocket connection with unified insert_cell pattern
             notebook, actual_index, new_total_cells = await self._insert_cell_websocket(
-                notebook_manager, cell_index, cell_type, cell_source
+                notebook_manager, cell_index, cell_type, cell_source, notebook_name
             )
         else:
             raise ValueError(f"Invalid mode or missing required clients: mode={mode}")

--- a/jupyter_mcp_server/tools/move_cell_tool.py
+++ b/jupyter_mcp_server/tools/move_cell_tool.py
@@ -15,8 +15,9 @@ from jupyter_mcp_server.notebook_manager import NotebookManager
 from jupyter_mcp_server.tools._base import BaseTool, ServerMode
 from jupyter_mcp_server.utils import (
     clean_notebook_outputs,
-    get_current_notebook_context,
     get_notebook_model,
+    resolve_notebook_connection,
+    resolve_notebook_path,
 )
 
 
@@ -136,13 +137,14 @@ class MoveCellTool(BaseTool):
         notebook_manager: NotebookManager,
         source_index: int,
         target_index: int,
+        notebook_name: str | None = None,
     ) -> tuple[Notebook, dict]:
         """Move cell using WebSocket connection (MCP_SERVER mode).
 
         Returns:
             Tuple of (notebook, moved_cell_info)
         """
-        async with notebook_manager.get_current_connection() as notebook:
+        async with resolve_notebook_connection(notebook_manager, notebook_name) as notebook:
             self._validate_move(source_index, target_index, len(notebook))
 
             if source_index == target_index:
@@ -171,6 +173,7 @@ class MoveCellTool(BaseTool):
         # Tool-specific parameters
         source_index: int = None,
         target_index: int = None,
+        notebook_name: str | None = None,
         **kwargs,
     ) -> str:
         """Execute the move_cell tool.
@@ -180,6 +183,9 @@ class MoveCellTool(BaseTool):
         2. JUPYTER_SERVER + File: Direct nbformat file operations
         3. MCP_SERVER + WebSocket: Remote notebook via NbModelClient
 
+        Args:
+            notebook_name: Notebook to target explicitly; the currently activated one if omitted
+
         Returns:
             Success message with moved cell info and surrounding context.
         """
@@ -188,7 +194,7 @@ class MoveCellTool(BaseTool):
 
             context = get_server_context()
             serverapp = context.serverapp
-            notebook_path, _ = get_current_notebook_context(notebook_manager)
+            notebook_path, _ = resolve_notebook_path(notebook_manager, notebook_name)
 
             if serverapp and not Path(notebook_path).is_absolute():
                 root_dir = serverapp.root_dir
@@ -205,7 +211,7 @@ class MoveCellTool(BaseTool):
 
         elif mode == ServerMode.MCP_SERVER and notebook_manager is not None:
             nb, cell_info = await self._move_cell_websocket(
-                notebook_manager, source_index, target_index
+                notebook_manager, source_index, target_index, notebook_name
             )
         else:
             raise ValueError(f"Invalid mode or missing required clients: mode={mode}")

--- a/jupyter_mcp_server/tools/overwrite_cell_source_tool.py
+++ b/jupyter_mcp_server/tools/overwrite_cell_source_tool.py
@@ -15,8 +15,9 @@ from jupyter_mcp_server.notebook_manager import NotebookManager
 from jupyter_mcp_server.tools._base import BaseTool, ServerMode
 from jupyter_mcp_server.utils import (
     clean_notebook_outputs,
-    get_current_notebook_context,
     get_notebook_model,
+    resolve_notebook_connection,
+    resolve_notebook_path,
 )
 
 
@@ -120,7 +121,11 @@ class OverwriteCellSourceTool(BaseTool):
         return self._generate_diff(old_source, cell_source)
 
     async def _overwrite_cell_websocket(
-        self, notebook_manager: NotebookManager, cell_index: int, cell_source: str
+        self,
+        notebook_manager: NotebookManager,
+        cell_index: int,
+        cell_source: str,
+        notebook_name: str | None = None,
     ) -> str:
         """Overwrite cell using WebSocket connection (MCP_SERVER mode).
 
@@ -128,6 +133,7 @@ class OverwriteCellSourceTool(BaseTool):
             notebook_manager: Notebook manager instance
             cell_index: Index of the cell to overwrite
             cell_source: New cell source content
+            notebook_name: Notebook to target; the currently activated one if None
 
         Returns:
             Diff showing changes made
@@ -135,7 +141,7 @@ class OverwriteCellSourceTool(BaseTool):
         Raises:
             ValueError: When cell_index is out of range
         """
-        async with notebook_manager.get_current_connection() as notebook:
+        async with resolve_notebook_connection(notebook_manager, notebook_name) as notebook:
             if cell_index >= len(notebook):
                 raise ValueError(f"Cell index {cell_index} out of range")
 
@@ -160,6 +166,7 @@ class OverwriteCellSourceTool(BaseTool):
         # Tool-specific parameters
         cell_index: int = None,
         cell_source: str = None,
+        notebook_name: str | None = None,
         **kwargs,
     ) -> str:
         """Execute the overwrite_cell_source tool.
@@ -192,6 +199,7 @@ class OverwriteCellSourceTool(BaseTool):
             notebook_manager: Notebook manager instance
             cell_index: Index of the cell to overwrite (0-based)
             cell_source: New cell source
+            notebook_name: Notebook to target explicitly; the currently activated one if omitted
             **kwargs: Additional parameters
 
         Returns:
@@ -207,7 +215,7 @@ class OverwriteCellSourceTool(BaseTool):
 
             context = get_server_context()
             serverapp = context.serverapp
-            notebook_path, _ = get_current_notebook_context(notebook_manager)
+            notebook_path, _ = resolve_notebook_path(notebook_manager, notebook_name)
 
             # Resolve to absolute path
             if serverapp and not Path(notebook_path).is_absolute():
@@ -225,7 +233,7 @@ class OverwriteCellSourceTool(BaseTool):
 
         elif mode == ServerMode.MCP_SERVER and notebook_manager is not None:
             # MCP_SERVER mode: Use WebSocket connection with remote transaction management
-            diff = await self._overwrite_cell_websocket(notebook_manager, cell_index, cell_source)
+            diff = await self._overwrite_cell_websocket(notebook_manager, cell_index, cell_source, notebook_name)
         else:
             raise ValueError(f"Invalid mode or missing required clients: mode={mode}")
 

--- a/jupyter_mcp_server/tools/read_cell_tool.py
+++ b/jupyter_mcp_server/tools/read_cell_tool.py
@@ -14,7 +14,11 @@ from mcp.types import ImageContent
 from jupyter_mcp_server.models import Notebook
 from jupyter_mcp_server.notebook_manager import NotebookManager
 from jupyter_mcp_server.tools._base import BaseTool, ServerMode
-from jupyter_mcp_server.utils import get_current_notebook_context, get_notebook_model
+from jupyter_mcp_server.utils import (
+    get_notebook_model,
+    resolve_notebook_connection,
+    resolve_notebook_path,
+)
 
 
 class ReadCellTool(BaseTool):
@@ -32,6 +36,7 @@ class ReadCellTool(BaseTool):
         # Tool-specific parameters
         cell_index: int = None,
         include_outputs: bool = True,
+        notebook_name: str | None = None,
         **kwargs,
     ) -> list[str | ImageContent]:
         """Execute the read_cell tool.
@@ -42,6 +47,7 @@ class ReadCellTool(BaseTool):
             notebook_manager: Notebook manager instance
             cell_index: Index of the cell to read (0-based)
             include_outputs: Include outputs in the response (only for code cells)
+            notebook_name: Notebook to target explicitly; the currently activated one if omitted
             **kwargs: Additional parameters
 
         Returns:
@@ -53,7 +59,7 @@ class ReadCellTool(BaseTool):
             # sees it instead of the on-disk copy the autosave hasn't flushed yet.
             # Guard against no active notebook — without this, a None path causes
             # 'quote_from_bytes() expected bytes' deep in the contents manager.
-            notebook_path, _ = get_current_notebook_context(notebook_manager)
+            notebook_path, _ = resolve_notebook_path(notebook_manager, notebook_name)
 
             if not notebook_path:
                 return [
@@ -80,9 +86,10 @@ class ReadCellTool(BaseTool):
                 notebook = Notebook(**model["content"])
         elif mode == ServerMode.MCP_SERVER and notebook_manager is not None:
             # Remote mode: use WebSocket connection to Y.js document.
-            # get_current_connection() falls back to the default pre-configured
-            # notebook (--document-id), so no explicit guard is needed here.
-            async with notebook_manager.get_current_connection() as notebook_content:
+            # resolve_notebook_connection() falls back to the default
+            # pre-configured notebook (--document-id) when notebook_name is
+            # None, so no explicit guard is needed here.
+            async with resolve_notebook_connection(notebook_manager, notebook_name) as notebook_content:
                 notebook = Notebook(**notebook_content.as_dict())
         else:
             raise ValueError(f"Invalid mode or missing required clients: mode={mode}")

--- a/jupyter_mcp_server/utils.py
+++ b/jupyter_mcp_server/utils.py
@@ -48,6 +48,56 @@ def get_current_notebook_context(notebook_manager=None):
     return notebook_path, kernel_id
 
 
+def resolve_notebook_path(notebook_manager=None, notebook_name: str | None = None):
+    """
+    Resolve a notebook's file path and kernel ID for JUPYTER_SERVER mode, optionally
+    targeting an explicit notebook instead of the currently activated one.
+
+    Args:
+        notebook_manager: NotebookManager instance (optional)
+        notebook_name: Explicit notebook identifier to target. When None, falls back
+            to the currently activated notebook (get_current_notebook_context).
+
+    Returns:
+        Tuple of (notebook_path, kernel_id)
+
+    Raises:
+        ValueError: When notebook_name is given but is not a connected notebook.
+    """
+    if notebook_name is None:
+        return get_current_notebook_context(notebook_manager)
+
+    if notebook_manager is None or notebook_name not in notebook_manager:
+        raise ValueError(f"Notebook '{notebook_name}' is not connected.")
+
+    return notebook_manager.get_notebook_path(notebook_name), notebook_manager.get_kernel_id(notebook_name)
+
+
+def resolve_notebook_connection(notebook_manager, notebook_name: str | None = None):
+    """
+    Resolve a NotebookConnection context manager for MCP_SERVER mode, optionally
+    targeting an explicit notebook instead of the currently activated one.
+
+    Args:
+        notebook_manager: NotebookManager instance
+        notebook_name: Explicit notebook identifier to target. When None, falls back
+            to the currently activated notebook (get_current_connection).
+
+    Returns:
+        NotebookConnection context manager
+
+    Raises:
+        ValueError: When notebook_name is given but is not a connected notebook.
+    """
+    if notebook_name is None:
+        return notebook_manager.get_current_connection()
+
+    if notebook_name not in notebook_manager:
+        raise ValueError(f"Notebook '{notebook_name}' is not connected.")
+
+    return notebook_manager.get_notebook_connection(notebook_name)
+
+
 def resolve_url_and_token_variables(
     jupyter_url,
     jupyter_token,

--- a/tests/test_cell_tools_explicit_notebook_target.py
+++ b/tests/test_cell_tools_explicit_notebook_target.py
@@ -1,0 +1,215 @@
+# Copyright (c) 2024- Datalayer, Inc.
+#
+# BSD 3-Clause License
+
+"""
+Tests for the optional notebook_name parameter on cell-level tools (#256).
+
+Two MCP clients sharing one server race NotebookManager's process-wide
+_current_notebook pointer: use_notebook(A) / cell-op / use_notebook(B) / cell-op
+can interleave and silently land on the wrong notebook, because every
+cell-level tool only ever resolved the implicit "current" notebook. These
+tests build a fake NotebookManager with two independently-addressable
+notebooks and confirm each cell-level tool's MCP_SERVER-mode path honors an
+explicit notebook_name instead of always following whichever notebook is
+"current".
+"""
+
+import contextlib
+
+import pytest
+
+from jupyter_mcp_server.tools._base import ServerMode
+from jupyter_mcp_server.tools.clear_cell_output_tool import ClearCellOutputTool
+from jupyter_mcp_server.tools.delete_cell_tool import DeleteCellTool
+from jupyter_mcp_server.tools.edit_cell_source_tool import EditCellSourceTool
+from jupyter_mcp_server.tools.insert_cell_tool import InsertCellTool
+from jupyter_mcp_server.tools.move_cell_tool import MoveCellTool
+from jupyter_mcp_server.tools.overwrite_cell_source_tool import OverwriteCellSourceTool
+from jupyter_mcp_server.tools.read_cell_tool import ReadCellTool
+
+
+def _notebook_model(cell_sources):
+    """Build a NotebookModel-backed fake notebook with one code cell per source."""
+    from jupyter_nbmodel_client import NotebookModel
+    from jupyter_ydoc import YNotebook
+
+    nb = NotebookModel()
+    nb._doc = YNotebook()
+    nb._doc.set({
+        "cells": [
+            {"cell_type": "code", "source": src, "metadata": {},
+             "outputs": [], "execution_count": None}
+            for src in cell_sources
+        ],
+        "metadata": {}, "nbformat": 4, "nbformat_minor": 5,
+    })
+    return nb
+
+
+class _FakeNotebookManager:
+    """Two independently-addressable notebooks; "A" is always the current one."""
+
+    def __init__(self, notebooks):
+        self._notebooks = notebooks
+        self._current = "A"
+
+    def __contains__(self, name):
+        return name in self._notebooks
+
+    def get_current_notebook(self):
+        return self._current
+
+    @contextlib.asynccontextmanager
+    async def get_current_connection(self):
+        yield self._notebooks[self._current]
+
+    @contextlib.asynccontextmanager
+    async def get_notebook_connection(self, name):
+        if name not in self._notebooks:
+            raise ValueError(f"Notebook '{name}' does not exist in manager")
+        yield self._notebooks[name]
+
+
+@pytest.fixture
+def two_notebooks():
+    """Notebook "A" (current) and "B" (not current), each with one cell."""
+    return _FakeNotebookManager({
+        "A": _notebook_model(["a_original"]),
+        "B": _notebook_model(["b_original"]),
+    })
+
+
+@pytest.mark.asyncio
+async def test_insert_cell_targets_explicit_notebook(two_notebooks):
+    """insert_cell(notebook_name="B") must land in B, never in the current notebook A."""
+    await InsertCellTool().execute(
+        mode=ServerMode.MCP_SERVER,
+        notebook_manager=two_notebooks,
+        cell_index=-1,
+        cell_type="code",
+        cell_source="into_b",
+        notebook_name="B",
+    )
+
+    assert len(two_notebooks._notebooks["A"]) == 1, "notebook A must be untouched"
+    assert len(two_notebooks._notebooks["B"]) == 2
+    assert two_notebooks._notebooks["B"].get_cell_source(1) == "into_b"
+
+
+@pytest.mark.asyncio
+async def test_insert_cell_default_still_targets_current(two_notebooks):
+    """Omitting notebook_name preserves today's behavior: lands in the current notebook."""
+    await InsertCellTool().execute(
+        mode=ServerMode.MCP_SERVER,
+        notebook_manager=two_notebooks,
+        cell_index=-1,
+        cell_type="code",
+        cell_source="into_current",
+    )
+
+    assert len(two_notebooks._notebooks["A"]) == 2
+    assert len(two_notebooks._notebooks["B"]) == 1
+
+
+@pytest.mark.asyncio
+async def test_read_cell_targets_explicit_notebook(two_notebooks):
+    result = await ReadCellTool().execute(
+        mode=ServerMode.MCP_SERVER,
+        notebook_manager=two_notebooks,
+        cell_index=0,
+        notebook_name="B",
+    )
+    assert "b_original" in "\n".join(str(part) for part in result)
+
+
+@pytest.mark.asyncio
+async def test_delete_cell_targets_explicit_notebook(two_notebooks):
+    await DeleteCellTool().execute(
+        mode=ServerMode.MCP_SERVER,
+        notebook_manager=two_notebooks,
+        cell_indices=[0],
+        notebook_name="B",
+    )
+    assert len(two_notebooks._notebooks["A"]) == 1, "notebook A must be untouched"
+    assert len(two_notebooks._notebooks["B"]) == 0
+
+
+@pytest.mark.asyncio
+async def test_overwrite_cell_source_targets_explicit_notebook(two_notebooks):
+    await OverwriteCellSourceTool().execute(
+        mode=ServerMode.MCP_SERVER,
+        notebook_manager=two_notebooks,
+        cell_index=0,
+        cell_source="b_overwritten",
+        notebook_name="B",
+    )
+    assert two_notebooks._notebooks["A"].get_cell_source(0) == "a_original"
+    assert two_notebooks._notebooks["B"].get_cell_source(0) == "b_overwritten"
+
+
+@pytest.mark.asyncio
+async def test_edit_cell_source_targets_explicit_notebook(two_notebooks):
+    await EditCellSourceTool().execute(
+        mode=ServerMode.MCP_SERVER,
+        notebook_manager=two_notebooks,
+        cell_index=0,
+        old_string="b_original",
+        new_string="b_edited",
+        notebook_name="B",
+    )
+    assert two_notebooks._notebooks["A"].get_cell_source(0) == "a_original"
+    assert two_notebooks._notebooks["B"].get_cell_source(0) == "b_edited"
+
+
+@pytest.mark.asyncio
+async def test_clear_cell_output_targets_explicit_notebook(two_notebooks):
+    b = two_notebooks._notebooks["B"]
+    cell = b[0]
+    cell["outputs"] = [{"output_type": "stream", "name": "stdout", "text": "hi\n"}]
+    cell["execution_count"] = 3
+    b[0] = cell
+
+    a_cell_before = dict(two_notebooks._notebooks["A"][0])
+
+    await ClearCellOutputTool().execute(
+        mode=ServerMode.MCP_SERVER,
+        notebook_manager=two_notebooks,
+        cell_index=0,
+        notebook_name="B",
+    )
+
+    assert b[0]["outputs"] == []
+    assert b[0]["execution_count"] is None
+    assert dict(two_notebooks._notebooks["A"][0]) == a_cell_before, "notebook A must be untouched"
+
+
+@pytest.mark.asyncio
+async def test_move_cell_targets_explicit_notebook(two_notebooks):
+    b = two_notebooks._notebooks["B"]
+    b.insert_cell(1, "second", "code")
+
+    await MoveCellTool().execute(
+        mode=ServerMode.MCP_SERVER,
+        notebook_manager=two_notebooks,
+        source_index=0,
+        target_index=1,
+        notebook_name="B",
+    )
+
+    assert two_notebooks._notebooks["A"].get_cell_source(0) == "a_original"
+    assert b.get_cell_source(1) == "b_original"
+
+
+@pytest.mark.asyncio
+async def test_unknown_notebook_name_raises(two_notebooks):
+    """An explicit target that isn't connected must fail loudly, never fall back to current."""
+    with pytest.raises(ValueError, match="not connected"):
+        await InsertCellTool().execute(
+            mode=ServerMode.MCP_SERVER,
+            notebook_manager=two_notebooks,
+            cell_index=-1,
+            cell_type="code",
+            cell_source="x",
+            notebook_name="does-not-exist",
+        )

--- a/tests/test_read_tools_ydoc.py
+++ b/tests/test_read_tools_ydoc.py
@@ -118,7 +118,7 @@ class TestReadCellToolYDocFirst:
             context_type="JUPYTER_SERVER", serverapp=_FakeServerApp(str(tmp_path))
         )
         monkeypatch.setattr(
-            read_cell_tool_module, "get_current_notebook_context", lambda nm: ("nb.ipynb", None)
+            read_cell_tool_module, "resolve_notebook_path", lambda nm, name: ("nb.ipynb", None)
         )
         monkeypatch.setattr(
             read_cell_tool_module,
@@ -145,7 +145,7 @@ class TestReadCellToolYDocFirst:
             context_type="JUPYTER_SERVER", serverapp=_FakeServerApp(str(tmp_path))
         )
         monkeypatch.setattr(
-            read_cell_tool_module, "get_current_notebook_context", lambda nm: ("nb.ipynb", None)
+            read_cell_tool_module, "resolve_notebook_path", lambda nm, name: ("nb.ipynb", None)
         )
         monkeypatch.setattr(
             read_cell_tool_module, "get_notebook_model", _fake_get_notebook_model(None)


### PR DESCRIPTION
### Root cause

`NotebookManager` tracks one process-wide `_current_notebook` pointer (`notebook_manager.py:76`). Every cell-level tool (`insert_cell`, `overwrite_cell_source`, `edit_cell_source`, `read_cell`, `delete_cell`, `clear_cell_output`, `move_cell`) resolves its target notebook only through that pointer, via `get_current_notebook_context()` (JUPYTER_SERVER mode) or `get_current_connection()` (MCP_SERVER mode). Neither path accepts an explicit target, unlike `read_notebook`, `restart_notebook`, and `unuse_notebook`, which already take a `notebook_name` argument.

Two MCP clients sharing one server race this pointer: client 1 calls `use_notebook(A)`, client 2 calls `use_notebook(B)`, and any cell-level call from client 1 issued after that silently lands on B instead of A, because both clients read the same `_current_notebook` field. There is no way for a caller to opt out of the shared pointer and address a notebook directly.

As discussed on #256, the complete fix is a session-identifier redesign that would touch a large part of the tool surface. This PR is a smaller, backward-compatible step: it does not solve session isolation, it gives callers an explicit-targeting escape hatch so a client that already knows which notebook it means never has to depend on the shared pointer being correct.

### Fix

Each of the seven cell-level tools gains an optional `notebook_name` parameter, defaulting to `None`. Two small resolver helpers in `utils.py` mirror `get_current_notebook_context`:

- `resolve_notebook_path(notebook_manager, notebook_name)` for JUPYTER_SERVER mode: returns the explicit notebook's path/kernel id when `notebook_name` is given (raising if it is not a connected notebook), otherwise falls back to `get_current_notebook_context`.
- `resolve_notebook_connection(notebook_manager, notebook_name)` for MCP_SERVER mode: same fallback, over `get_notebook_connection` / `get_current_connection`.

Both are reused by the existing per-notebook accessors (`NotebookManager.get_notebook_path`, `get_kernel_id`, `get_notebook_connection`), so this does not introduce a second way of tracking notebook state, only a second way of choosing which existing entry to read. Omitting `notebook_name` is a no-op: behavior for every existing caller is unchanged.

`execute_cell` and `insert_execute_code_cell` are deliberately left out of this PR. Their JUPYTER_SERVER path resolves a kernel and a live YDoc/file_id alongside the notebook path, which is a materially larger change than the read/write tools above; targeting execution correctly needs the kernel side of the redesign echarles described, not just the notebook side.

### Verified

In a clean `python:3.13-slim` container (non-root user, dependencies from `pyproject.toml`'s core list installed, source bind-mounted so both `main` and this branch run the same image), HEAD `cffe9b1`:

- New `tests/test_cell_tools_explicit_notebook_target.py`: a fake `NotebookManager` with two independent notebooks, "A" (current) and "B". 9 tests call each of the 7 tools with `notebook_name="B"` while "A" stays current, plus one default-omitted control and one unknown-name error case. On unpatched `main`: 8 of 9 fail (`notebook_name` is silently absorbed by `**kwargs` and every op still lands on the current notebook "A" instead of "B"; only the default-omitted control passes). On this branch: all 9 pass.
- `ruff check` on the 9 changed source files: 625 findings on the branch vs. 605 on the same files at `main`; every new finding is `E501`/`UP045`, matching this repo's own pre-existing style in these files (the repo's `Optional[X]` annotations already trip `UP045` 44 times on `main`), and `ruff` is confirmed non-gating in practice on this repo (2628 pre-existing errors on `main` overall). `mypy` reports the identical 123 pre-existing module-resolution errors on `main` and on this branch (unrelated to this change, and unchanged by it).

Not verified: end to end against a real two-client race (two live MCP sessions hitting one server). The fake-manager tests exercise the exact resolution path (`resolve_notebook_path` / `resolve_notebook_connection`) that the real `NotebookManager` shares between both code paths, but I have not driven this through a live JupyterLab + two MCP stdio clients.

Fixes #256
