### PR TITLE
fix(tools): forward reconnect_interval/timeout in use_notebook's MCP_SERVER kernel creation

### DIFF
--- a/jupyter_mcp_server/tools/use_notebook_tool.py
+++ b/jupyter_mcp_server/tools/use_notebook_tool.py
@@ -243,12 +243,17 @@ class UseNotebookTool(BaseTool):
                 # Ensure the kernel is started with the same path as the notebook.
                 # Routed through code-sandboxes (jupyter variant) rather than a
                 # direct KernelClient; the sandbox creates and starts the kernel.
+                from jupyter_mcp_server.config import get_config
+
+                config = get_config()
                 kernel = create_jupyter_sandbox_kernel(
                     server_url=runtime_url,
                     token=runtime_token,
                     kernel_id=kernel_id,
                     path=notebook_path,
                     logger=logger,
+                    timeout=getattr(config, "execution_timeout", None),
+                    reconnect_interval=getattr(config, "reconnect_interval", 0) or 0,
                 )
 
                 info_list.append(f"[INFO] Connected to kernel '{kernel.id}'.")

--- a/tests/test_use_notebook_reconnect_interval.py
+++ b/tests/test_use_notebook_reconnect_interval.py
@@ -1,0 +1,105 @@
+# Copyright (c) 2024- Datalayer, Inc.
+#
+# BSD 3-Clause License
+
+"""use_notebook's MCP_SERVER kernel-creation path must forward the configured
+reconnect_interval/execution_timeout to create_jupyter_sandbox_kernel, the same
+way its sibling call sites (utils.create_kernel, execute_code_tool) already do.
+"""
+
+from unittest.mock import patch
+
+import pytest
+
+import jupyter_mcp_server.tools.use_notebook_tool as use_notebook_tool
+from jupyter_mcp_server.config import reset_config, set_config
+from jupyter_mcp_server.notebook_manager import NotebookManager
+from jupyter_mcp_server.tools._base import ServerMode
+from jupyter_mcp_server.tools.use_notebook_tool import UseNotebookTool
+
+
+class _FakeContents:
+    @staticmethod
+    def create_notebook(path, content=None):
+        return None
+
+    @staticmethod
+    def list_directory(path):
+        return []
+
+
+class _FakeKernels:
+    @staticmethod
+    def list_kernels():
+        return []
+
+
+class FakeServerClient:
+    """Stand-in for JupyterServerClient: no live server needed, only the
+    surface use_notebook touches before it reaches kernel creation."""
+
+    contents = _FakeContents
+    kernels = _FakeKernels
+
+    def get_status(self):
+        return {}
+
+
+class FakeKernel:
+    id = "kernel-1"
+
+
+@pytest.fixture
+def configured_reconnect():
+    reset_config()
+    set_config(reconnect_interval=5, execution_timeout=300)
+    yield
+    reset_config()
+
+
+@pytest.mark.asyncio
+async def test_use_notebook_mcp_server_forwards_reconnect_interval(configured_reconnect):
+    """A configured --reconnect-interval must reach create_jupyter_sandbox_kernel
+    on the use_notebook MCP_SERVER path, not be silently dropped."""
+    with patch.object(
+        use_notebook_tool, "create_jupyter_sandbox_kernel", return_value=FakeKernel()
+    ) as mock_create:
+        await UseNotebookTool().execute(
+            mode=ServerMode.MCP_SERVER,
+            server_client=FakeServerClient(),
+            notebook_manager=NotebookManager(),
+            notebook_name="nb",
+            notebook_path="nb.ipynb",
+            use_mode="create",
+            runtime_url="http://localhost:8888",
+            runtime_token="secret",
+        )
+
+    assert mock_create.call_count == 1
+    kwargs = mock_create.call_args.kwargs
+    assert kwargs["reconnect_interval"] == 5
+    assert kwargs["timeout"] == 300
+
+
+@pytest.mark.asyncio
+async def test_use_notebook_mcp_server_defaults_reconnect_interval_to_zero(configured_reconnect):
+    """No --reconnect-interval configured means 0 (disabled), matching the
+    sibling call sites' `getattr(config, "reconnect_interval", 0) or 0`."""
+    reset_config()
+
+    with patch.object(
+        use_notebook_tool, "create_jupyter_sandbox_kernel", return_value=FakeKernel()
+    ) as mock_create:
+        await UseNotebookTool().execute(
+            mode=ServerMode.MCP_SERVER,
+            server_client=FakeServerClient(),
+            notebook_manager=NotebookManager(),
+            notebook_name="nb2",
+            notebook_path="nb2.ipynb",
+            use_mode="create",
+            runtime_url="http://localhost:8888",
+            runtime_token="secret",
+        )
+
+    kwargs = mock_create.call_args.kwargs
+    assert kwargs["reconnect_interval"] == 0


### PR DESCRIPTION
Fixes #321.

## Root cause

`UseNotebookTool.execute()`'s MCP_SERVER branch calls `create_jupyter_sandbox_kernel(...)`
without `reconnect_interval` or `timeout`. The two sibling call sites that create a kernel
the same way, `utils.create_kernel()` and `execute_code_tool.py`'s `_connect_to_kernel`,
both forward `reconnect_interval=getattr(config, "reconnect_interval", 0) or 0` and
`timeout=getattr(config, "execution_timeout", None)`. `use_notebook` is the call site that
actually establishes the kernel connection in MCP_SERVER mode, so a configured
`--reconnect-interval` was silently inert there.

## Fix

Forward both values the same way the sibling call sites already do, so all three
`create_jupyter_sandbox_kernel` call sites stay consistent.

## Verified

Docker (python:3.11-slim, current main `1c52823`): the new regression test fails on main
(`KeyError: 'reconnect_interval'`) and passes on this branch, confirmed the loaded module
is the branch's own file via `__file__`. Also ran the existing `use_notebook`/`restart_notebook`
unit-test files that don't need a live server (`test_use_notebook_create_local.py`,
`test_use_notebook_ui_open.py`, `test_restart_notebook_tool.py`) alongside the new test, all
green. Checked `ruff`/`mypy` on the touched files: both report only pre-existing errors
elsewhere in the file, none on the changed lines.

I did not run the full live-server suite (`tests/conftest.py`'s session-scoped `jupyter_server`
fixture), since this change is scoped to a mocked, no-live-server code path and the fixture
mutates tracked notebook content as a side effect.
