### PR TITLE
fix(execute): use the kernel's own execution_count instead of a file-scan guess

### DIFF
--- a/jupyter_mcp_server/tools/execute_cell_tool.py
+++ b/jupyter_mcp_server/tools/execute_cell_tool.py
@@ -38,6 +38,7 @@ class ExecuteCellTool(BaseTool):
         cell_index: int,
         outputs: list[str | ImageContent],
         raw_outputs: list[dict] | None = None,
+        kernel_execution_count: int | None = None,
     ):
         """Write execution outputs back to a notebook cell.
 
@@ -45,6 +46,12 @@ class ExecuteCellTool(BaseTool):
         persisted, which keeps each output's real output_type. Without them only
         the formatted strings are available (the timeout path, for example), and
         the output type can only be guessed from the string form.
+
+        When kernel_execution_count is given, it is used as the cell's
+        execution_count directly. Without it, the count is re-derived by
+        scanning the notebook's other cells, which diverges from the kernel's
+        own counter whenever the two disagree (most commonly after a kernel
+        restart mid-session).
         """
 
         with open(notebook_path, encoding="utf-8") as f:
@@ -111,12 +118,18 @@ class ExecuteCellTool(BaseTool):
         # (the raw outputs above come straight from the kernel).
         clean_notebook_outputs(notebook)
 
-        # Update execution count
-        max_count = 0
-        for c in notebook.cells:
-            if c.cell_type == "code" and c.execution_count:
-                max_count = max(max_count, c.execution_count)
-        cell.execution_count = max_count + 1
+        # Update execution count. Prefer the kernel's own reported count; it is
+        # the authoritative source and can diverge from a file-scan heuristic
+        # (e.g. after a kernel restart resets the kernel's counter below the
+        # notebook's existing max).
+        if kernel_execution_count is not None:
+            cell.execution_count = kernel_execution_count
+        else:
+            max_count = 0
+            for c in notebook.cells:
+                if c.cell_type == "code" and c.execution_count:
+                    max_count = max(max_count, c.execution_count)
+            cell.execution_count = max_count + 1
 
         # An execute_result carries the execution count of the cell that produced it.
         for output in cell.outputs:
@@ -274,17 +287,23 @@ class ExecuteCellTool(BaseTool):
 
                 # Execute without RTC metadata
                 raw_outputs: list[dict] = []
+                execution_count_out: list[int] = []
                 outputs = await execute_via_execution_stack(
                     serverapp=serverapp,
                     kernel_id=kernel_id,
                     code=code_to_execute,
                     timeout=timeout_seconds,
                     raw_outputs=raw_outputs,
+                    execution_count_out=execution_count_out,
                 )
 
                 # Write outputs back to file
                 await self._write_outputs_to_cell(
-                    notebook_path, cell_index, outputs, raw_outputs=raw_outputs
+                    notebook_path,
+                    cell_index,
+                    outputs,
+                    raw_outputs=raw_outputs,
+                    kernel_execution_count=execution_count_out[0] if execution_count_out else None,
                 )
 
                 return outputs

--- a/jupyter_mcp_server/utils.py
+++ b/jupyter_mcp_server/utils.py
@@ -686,6 +686,7 @@ async def execute_via_execution_stack(
     poll_interval: float = 0.1,
     logger=None,
     raw_outputs: list | None = None,
+    execution_count_out: list | None = None,
 ) -> list[str | ImageContent]:
     """Execute code using ExecutionStack (JUPYTER_SERVER mode with jupyter-server-nbmodel).
 
@@ -707,6 +708,10 @@ async def execute_via_execution_stack(
             outputs to disk can keep each output's real ``output_type`` instead
             of re-deriving it from the formatted strings. The formatted return
             value is unaffected.
+        execution_count_out: Optional list. When provided, the kernel's own
+            reply execution_count is appended to it (once), so callers that
+            persist the cell to disk can use the kernel's real counter instead
+            of re-deriving it by scanning the notebook's existing cells.
 
     Returns:
         List of formatted outputs (strings or ImageContent)
@@ -766,6 +771,13 @@ async def execute_via_execution_stack(
                 if result is not None:
                     # Execution complete
                     logger.info(f"Execution request {request_id} completed")
+
+                    # The kernel's reply carries the real execution_count for
+                    # both the error and success cases (a kernel increments it
+                    # whether or not the cell raised); capture it before the
+                    # branches below return.
+                    if execution_count_out is not None and "execution_count" in result:
+                        execution_count_out.append(result["execution_count"])
 
                     # Check for errors
                     if "error" in result:

--- a/tests/test_execute_cell_kernel_execution_count.py
+++ b/tests/test_execute_cell_kernel_execution_count.py
@@ -1,0 +1,87 @@
+# Copyright (c) 2024- Datalayer, Inc.
+#
+# BSD 3-Clause License
+
+"""Unit tests for cell.execution_count after a kernel restart in JUPYTER_SERVER
+file mode.
+
+execute_via_execution_stack polls jupyter-server-nbmodel's ExecutionStack,
+whose result carries the kernel's own execution_count alongside the outputs.
+_write_outputs_to_cell used to ignore it and re-derive the count by scanning
+the notebook's existing cells (max + 1), which only matches the kernel's
+counter when the two never diverge. A kernel restart resets the kernel's
+counter without touching the file on disk, so the file-scan heuristic then
+stamps a cell with a count the kernel never reported.
+"""
+
+import nbformat
+import pytest
+
+from jupyter_mcp_server.tools.execute_cell_tool import ExecuteCellTool
+
+
+EXECUTE_RESULT_OUTPUT = {
+    "output_type": "execute_result",
+    "data": {"text/plain": "1"},
+    "metadata": {},
+    "execution_count": 1,
+}
+
+
+def _write_notebook_with_prior_execution_count(tmp_path, prior_count):
+    """A notebook whose first cell already ran, before a kernel restart."""
+    notebook = nbformat.v4.new_notebook()
+    ran_cell = nbformat.v4.new_code_cell(source="x = 1")
+    ran_cell.execution_count = prior_count
+    notebook.cells.append(ran_cell)
+    notebook.cells.append(nbformat.v4.new_code_cell(source="x + 1"))
+    path = tmp_path / "notebook.ipynb"
+    with open(path, "w", encoding="utf-8") as f:
+        nbformat.write(notebook, f)
+    return str(path)
+
+
+def _read_notebook(path):
+    with open(path, "r", encoding="utf-8") as f:
+        return nbformat.read(f, as_version=4)
+
+
+@pytest.mark.asyncio
+async def test_kernel_execution_count_wins_over_file_scan_after_restart():
+    """After a kernel restart, the kernel's own count is persisted, not max+1."""
+    import tempfile
+    from pathlib import Path
+
+    with tempfile.TemporaryDirectory() as tmp:
+        tmp_path = Path(tmp)
+        # Cell 0 ran as execution_count=5 before the kernel restarted.
+        path = _write_notebook_with_prior_execution_count(tmp_path, prior_count=5)
+        tool = ExecuteCellTool()
+
+        # The kernel restarted and its own counter is back at 1, per its reply.
+        await tool._write_outputs_to_cell(
+            path, 1, [], raw_outputs=[EXECUTE_RESULT_OUTPUT], kernel_execution_count=1
+        )
+
+        cell = _read_notebook(path).cells[1]
+        assert cell.execution_count == 1
+        assert cell.outputs[0]["execution_count"] == 1
+
+
+@pytest.mark.asyncio
+async def test_file_scan_fallback_unchanged_without_kernel_count():
+    """Callers that cannot report a kernel execution_count keep the old heuristic."""
+    import tempfile
+    from pathlib import Path
+
+    with tempfile.TemporaryDirectory() as tmp:
+        tmp_path = Path(tmp)
+        path = _write_notebook_with_prior_execution_count(tmp_path, prior_count=5)
+        tool = ExecuteCellTool()
+
+        await tool._write_outputs_to_cell(
+            path, 1, [], raw_outputs=[EXECUTE_RESULT_OUTPUT]
+        )
+
+        cell = _read_notebook(path).cells[1]
+        assert cell.execution_count == 6


### PR DESCRIPTION
## Root cause

`execute_via_execution_stack` (JUPYTER_SERVER file mode, no live YDoc) reads `result["outputs"]` from `ExecutionStack.get()` but never reads the same reply's top-level `execution_count`, even though `jupyter-server-nbmodel`'s `_execute_snippet` returns it right alongside `outputs`. `_write_outputs_to_cell` then re-derives the cell's `execution_count` by scanning the notebook's other cells (`max(existing) + 1`), which only matches the kernel's real counter when the two never diverge. A kernel restart resets the kernel's counter without touching the file on disk, so the next execution gets stamped with the file-scan guess instead of the kernel's own reported count.

Fixes #313.

## Invariant

`cell.execution_count` (and the `execute_result` output's own `execution_count`) reflects the kernel's own counter whenever the kernel reports one, not a value re-derived from the notebook file.

## Fix

- `execute_via_execution_stack` gains an optional `execution_count_out` out-param (same shape as the existing `raw_outputs` one) and appends the reply's `execution_count` to it once, for both the success and error branches (a kernel increments its counter either way).
- `_write_outputs_to_cell` gains an optional `kernel_execution_count` parameter; when given, it is used directly instead of the file-scan heuristic.
- The one file-mode call site now threads the kernel's reported count through. The RTC call site is untouched: `jupyter-server-nbmodel` already writes `execution_count` into the Yjs cell directly in that path.
- Without a kernel count (e.g. the timeout path, which only has formatted strings), the old heuristic is unchanged.

## Verification

Docker (`python:3.10-slim`, matching the CI matrix's lower bound), two isolated checkouts (branch and a `git worktree` of `main`) so the differential's provenance is real, confirmed via `jupyter_mcp_server.__file__` on each side:

- New regression test (`tests/test_execute_cell_kernel_execution_count.py`): a notebook where cell 0 already ran as `execution_count=5`, cell 1 executed with a simulated post-restart kernel reply reporting `execution_count=1`. FAILS on `main` (`TypeError: unexpected keyword argument 'kernel_execution_count'`), PASSES on the branch (`cell.execution_count == 1`).
- Full existing suite (`tests/`) run on both sides for comparison: identical baseline of 58 pre-existing errors (JupyterLab fails to start in this container) and one pre-existing unrelated failure (`test_otel_integration.py::test_span_log_summary`) on both `main` and the branch. No new failures from this change.
- Smoke test from `build.yml` (bare `pip install .`, import every submodule, `jupyter-mcp-server --help`, extension listing) and `scripts/sync_mcpb_version.py --check`: both pass.

Not verified: a live kernel-restart end-to-end run against a real JupyterLab server (this container's JupyterLab fails to start regardless of this change, a pre-existing environment gap, not something this PR touches).
