### PR TITLE
fix(delete_cell): reject duplicate indices in cell_indices

### DIFF
--- a/jupyter_mcp_server/tools/delete_cell_tool.py
+++ b/jupyter_mcp_server/tools/delete_cell_tool.py
@@ -43,7 +43,13 @@ class DeleteCellTool(BaseTool):
                 each index (rather than only ``max(cell_indices)``) rejects
                 out-of-range negatives, which would otherwise raise a raw
                 IndexError or silently delete the wrong cell.
+            ValueError: When cell_indices contains a duplicate. A repeated
+                index pops the same position twice, deleting the neighboring
+                cell that shifted into that slot after the first pop while
+                the tool's own report still names only the intended index.
         """
+        if len(set(cell_indices)) != len(cell_indices):
+            raise ValueError(f"cell_indices contains duplicate values: {cell_indices}")
         for cell_index in cell_indices:
             if cell_index < 0 or cell_index >= total_cells:
                 raise ValueError(

--- a/tests/test_delete_cell.py
+++ b/tests/test_delete_cell.py
@@ -60,10 +60,12 @@ class TestDeleteCellValidation:
             ([5], 5),  # index == total_cells
             ([999], 5),  # far out of range
             ([0, 5], 5),  # one valid, one out of range
+            ([1, 1], 5),  # duplicate: pops the same position twice
+            ([0, 2, 2], 5),  # duplicate mixed with distinct indices
         ],
     )
     def test_invalid_indices_raise_error(self, indices, total):
-        """Out-of-range indices (negative or too large) must be rejected."""
+        """Out-of-range or duplicate indices must be rejected."""
         with pytest.raises((ValueError, IndexError)):
             self.tool._validate_indices(indices, total)
 
@@ -139,3 +141,17 @@ class TestDeleteCellFileNegativeIndices:
 
         assert {d["index"] for d in deleted} == {1, 3}
         assert _read_sources(path) == ["cell 0", "cell 2", "cell 4"]
+
+    @pytest.mark.asyncio
+    async def test_duplicate_index_rejected_instead_of_deleting_neighbor(self, tmp_path):
+        """A repeated index pops the same position twice, so the second pop
+        removes whatever shifted into that slot: [1, 1] on a 4-cell notebook
+        silently deletes cells 1 AND 2 while reporting cell 1 deleted twice.
+        Must be rejected before either pop happens."""
+        path = str(tmp_path / "nb.ipynb")
+        original = _write_notebook(path, 4)
+
+        with pytest.raises(ValueError, match="duplicate"):
+            await self.tool._delete_cell_file(path, [1, 1])
+
+        assert _read_sources(path) == original  # cell 2 NOT silently dropped


### PR DESCRIPTION
## Root cause

`_validate_indices` only checks that each index in `cell_indices` is within `[0, total_cells)`; it never checks for duplicates. `_delete_cell_file` then pops cells in `sorted(cell_indices, reverse=True)` order, so a repeated index pops the same position twice: the second pop removes whatever cell shifted into that slot after the first pop, while the tool's own success message still names only the intended index (twice).

## Fix

Reject non-unique `cell_indices` in `_validate_indices`, the same guard `_delete_cell_ydoc`, `_delete_cell_file`, and `_delete_cell_websocket` all call before deleting, so all three paths are covered by one change.

## Verification

- New regression test `test_duplicate_index_rejected_instead_of_deleting_neighbor` (`tests/test_delete_cell.py`) fails on unmodified `main` (`DID NOT RAISE ValueError`) and passes on this branch; two new parametrized cases added to the existing `_validate_indices` table for the same reason.
- Full `tests/test_delete_cell.py` (17 tests) and the broader `pytest tests/ -k "not E2E and not SessionExpiry"` suite pass identically before and after this diff (245 vs 242 passed, the +3 being the new tests here); the pre-existing errors in that run come from live-server fixtures that cannot start as root in this container, unrelated to this change.
- `ruff check`, `mypy`, and `header-license-fix` (skywalking-eyes) on the changed files show the same pre-existing findings on `main` and this branch (none on the added lines).
- Not verified: the YDoc and WebSocket delete paths were not exercised end to end (no live Jupyter server in this environment); only `_delete_cell_file` was directly reproduced. Both call the same `_validate_indices` guard before deleting, so the fix applies to them as well, but that is inference from the shared code path rather than a direct repro.

Fixes #336
