### PR TITLE
fix(use_notebook): build created notebooks via nbformat so cells get a valid id

### DIFF
--- a/jupyter_mcp_server/tools/use_notebook_tool.py
+++ b/jupyter_mcp_server/tools/use_notebook_tool.py
@@ -9,6 +9,7 @@ import logging
 from pathlib import Path
 from typing import Any, Literal
 
+import nbformat
 from jupyter_core.utils import ensure_async
 from jupyter_nbmodel_client import NbModelClient
 from jupyter_server_client import JupyterServerClient, NotFoundError
@@ -211,20 +212,22 @@ class UseNotebookTool(BaseTool):
             # This runs before the kernel and the Jupyter session below, which are
             # both pointed at notebook_path and so need the file to exist already.
             if use_mode == "create":
-                content = {
-                    "cells": [
-                        {
-                            "cell_type": "markdown",
-                            "metadata": {},
-                            "source": [
-                                "New Notebook Created by Jupyter MCP Server",
-                            ],
-                        }
-                    ],
-                    "metadata": {},
-                    "nbformat": 4,
-                    "nbformat_minor": 4,
-                }
+                # Build the notebook with nbformat's constructors rather than a
+                # raw dict so the format version and the per-cell `id` stay
+                # consistent: nbformat 4.5 requires a unique `id` on every cell,
+                # and new_markdown_cell()/new_notebook() assign the id and stamp
+                # the matching nbformat_minor for us. Hand-writing the dict is how
+                # a cell ended up without an `id` under nbformat_minor 5 (see #338)
+                # and, on main, a downgrade to nbformat_minor 4 that drops cell ids
+                # entirely. This also matches insert_cell, which already uses
+                # nbformat.v4.new_code_cell().
+                content = nbformat.v4.new_notebook(
+                    cells=[
+                        nbformat.v4.new_markdown_cell(
+                            "New Notebook Created by Jupyter MCP Server"
+                        )
+                    ]
+                )
                 if mode == ServerMode.JUPYTER_SERVER and contents_manager is not None:
                     # Use local API to create notebook
                     await ensure_async(


### PR DESCRIPTION
## What
`use_notebook` (create mode) builds the seed notebook with nbformat's v4 constructors instead of a hand-written dict, so the format version and the per-cell `id` stay consistent.

## Why
Fixes #338. `use_notebook`'s create branch hand-built the notebook JSON:

- In the **1.1.4** release it declared `nbformat_minor: 5` but the seed cell had **no `id`** — nbformat 4.5 requires a unique `id` on every cell, so the written notebook is non-conformant with the version it claims (`'id' is a required property`).
- On **main** it was lowered to `nbformat_minor: 4`, which is valid but produces notebooks with **no cell ids at all** — worse for anything that keys on stable cell ids (cell-level diff/review, collaborative rooms) and inconsistent with `insert_cell`, which already creates cells via `nbformat.v4.new_code_cell()`.

## Change
```python
content = nbformat.v4.new_notebook(
    cells=[nbformat.v4.new_markdown_cell("New Notebook Created by Jupyter MCP Server")]
)
```
`new_notebook()` stamps the current `nbformat_minor` and `new_markdown_cell()` assigns the cell `id`, giving a valid nbformat 4.5 notebook with ids.

## Verification
```
nbformat: 4  minor: 5
cell has id: True -> a01a4577
nbformat.validate: OK
```
Both create paths (`contents_manager.new(...)` and `server_client.contents.create_notebook(...)`) receive the resulting `NotebookNode` unchanged (it is a `dict` subclass and serializes as before).

Fixes #338
