### PR TITLE
fix(execute): track a timed-out execute_code's background task so is_kernel_busy sees it

### DIFF
--- a/jupyter_mcp_server/tools/execute_code_tool.py
+++ b/jupyter_mcp_server/tools/execute_code_tool.py
@@ -15,6 +15,7 @@ from mcp.types import ImageContent
 from jupyter_mcp_server.hooks import HookEvent, HookRegistry
 from jupyter_mcp_server.notebook_manager import NotebookManager
 from jupyter_mcp_server.tools._base import BaseTool, ServerMode
+from jupyter_mcp_server.utils import track_pending_execution
 
 logger = logging.getLogger(__name__)
 
@@ -166,11 +167,21 @@ class ExecuteCodeTool(BaseTool):
         try:
             # Execute code directly with kernel
             execution_task = asyncio.create_task(asyncio.to_thread(sandbox_client.execute, code))
+            track_pending_execution(sandbox_client, execution_task)
 
-            # Wait for execution with timeout
-            try:
-                outputs = await asyncio.wait_for(execution_task, timeout=timeout)
-            except asyncio.TimeoutError as e:
+            # asyncio.wait_for() would also work for the happy path, but on
+            # timeout it cancels the task and then awaits it until asyncio
+            # settles it as done -- which happens immediately even though
+            # the underlying OS thread (started via to_thread) keeps running
+            # kernel.execute() in the background, since the wrapping Future
+            # can be marked cancelled without the thread actually stopping.
+            # That makes execution_task.done() report True right away,
+            # defeating track_pending_execution above. asyncio.wait() does
+            # not auto-cancel, so leaving the task un-awaited past cancel()
+            # below keeps it accurately pending until the real thread returns.
+            _, pending = await asyncio.wait({execution_task}, timeout=timeout)
+
+            if execution_task in pending:
                 execution_task.cancel()
                 try:
                     if sandbox_client and hasattr(sandbox_client, "interrupt"):
@@ -188,10 +199,12 @@ class ExecuteCodeTool(BaseTool):
                     kernel_id=kid,
                     metadata={},
                     outputs=result,
-                    error=e,
+                    error=asyncio.TimeoutError(),
                     context=hook_ctx,
                 )
                 return result
+
+            outputs = execution_task.result()
 
             # Process and extract outputs
             if outputs:

--- a/tests/test_execute_code_orphaned_timeout.py
+++ b/tests/test_execute_code_orphaned_timeout.py
@@ -1,0 +1,99 @@
+# Copyright (c) 2024- Datalayer, Inc.
+#
+# BSD 3-Clause License
+
+"""Regression test for the timeout path in execute_code abandoning its
+background execution.
+
+asyncio.Task.cancel() on a task wrapping asyncio.to_thread() cannot stop the
+underlying OS thread: kernel.execute(code) keeps running in the background
+after a timeout has already been raised back to the caller.
+_execute_on_kernel must record that task via track_pending_execution so
+is_kernel_busy()/wait_for_kernel_idle() see the still-running execution,
+the same way execute_cell_tool.py already does. Without it, a subsequent
+execute_code/execute_cell call against the same kernel can start immediately
+while the abandoned thread is still talking to the kernel.
+"""
+
+import asyncio
+import time
+
+import pytest
+
+from jupyter_mcp_server.tools.execute_code_tool import ExecuteCodeTool
+from jupyter_mcp_server.utils import is_kernel_busy, wait_for_kernel_idle
+
+
+class FakeKernel:
+    """Minimal stand-in covering the surface _execute_on_kernel uses."""
+
+    def __init__(self, execute_impl):
+        self.interrupted = False
+        self._execute_impl = execute_impl
+
+    def execute(self, code):
+        return self._execute_impl()
+
+    def interrupt(self):
+        self.interrupted = True
+
+
+# The tool's timeout monitoring goes through asyncio.wait_for, which can burn
+# real wall clock before control returns to the caller. The background
+# execute_impl must still be running by the time we make our first assertion
+# (mirrors tests/test_execute_orphaned_timeout.py's _ORPHANED_TASK_SLEEP).
+_ORPHANED_TASK_SLEEP = 2.0
+
+
+async def _noop_wait_for_kernel_idle(kernel, max_wait_seconds=30):
+    return None
+
+
+@pytest.mark.asyncio
+async def test_execute_code_timeout_leaves_kernel_marked_busy_until_thread_finishes():
+    """Regression for _execute_on_kernel never calling track_pending_execution:
+    a timed-out execute_code call must still leave is_kernel_busy() True while
+    the orphaned background thread is running."""
+    kernel = FakeKernel(lambda: time.sleep(_ORPHANED_TASK_SLEEP))
+
+    result = await ExecuteCodeTool()._execute_on_kernel(
+        sandbox_client=kernel,
+        kid="kernel-1",
+        code="time.sleep(60)",
+        timeout=0,
+        wait_for_kernel_idle_fn=_noop_wait_for_kernel_idle,
+        safe_extract_outputs_fn=lambda outputs: outputs,
+    )
+
+    assert result == ["[TIMEOUT ERROR: IPython execution exceeded 0 seconds and was interrupted]"]
+    # The tool already returned its [TIMEOUT ...] result, but the fake
+    # kernel.execute is still asleep in its background thread.
+    assert is_kernel_busy(kernel) is True
+
+    await asyncio.sleep(_ORPHANED_TASK_SLEEP + 0.5)
+
+    assert is_kernel_busy(kernel) is False
+
+
+@pytest.mark.asyncio
+async def test_wait_for_kernel_idle_blocks_until_orphaned_execute_code_finishes():
+    """The guard every execute_code/execute_cell call makes before starting a
+    new execution must actually wait for a prior timed-out execute_code call
+    to finish."""
+    kernel = FakeKernel(lambda: time.sleep(_ORPHANED_TASK_SLEEP))
+
+    await ExecuteCodeTool()._execute_on_kernel(
+        sandbox_client=kernel,
+        kid="kernel-1",
+        code="time.sleep(60)",
+        timeout=0,
+        wait_for_kernel_idle_fn=_noop_wait_for_kernel_idle,
+        safe_extract_outputs_fn=lambda outputs: outputs,
+    )
+
+    start = time.time()
+    await wait_for_kernel_idle(kernel, max_wait_seconds=10)
+    elapsed = time.time() - start
+
+    assert elapsed >= 0.5
+    assert is_kernel_busy(kernel) is False


### PR DESCRIPTION
### Root cause

`_execute_on_kernel` (`execute_code`, MCP_SERVER mode) runs `kernel.execute(code)` via `asyncio.to_thread` and bounds it with `asyncio.wait_for(execution_task, timeout=timeout)`. On timeout it cancels the task and returns a `[TIMEOUT ERROR ...]` string, but `asyncio.Task.cancel()` cannot stop the underlying OS thread once it has started: `kernel.execute()` keeps running in the background, still talking to the kernel over ZMQ, after the caller already has its timeout result.

Unlike `execute_cell_tool.py`'s streaming path and `execute_cell_with_forced_sync` (both fixed in #308), this function never called `track_pending_execution(kernel, execution_task)`, so `is_kernel_busy()`/`wait_for_kernel_idle()` never see the orphaned execution and a following call can start immediately against the same kernel while the abandoned thread is still live.

Adding that call alone is not sufficient here, and this is the reason the fix is not a one-liner. `asyncio.wait_for()`'s cancel-on-timeout path awaits the wrapped task until asyncio settles it as done before raising `TimeoutError`. For a task wrapping `asyncio.to_thread`, the wrapping `Future` can be marked cancelled by asyncio immediately, independent of whether the underlying OS thread actually stops (a running `concurrent.futures.Future` cannot be cancelled, but the asyncio-side bridge future can). Measured directly: `execution_task.done()` becomes `True` in under a millisecond after `wait_for` raises, while a fake 2-second background execute is still running. `track_pending_execution`'s `is_kernel_busy()` is driven entirely by `task.done()`, so it reads `False` immediately regardless of where the tracking call is added.

### Fix

Switched the timeout wait from `asyncio.wait_for()` to `asyncio.wait()`, which does not auto-cancel on timeout. Cancelling the task explicitly and returning without awaiting it again (the same pattern already used by the streaming and forced-sync call sites) keeps `execution_task.done()` accurately `False` until the real thread returns. `track_pending_execution(kernel, execution_task)` is called right after creating the task, mirroring `execute_cell_tool.py`.

`kernel._mcp_pending_execution` has exactly two writers, both inside `track_pending_execution` (`utils.py:516`, `:520`); this PR does not add a new writer, it makes this call site call the existing one.

### Verified

In a clean `python:3.12-slim` container, editable install, HEAD `a5c5684`:

- New `tests/test_execute_code_orphaned_timeout.py` (2 tests, fake kernel, same style as `tests/test_execute_orphaned_timeout.py`): both fail on unfixed `execute_code_tool.py` (`is_kernel_busy` reads `False` immediately after timeout instead of staying `True` until the background thread finishes), pass on this branch. `__file__`-checked on both sides.
- Confirmed the naive fix (add `track_pending_execution` alone, keep `asyncio.wait_for`) still fails the same way, isolating the `wait_for`/`to_thread` cancellation interaction as the actual root cause before switching to `asyncio.wait()`.
- `tests/test_execute_orphaned_timeout.py` and `tests/test_execute_code_timeout.py` (siblings covering the other call sites and the timeout-clamping logic): unaffected, still pass.
- `tests/test_execute_code_kernel_id.py` against the real `jupyter_server` fixture with two real kernels (`TEST_MCP_SERVER=true TEST_JUPYTER_SERVER=false pytest`): all 4 pass, confirming the success path through the rewritten wait still returns the right output from the right kernel.
- Manually exercised the error path (`kernel.execute` raising) and the success path (kernel returning outputs): both still route through the same `except Exception` / output-extraction code as before, unchanged.
- `ruff check` / `mypy` on the changed file return the same pre-existing, unrelated findings as on `origin/main` (matches this repo's known `lint.sh` local/CI mismatch); none of the new findings touch the lines this PR adds, and the one pre-existing `I001` import-order finding on this file's import block predates this change.

Not verified: a real kernel actually still executing 2+ seconds after a genuine timeout against a live server (the fake-kernel tests exercise the exact `wait()`/cancel/`is_kernel_busy` control flow, but not a real ZMQ execute that ignores an interrupt).

Fixes #317
