### PR TITLE
fix(auth): fetch anonymous XSRF cookie when no password or token is set

### DIFF
--- a/jupyter_mcp_server/auth.py
+++ b/jupyter_mcp_server/auth.py
@@ -195,3 +195,36 @@ class JupyterPasswordAuth:
             return
         for name, value in self._live_cookies().items():
             session.cookies.set(name, value)
+
+
+class JupyterAnonymousAuth(JupyterPasswordAuth):
+    """Obtains only the anonymous `_xsrf` cookie, for deployments with no
+    password and no bearer token (SSO/reverse-proxy auth, JupyterHub
+    single-user servers, `--IdentityProvider.token=''`).
+
+    XSRF-protected POST/PUT/DELETE requests need the `_xsrf` cookie Tornado's
+    login handler sets on any GET, even with no credentials being presented,
+    so this performs that GET and skips the password POST and verification
+    entirely. If the server does not enforce XSRF, no cookie is set and
+    `get_headers()` returns an empty dict, same as before this class existed.
+    """
+
+    def __init__(self, server_url: str):
+        super().__init__(server_url, password="")
+
+    def login(self, timeout: float = 10.0) -> None:
+        session = requests.Session()
+        self._session = session
+        try:
+            self._do_request(
+                "GET", f"{self.server_url}/login",
+                stage="anonymous XSRF fetch", timeout=timeout,
+                allow_redirects=False,
+            )
+            self._xsrf_token = session.cookies.get("_xsrf", "")
+            self._authenticated = True
+            logger.info(f"Anonymous XSRF cookie fetch complete for {self.server_url}")
+        except BaseException:
+            session.close()
+            self._session = None
+            raise

--- a/jupyter_mcp_server/server_context.py
+++ b/jupyter_mcp_server/server_context.py
@@ -93,7 +93,7 @@ class ServerContext:
 
         logger.info(f"Initializing MCP_SERVER mode with code_sandbox_url: {code_sandbox_url}")
 
-        from jupyter_mcp_server.auth import JupyterPasswordAuth
+        from jupyter_mcp_server.auth import JupyterAnonymousAuth, JupyterPasswordAuth
 
         try:
             # Code Sandbox auth — password takes precedence over token
@@ -107,6 +107,13 @@ class ServerContext:
                 self._install_code_sandbox_auth_retry(self._server_client)
             else:
                 self._server_client = JupyterServerClient(base_url=code_sandbox_url, token=config.code_sandbox_token)
+                if not config.code_sandbox_token:
+                    # No password and no token, but the server may still require the
+                    # anonymous `_xsrf` cookie on state-changing requests (SSO/reverse-proxy
+                    # auth, JupyterHub single-user servers, --IdentityProvider.token='').
+                    self._code_sandbox_password_auth = JupyterAnonymousAuth(code_sandbox_url)
+                    self._code_sandbox_password_auth.login()
+                    self._code_sandbox_password_auth.inject_into_session(self._server_client.http_client.session)
 
             # Document auth — only needed when the document server is explicitly
             # different from the code sandbox server. When URLs match (or document_url

--- a/jupyter_mcp_server/server_context.py
+++ b/jupyter_mcp_server/server_context.py
@@ -66,6 +66,29 @@ class ServerContext:
         if document is not None and document is not code_sandbox:
             document.close()
 
+    @staticmethod
+    def _try_anonymous_auth(code_sandbox_url):
+        """Fetch the anonymous `_xsrf` cookie.
+
+        Unlike explicit password auth, nobody configured this deployment to
+        expect a cookie, so a server that isn't reachable yet must not block
+        startup: on failure this returns the (unauthenticated) auth object
+        rather than raising. `inject_into_session`/`get_headers` already
+        no-op when `_authenticated` is False, so callers can use the result
+        unconditionally, same as before this class existed.
+        """
+        from jupyter_mcp_server.auth import JupyterAnonymousAuth
+
+        auth = JupyterAnonymousAuth(code_sandbox_url)
+        try:
+            auth.login()
+        except RuntimeError as error:
+            logger.warning(
+                f"Anonymous XSRF cookie fetch failed for {code_sandbox_url}, "
+                f"continuing without it: {error}"
+            )
+        return auth
+
     def _init_mcp_server_mode(self):
         """Initialize MCP_SERVER mode with HTTP client and optional password auth.
 
@@ -93,7 +116,7 @@ class ServerContext:
 
         logger.info(f"Initializing MCP_SERVER mode with code_sandbox_url: {code_sandbox_url}")
 
-        from jupyter_mcp_server.auth import JupyterAnonymousAuth, JupyterPasswordAuth
+        from jupyter_mcp_server.auth import JupyterPasswordAuth
 
         try:
             # Code Sandbox auth — password takes precedence over token
@@ -111,8 +134,7 @@ class ServerContext:
                     # No password and no token, but the server may still require the
                     # anonymous `_xsrf` cookie on state-changing requests (SSO/reverse-proxy
                     # auth, JupyterHub single-user servers, --IdentityProvider.token='').
-                    self._code_sandbox_password_auth = JupyterAnonymousAuth(code_sandbox_url)
-                    self._code_sandbox_password_auth.login()
+                    self._code_sandbox_password_auth = self._try_anonymous_auth(code_sandbox_url)
                     self._code_sandbox_password_auth.inject_into_session(self._server_client.http_client.session)
 
             # Document auth — only needed when the document server is explicitly

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -802,6 +802,35 @@ class TestInitMcpServerModeAnonymousXsrf:
         mock_session_cls.assert_not_called()
         mock_client_cls.assert_called_once_with(base_url="http://localhost:8888", token="mytoken")
 
+    @patch("jupyter_mcp_server.auth.requests.Session")
+    @patch("jupyter_mcp_server.server_context.JupyterServerClient")
+    def test_unreachable_server_does_not_abort_init(self, mock_client_cls, mock_session_cls):
+        """A connection error during the anonymous XSRF fetch must not raise out of
+        _init_mcp_server_mode: this path runs for every no-token, no-password config,
+        including ones where the code sandbox server isn't up yet (or isn't real, as
+        in most of this repo's own unit tests), and previously that case did no
+        network I/O at all.
+        """
+        mock_client = MagicMock()
+        mock_client.http_client.session = requests.Session()
+        mock_client_cls.return_value = mock_client
+
+        session = _patch_session(mock_session_cls)
+        session.cookies = RequestsCookieJar()
+        session.request.side_effect = requests.exceptions.ConnectionError("refused")
+
+        set_config(
+            code_sandbox_url="http://localhost:8888",
+            code_sandbox_token=None,
+            code_sandbox_password=None,
+        )
+        context = ServerContext.get_instance()
+        context._init_mcp_server_mode()  # must not raise
+        context._initialized = True
+
+        assert context._code_sandbox_password_auth is not None
+        assert context.code_sandbox_auth_headers == {}
+
 
 # ---------------------------------------------------------------------------
 # NotebookConnection auth headers tests

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -380,6 +380,71 @@ class TestJupyterPasswordAuth:
 
 
 # ---------------------------------------------------------------------------
+# JupyterAnonymousAuth unit tests
+# ---------------------------------------------------------------------------
+
+
+class TestJupyterAnonymousAuth:
+    """Tests for the no-password, no-token anonymous XSRF fetch (#183)."""
+
+    def _make_auth(self, url="http://localhost:8888"):
+        from jupyter_mcp_server.auth import JupyterAnonymousAuth
+        return JupyterAnonymousAuth(url)
+
+    @patch("jupyter_mcp_server.auth.requests.Session")
+    def test_login_fetches_xsrf_without_posting_credentials(self, mock_session_cls):
+        """login() issues one GET /login and never a POST, unlike password auth."""
+        session = _patch_session(mock_session_cls)
+        jar = RequestsCookieJar()
+        jar.set("_xsrf", "2|anon123")
+        session.cookies = jar
+        session.request.side_effect = _request_responses(MagicMock())  # GET /login only
+
+        auth = self._make_auth()
+        auth.login()
+
+        assert auth._authenticated is True
+        assert auth._xsrf_token == "2|anon123"
+        assert session.request.call_count == 1
+        get_call = session.request.call_args_list[0]
+        assert get_call.args[0] == "GET"
+        assert get_call.args[1] == "http://localhost:8888/login"
+        assert get_call.kwargs["allow_redirects"] is False
+
+        headers = auth.get_headers()
+        assert headers["X-XSRFToken"] == "2|anon123"
+        assert "_xsrf=2|anon123" in headers["Cookie"]
+
+    @patch("jupyter_mcp_server.auth.requests.Session")
+    def test_login_succeeds_even_without_xsrf_cookie(self, mock_session_cls):
+        """Unlike JupyterPasswordAuth, a missing _xsrf cookie is not fatal here:
+
+        a deployment with XSRF protection disabled is not an error for the
+        anonymous case, it just means no header is needed.
+        """
+        session = _patch_session(mock_session_cls)
+        session.cookies = RequestsCookieJar()  # no _xsrf set
+        session.request.side_effect = _request_responses(MagicMock())
+
+        auth = self._make_auth()
+        auth.login()  # must not raise
+
+        assert auth._authenticated is True
+        assert auth.get_headers() == {}
+
+    @patch("jupyter_mcp_server.auth.requests.Session")
+    def test_login_translates_connection_error(self, mock_session_cls):
+        """Connection failures during the anonymous GET surface as RuntimeError."""
+        session = _patch_session(mock_session_cls)
+        session.request.side_effect = requests.exceptions.ConnectionError("refused")
+
+        auth = self._make_auth()
+        with pytest.raises(RuntimeError, match="Connection error"):
+            auth.login()
+        session.close.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
 # Config password fields
 # ---------------------------------------------------------------------------
 
@@ -663,6 +728,79 @@ class TestCodeSandboxAuthRetry:
 
         assert result == {"ok": True}
         context.relogin_code_sandbox.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# _init_mcp_server_mode anonymous XSRF wiring tests (#183)
+# ---------------------------------------------------------------------------
+
+
+class TestInitMcpServerModeAnonymousXsrf:
+    """Tests that _init_mcp_server_mode fetches an anonymous _xsrf cookie when
+    neither a password nor a token is configured (issue #183)."""
+
+    def setup_method(self):
+        reset_config()
+        ServerContext.reset()
+        ServerContext._instance = None
+
+    def teardown_method(self):
+        reset_config()
+        ServerContext.reset()
+        ServerContext._instance = None
+
+    @patch("jupyter_mcp_server.auth.requests.Session")
+    @patch("jupyter_mcp_server.server_context.JupyterServerClient")
+    def test_no_password_no_token_fetches_xsrf(self, mock_client_cls, mock_session_cls):
+        """With no code_sandbox_password and no code_sandbox_token, the code
+        sandbox session still ends up carrying an X-XSRFToken header.
+
+        This is the exact deployment shape from #183 (--IdentityProvider.token='',
+        no password): before this fix, code_sandbox_auth_headers was permanently
+        {} in this configuration.
+        """
+        mock_client = MagicMock()
+        mock_client.http_client.session = requests.Session()
+        mock_client_cls.return_value = mock_client
+
+        session = _patch_session(mock_session_cls)
+        jar = RequestsCookieJar()
+        jar.set("_xsrf", "2|nocred")
+        session.cookies = jar
+        session.request.side_effect = _request_responses(MagicMock())  # GET /login only
+
+        set_config(
+            code_sandbox_url="http://localhost:8888",
+            code_sandbox_token=None,
+            code_sandbox_password=None,
+        )
+        context = ServerContext.get_instance()
+        context._init_mcp_server_mode()
+        context._initialized = True  # bypass initialize()'s extension-detection path
+
+        assert context._code_sandbox_password_auth is not None
+        headers = context.code_sandbox_auth_headers
+        assert headers.get("X-XSRFToken") == "2|nocred"
+
+    @patch("jupyter_mcp_server.auth.requests.Session")
+    @patch("jupyter_mcp_server.server_context.JupyterServerClient")
+    def test_token_set_skips_anonymous_auth(self, mock_client_cls, mock_session_cls):
+        """A configured code_sandbox_token still bypasses the anonymous XSRF path
+        entirely (backward compatible, no new HTTP call for the token case)."""
+        mock_client = MagicMock()
+        mock_client_cls.return_value = mock_client
+
+        set_config(
+            code_sandbox_url="http://localhost:8888",
+            code_sandbox_token="mytoken",
+            code_sandbox_password=None,
+        )
+        context = ServerContext.get_instance()
+        context._init_mcp_server_mode()
+
+        assert context._code_sandbox_password_auth is None
+        mock_session_cls.assert_not_called()
+        mock_client_cls.assert_called_once_with(base_url="http://localhost:8888", token="mytoken")
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Root cause

`ServerContext._init_mcp_server_mode` only ever sets up an `_xsrf` cookie when
`code_sandbox_password` is configured (added in #250). When neither a password
nor a token is set, the `else` branch just builds a `JupyterServerClient` and
`code_sandbox_auth_headers` stays permanently `{}` (`server_context.py:226`),
so every state-changing request (kernel management, the collaboration API)
fails with `'_xsrf' argument missing from POST` on any deployment where auth
is handled externally: `--IdentityProvider.token=''`, JupyterHub single-user
servers, or managed environments (SageMaker Studio, Colab Enterprise). #250's
own body says it "partially addresses #183" and does not cover this case.

## Fix

Added `JupyterAnonymousAuth` (`auth.py`), a `JupyterPasswordAuth` subclass
that performs only the anonymous `GET /login` step to pick up the `_xsrf`
cookie, skipping the password `POST` and its verification. Wired into
`_init_mcp_server_mode`'s existing no-password branch, only when
`code_sandbox_token` is also unset, so the token-authenticated path is
unchanged. Every existing reader of `_code_sandbox_password_auth`
(`code_sandbox_auth_headers`, `relogin_code_sandbox`, the document-auth
reuse when `document_url` matches `code_sandbox_url`) already goes through
`get_headers()` / `relogin()` / `close()`, so no other call site needed to
change.

Scoped to the reported case (code sandbox with no credentials, document
server at the same URL or unset). A document server configured at a
genuinely different URL with no credentials of its own is unchanged, still
silently unauthenticated as before this PR; not attempted here to keep the
diff to the no-token-no-password branch.

**Update:** CI on this PR caught a regression from the first commit. The
anonymous fetch ran eagerly at init time, and several existing tests (e.g.
`test_create_kernel_passes_reconnect_interval`) go through
`ServerContext.get_instance()` with the process-global default config, which
has no token and no password. That combination previously did zero network
I/O; after the first commit it made a real GET and raised when the target
wasn't reachable, failing 6 tests across the matrix. Second commit extracts
the fetch into `_try_anonymous_auth`, which degrades to no cookie on a
connection error instead of raising (explicit password auth is untouched and
still hard-fails as before).

## Verification

- `tests/test_auth.py::TestInitMcpServerModeAnonymousXsrf::test_no_password_no_token_fetches_xsrf`
  fails on unmodified main (`_code_sandbox_password_auth` stays `None`) and
  passes on this branch; a sibling test pins that a configured
  `code_sandbox_token` still skips the anonymous fetch entirely.
- `test_unreachable_server_does_not_abort_init` (added in the second commit)
  fails against the first commit and passes against the second; confirmed the
  6 CI-failing tests (`test_create_kernel_passes_reconnect_interval`,
  `test_create_kernel_no_reconnect_by_default`, all 4 in
  `test_execute_code_timeout.py`) pass locally in `python:3.11-slim` Docker.
- `python:3.11-slim` Docker: full `tests/` (excluding the live-server E2E/
  session-expiry tests, which need a non-root Jupyter Lab and fail identically
  on unmodified main in this container) shows no new failures or errors versus
  main, only the same pre-existing ones.
- `ruff check` on the two changed files: identical finding set to unmodified
  main, nothing new on the added code.
- Not verified: end-to-end against a real Jupyter server started with
  `--IdentityProvider.token=''` (no such server available in this session).

Fixes #183
