### PR TITLE
fix(tools): report real kernel liveness for list_notebooks in JUPYTER_SERVER mode

### DIFF
--- a/jupyter_mcp_server/notebook_manager.py
+++ b/jupyter_mcp_server/notebook_manager.py
@@ -382,9 +382,15 @@ class NotebookManager:
             return self._notebooks[current]["notebook_info"].get("path")
         return None
 
-    def list_all_notebooks(self) -> dict[str, dict[str, Any]]:
+    def list_all_notebooks(self, kernel_manager: Any | None = None) -> dict[str, dict[str, Any]]:
         """
         Get information about all managed notebooks.
+
+        Args:
+            kernel_manager: Jupyter server's kernel manager (JUPYTER_SERVER mode only).
+                In that mode `kernel` is a plain dict ({"id": kernel_id}), not a
+                KernelClient, so liveness has to be checked against the real kernel
+                manager instead of via `is_alive()`.
 
         Returns:
             Dictionary with notebook names as keys and their info as values
@@ -398,9 +404,11 @@ class NotebookManager:
             kernel_status = "unknown"
             if kernel:
                 try:
-                    kernel_status = (
-                        "alive" if hasattr(kernel, "is_alive") and kernel.is_alive() else "dead"
-                    )
+                    if hasattr(kernel, "is_alive"):
+                        kernel_status = "alive" if kernel.is_alive() else "dead"
+                    elif isinstance(kernel, dict) and kernel_manager is not None:
+                        kernel_id = kernel.get("id")
+                        kernel_status = "alive" if kernel_id and kernel_id in kernel_manager else "dead"
                 except Exception:
                     kernel_status = "error"
             else:

--- a/jupyter_mcp_server/server.py
+++ b/jupyter_mcp_server/server.py
@@ -469,6 +469,7 @@ async def list_notebooks() -> (
     return await ListNotebooksTool().execute(
         mode=server_context.mode,
         notebook_manager=notebook_manager,
+        kernel_manager=server_context.kernel_manager,
     )
 
 

--- a/jupyter_mcp_server/tools/list_notebooks_tool.py
+++ b/jupyter_mcp_server/tools/list_notebooks_tool.py
@@ -41,7 +41,7 @@ class ListNotebooksTool(BaseTool):
             return "No notebook manager available."
 
         # Get all managed notebooks
-        managed_notebooks = notebook_manager.list_all_notebooks()
+        managed_notebooks = notebook_manager.list_all_notebooks(kernel_manager=kernel_manager)
 
         if not managed_notebooks:
             return "No managed notebooks. Use the use_notebook tool to manage notebooks first."

--- a/tests/test_notebook_manager_list_all_notebooks_kernel_status.py
+++ b/tests/test_notebook_manager_list_all_notebooks_kernel_status.py
@@ -1,0 +1,84 @@
+# Copyright (c) 2024- Datalayer, Inc.
+#
+# BSD 3-Clause License
+
+"""Unit tests for NotebookManager.list_all_notebooks kernel_status reporting.
+
+These use an in-memory NotebookManager with minimal kernel/kernel-manager
+stand-ins, so no running Jupyter server is required.
+"""
+
+from jupyter_mcp_server.notebook_manager import NotebookManager
+
+
+class FakeKernelClient:
+    """MCP_SERVER-mode kernel: has is_alive()."""
+
+    def __init__(self, alive=True):
+        self._alive = alive
+
+    def is_alive(self):
+        return self._alive
+
+
+class FakeServerKernelManager:
+    """Stand-in for the Jupyter server's real kernel manager: liveness is
+    queried via `kernel_id in kernel_manager`, as restart_notebook_tool.py and
+    use_notebook_tool.py already do for JUPYTER_SERVER mode."""
+
+    def __init__(self, live_ids):
+        self._live_ids = set(live_ids)
+
+    def __contains__(self, kernel_id):
+        return kernel_id in self._live_ids
+
+
+def test_list_all_notebooks_mcp_server_mode_kernel_status_unaffected():
+    """MCP_SERVER-mode kernels (KernelClient-shaped) keep using is_alive(),
+    regardless of whether a kernel_manager is passed."""
+    nm = NotebookManager()
+    nm.add_notebook("alive-nb", FakeKernelClient(alive=True))
+    nm.add_notebook("dead-nb", FakeKernelClient(alive=False))
+
+    result = nm.list_all_notebooks()
+
+    assert result["alive-nb"]["kernel_status"] == "alive"
+    assert result["dead-nb"]["kernel_status"] == "dead"
+
+
+def test_list_all_notebooks_jupyter_server_mode_reports_alive_kernel():
+    """JUPYTER_SERVER-mode kernels are a plain dict ({"id": kernel_id}), not a
+    KernelClient. Without a kernel_manager to consult, hasattr(kernel,
+    'is_alive') is always False, so this used to report 'dead' unconditionally
+    even for a kernel that is actually running."""
+    nm = NotebookManager()
+    nm.add_notebook("nb", {"id": "kernel-123"}, server_url="local")
+    kernel_manager = FakeServerKernelManager(live_ids=["kernel-123"])
+
+    result = nm.list_all_notebooks(kernel_manager=kernel_manager)
+
+    assert result["nb"]["kernel_status"] == "alive"
+
+
+def test_list_all_notebooks_jupyter_server_mode_reports_dead_kernel():
+    """A JUPYTER_SERVER-mode kernel that the real kernel manager no longer
+    knows about (culled/restarted) still reports 'dead'."""
+    nm = NotebookManager()
+    nm.add_notebook("nb", {"id": "kernel-gone"}, server_url="local")
+    kernel_manager = FakeServerKernelManager(live_ids=[])
+
+    result = nm.list_all_notebooks(kernel_manager=kernel_manager)
+
+    assert result["nb"]["kernel_status"] == "dead"
+
+
+def test_list_all_notebooks_jupyter_server_mode_without_kernel_manager_is_unknown():
+    """Without a kernel_manager to consult (e.g. an older caller), a
+    dict-shaped kernel is honestly reported 'unknown' rather than the old
+    silent-'dead' default."""
+    nm = NotebookManager()
+    nm.add_notebook("nb", {"id": "kernel-123"}, server_url="local")
+
+    result = nm.list_all_notebooks()
+
+    assert result["nb"]["kernel_status"] == "unknown"


### PR DESCRIPTION
## Root cause

`NotebookManager.list_all_notebooks()` (`jupyter_mcp_server/notebook_manager.py:398`)
decides kernel liveness with `hasattr(kernel, 'is_alive') and kernel.is_alive()`. That
works in `MCP_SERVER` mode, where `kernel` is a real `jupyter_kernel_client.KernelClient`,
but in `JUPYTER_SERVER` (extension) mode `kernel` is a plain `{"id": kernel_id}` dict
(see `use_notebook_tool.py`, `restart_notebook_tool.py`'s `_reprovision_kernel`, and the
on-demand kernel-start paths in `execute_cell_tool.py`/`execute_code_tool.py`). A dict
has no `is_alive`, so the check is unconditionally `False` and `kernel_status` reports
`"dead"` for every notebook regardless of the kernel's real state. `list_notebooks`
takes no parameters, so every call in extension mode hits this.

## Fix

Thread the server's real `kernel_manager` through (`server.py`'s `list_notebooks` ->
`ListNotebooksTool.execute` -> `list_all_notebooks`) and, for a dict-shaped kernel, check
liveness the way the rest of the codebase already does for `JUPYTER_SERVER` mode:
`kernel_id in kernel_manager` (same pattern as `restart_notebook_tool.py:94` and
`use_notebook_tool.py:234`). `MCP_SERVER` mode is untouched. When no `kernel_manager` is
passed, a dict-shaped kernel now reports `"unknown"` instead of the previous incorrect
`"dead"`.

The same `hasattr` pattern also exists at `server.py:286` (the standalone `/api/healthz`
route). I left it alone: that route only runs in `MCP_SERVER` mode, where the kernel is
always a real `KernelClient`, so it never sees a dict-shaped kernel and isn't part of
this bug.

## Verification

Added `tests/test_notebook_manager_list_all_notebooks_kernel_status.py`, constructing a
`NotebookManager` directly (no live Jupyter server needed):
- MCP_SERVER-mode kernel (KernelClient-shaped): unaffected, still uses `is_alive()`.
- JUPYTER_SERVER-mode kernel present in a fake kernel manager: now reports `alive`.
- JUPYTER_SERVER-mode kernel absent from the kernel manager: reports `dead`.
- JUPYTER_SERVER-mode kernel with no kernel_manager passed: reports `unknown`.

Ran on `main` (`a5c5684`): 3 of the 4 new tests fail, confirming the bug. Ran on this
branch: all 4 pass. Also ran the full non-integration test suite (everything except the
tests that spin up a real `jupyter lab` process, which needs a non-root user to start):
172 passed, no regressions, plus the existing `test_restart_notebook_tool.py` suite
green.

Fixes #315
