### PR TITLE
deps: migrate to mcp version 2

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
   ~ BSD 3-Clause License
 -->
 
-[![Datalayer](https://images.datalayer.io/brand/logos/datalayer-horizontal.svg)](https://datalayer.io)
+[![Datalayer](https://images.datalayer.io/brand/logos/datalayer-horizontal.svg)](https://datalayer.ai)
 
 [![Become a Sponsor](https://img.shields.io/static/v1?label=Become%20a%20Sponsor&message=%E2%9D%A4&logo=GitHub&style=flat&color=1ABC9C)](https://github.com/sponsors/datalayer)
 

--- a/dev/README.md
+++ b/dev/README.md
@@ -4,6 +4,6 @@
   ~ BSD 3-Clause License
 -->
 
-[![Datalayer](https://images.datalayer.io/brand/logos/datalayer-horizontal.svg)](https://datalayer.io)
+[![Datalayer](https://images.datalayer.io/brand/logos/datalayer-horizontal.svg)](https://datalayer.ai)
 
 [![Become a Sponsor](https://img.shields.io/static/v1?label=Become%20a%20Sponsor&message=%E2%9D%A4&logo=GitHub&style=flat&color=1ABC9C)](https://github.com/sponsors/datalayer)

--- a/dev/content/README.md
+++ b/dev/content/README.md
@@ -4,6 +4,6 @@
   ~ BSD 3-Clause License
 -->
 
-[![Datalayer](https://images.datalayer.io/brand/logos/datalayer-horizontal.svg)](https://datalayer.io)
+[![Datalayer](https://images.datalayer.io/brand/logos/datalayer-horizontal.svg)](https://datalayer.ai)
 
 [![Become a Sponsor](https://img.shields.io/static/v1?label=Become%20a%20Sponsor&message=%E2%9D%A4&logo=GitHub&style=flat&color=1ABC9C)](https://github.com/sponsors/datalayer)

--- a/docs/.yarnrc.yml
+++ b/docs/.yarnrc.yml
@@ -1,4 +1,4 @@
-# Copyright (c) Datalayer, Inc. https://datalayer.io
+# Copyright (c) Datalayer, Inc. https://datalayer.ai
 # Distributed under the terms of the MIT License.
 
 enableImmutableInstalls: false

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -2,7 +2,7 @@
 #
 # BSD 3-Clause License
 
-# Copyright (c) Datalayer, Inc. https://datalayer.io
+# Copyright (c) Datalayer, Inc. https://datalayer.ai
 # Distributed under the terms of the MIT License.
 
 SHELL=/bin/bash

--- a/docs/README.md
+++ b/docs/README.md
@@ -4,13 +4,13 @@
   ~ BSD 3-Clause License
 -->
 
-[![Datalayer](https://images.datalayer.io/brand/logos/datalayer-horizontal.svg)](https://datalayer.io)
+[![Datalayer](https://images.datalayer.io/brand/logos/datalayer-horizontal.svg)](https://datalayer.ai)
 
 [![Become a Sponsor](https://img.shields.io/static/v1?label=Become%20a%20Sponsor&message=%E2%9D%A4&logo=GitHub&style=flat&color=1ABC9C)](https://github.com/sponsors/datalayer)
 
 # Jupyter MCP Server Docs
 
-> Source code for the [Jupyter MCP Server Documentation](https://datalayer.io), built with [Docusaurus](https://docusaurus.io).
+> Source code for the [Jupyter MCP Server Documentation](https://datalayer.ai), built with [Docusaurus](https://docusaurus.io).
 
 ```bash
 # Install the dependencies.

--- a/examples/README.md
+++ b/examples/README.md
@@ -4,7 +4,7 @@
   ~ BSD 3-Clause License
 -->
 
-[![Datalayer](https://images.datalayer.io/brand/logos/datalayer-horizontal.svg)](https://datalayer.io)
+[![Datalayer](https://images.datalayer.io/brand/logos/datalayer-horizontal.svg)](https://datalayer.ai)
 
 [![Become a Sponsor](https://img.shields.io/static/v1?label=Become%20a%20Sponsor&message=%E2%9D%A4&logo=GitHub&style=flat&color=1ABC9C)](https://github.com/sponsors/datalayer)
 

--- a/examples/cli/README.md
+++ b/examples/cli/README.md
@@ -4,7 +4,7 @@
   ~ BSD 3-Clause License
 -->
 
-[![Datalayer](https://images.datalayer.io/brand/logos/datalayer-horizontal.svg)](https://datalayer.io)
+[![Datalayer](https://images.datalayer.io/brand/logos/datalayer-horizontal.svg)](https://datalayer.ai)
 
 [![Become a Sponsor](https://img.shields.io/static/v1?label=Become%20a%20Sponsor&message=%E2%9D%A4&logo=GitHub&style=flat&color=1ABC9C)](https://github.com/sponsors/datalayer)
 

--- a/ext/README.md
+++ b/ext/README.md
@@ -4,7 +4,7 @@
   ~ BSD 3-Clause License
 -->
 
-[![Datalayer](https://images.datalayer.io/brand/logos/datalayer-horizontal.svg)](https://datalayer.io)
+[![Datalayer](https://images.datalayer.io/brand/logos/datalayer-horizontal.svg)](https://datalayer.ai)
 
 [![Become a Sponsor](https://img.shields.io/static/v1?label=Become%20a%20Sponsor&message=%E2%9D%A4&logo=GitHub&style=flat&color=1ABC9C)](https://github.com/sponsors/datalayer)
 

--- a/ext/sandboxes/README.md
+++ b/ext/sandboxes/README.md
@@ -4,7 +4,7 @@
   ~ BSD 3-Clause License
 -->
 
-[![Datalayer](https://images.datalayer.io/brand/logos/datalayer-horizontal.svg)](https://datalayer.io)
+[![Datalayer](https://images.datalayer.io/brand/logos/datalayer-horizontal.svg)](https://datalayer.ai)
 
 [![Become a Sponsor](https://img.shields.io/static/v1?label=Become%20a%20Sponsor&message=%E2%9D%A4&logo=GitHub&style=flat&color=1ABC9C)](https://github.com/sponsors/datalayer)
 

--- a/ext/sandboxes/pyproject.toml
+++ b/ext/sandboxes/pyproject.toml
@@ -24,8 +24,8 @@ classifiers = [
 ]
 dependencies = [
     "code-sandboxes",
-    "datalayer_reactor",
-    "jupyter_mcp_server",
+    "datalayer-reactor",
+    "jupyter-mcp-server",
 ]
 
 [project.optional-dependencies]

--- a/ext/sandboxes/pyproject.toml
+++ b/ext/sandboxes/pyproject.toml
@@ -13,7 +13,7 @@ description = "Sandboxes extension for Jupyter MCP Server (launch/use code-sandb
 readme = "README.md"
 requires-python = ">=3.10"
 license = { text = "BSD-3-Clause" }
-authors = [{ name = "Datalayer", email = "info@datalayer.io" }]
+authors = [{ name = "Datalayer", email = "info@datalayer.ai" }]
 keywords = ["jupyter", "mcp", "sandbox", "extension"]
 classifiers = [
     "License :: OSI Approved :: BSD License",

--- a/jupyter_mcp_server/__version__.py
+++ b/jupyter_mcp_server/__version__.py
@@ -4,4 +4,4 @@
 
 """Jupyter MCP Server."""
 
-__version__ = "1.1.3"
+__version__ = "1.1.4"

--- a/jupyter_mcp_server/server.py
+++ b/jupyter_mcp_server/server.py
@@ -12,7 +12,7 @@ from urllib.parse import urlsplit
 
 from code_sandboxes.interfaces import ISandboxClient
 from fastapi import Request
-from mcp.server import FastMCP
+from mcp.server.mcpserver import MCPServer
 from mcp.server.auth.provider import AccessToken
 from mcp.types import ImageContent, ToolAnnotations
 from pydantic import Field
@@ -149,7 +149,7 @@ class ManagementRouteSecurityMiddleware(BaseHTTPMiddleware):
         return await call_next(request)
 
 
-class FastMCPWithCORS(FastMCP):
+class FastMCPWithCORS(MCPServer):
     def streamable_http_app(self) -> Starlette:
         """Return StreamableHTTP server app with CORS and auth middleware.
 
@@ -159,7 +159,7 @@ class FastMCPWithCORS(FastMCP):
         # when _token_verifier is set, but NOT the AuthenticationMiddleware
         # that actually validates Bearer tokens — that requires settings.auth
         # which we don't use). Add it here directly.
-        app = super().streamable_http_app()
+        app = super().streamable_http_app(json_response=False, stateless_http=True)
 
         app.add_middleware(
             ManagementRouteSecurityMiddleware,
@@ -186,7 +186,7 @@ class FastMCPWithCORS(FastMCP):
         return app
 
 
-mcp = FastMCPWithCORS(name="Jupyter MCP Server", json_response=False, stateless_http=True)
+mcp = FastMCPWithCORS(name="Jupyter MCP Server")
 notebook_manager = NotebookManager()
 server_context = ServerContext.get_instance()
 extension_manager = get_extension_manager()

--- a/jupyter_mcp_server/tools/jupyter_cite_prompt.py
+++ b/jupyter_mcp_server/tools/jupyter_cite_prompt.py
@@ -8,7 +8,7 @@ from typing import Any
 
 from jupyter_core.utils import ensure_async
 from jupyter_server_client import JupyterServerClient
-from mcp.server.fastmcp.prompts.base import UserMessage
+from mcp.server.mcpserver.prompts.base import UserMessage
 
 from jupyter_mcp_server.models import Notebook
 from jupyter_mcp_server.notebook_manager import NotebookManager

--- a/mcpb/manifest.json
+++ b/mcpb/manifest.json
@@ -2,13 +2,13 @@
   "manifest_version": "0.4",
   "name": "jupyter-mcp-server",
   "display_name": "Jupyter MCP Server",
-  "version": "1.1.2",
+  "version": "1.1.4",
   "description": "Connect AI agents to Jupyter Notebooks - execute code, manage notebooks, and interact with kernels in real-time",
   "long_description": "The Jupyter MCP Server enables AI agents like Claude to connect to and manage Jupyter Notebooks in real-time. It provides 14 tools to execute code, manage notebooks, read and write cells, and interact with Jupyter kernels through the standardized Model Context Protocol.\n\n**Requirements:** You need a running Jupyter server (JupyterLab or Jupyter Notebook) to connect to. Start one with:\n```\npip install jupyterlab\njupyter lab --port 8888 --IdentityProvider.token MY_TOKEN\n```",
   "author": {
     "name": "Datalayer",
-    "email": "info@datalayer.io",
-    "url": "https://datalayer.io"
+    "email": "info@datalayer.ai",
+    "url": "https://datalayer.ai"
   },
   "repository": {
     "type": "git",

--- a/mcpb/pyproject.toml
+++ b/mcpb/pyproject.toml
@@ -4,7 +4,7 @@
 
 [project]
 name = "jupyter-mcp-server-mcpb"
-version = "1.1.2"
+version = "1.1.4"
 description = "Jupyter MCP Server - MCPB bundle for one-click installation in Claude Desktop"
 requires-python = ">=3.10"
 dependencies = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "jupyter_mcp_server"
-authors = [{ name = "Datalayer", email = "info@datalayer.io" }]
+authors = [{ name = "Datalayer", email = "info@datalayer.ai" }]
 dynamic = ["version"]
 readme = "README.md"
 requires-python = ">=3.10"
@@ -31,7 +31,7 @@ dependencies = [
     "jupyter-collaboration",
     "tornado>=6.1",
     "traitlets>=5.0",
-    "mcp[cli]>=2.0.0",
+    "mcp[cli]>=2.0.0,<3",
     "pydantic",
     "uvicorn",
     "typer",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ dependencies = [
     "jupyter-collaboration",
     "tornado>=6.1",
     "traitlets>=5.0",
-    "mcp[cli]>=1.10.1",
+    "mcp[cli]>=2.0.0",
     "pydantic",
     "uvicorn",
     "typer",


### PR DESCRIPTION
- [ ] Needs also to monitor other MCP Servers migrations to avoid having incompatible MCP version 1 and 2 in the same python environment
- [ ] Monitor progress on https://github.com/pydantic/pydantic-ai/pull/6738 to avoid upstream consumers breaking.
- [ ] Should Jupyter MCP Version bump to version 2 to clearly indicate breaking MCP client version?
