### PR TITLE
fix(tools): use the authenticated server_client in list_files MCP_SERVER mode

### DIFF
--- a/jupyter_mcp_server/tools/list_files_tool.py
+++ b/jupyter_mcp_server/tools/list_files_tool.py
@@ -10,7 +10,6 @@ from typing import Any
 from jupyter_core.utils import ensure_async
 from jupyter_server_client import JupyterServerClient
 
-from jupyter_mcp_server.config import get_config
 from jupyter_mcp_server.tools._base import BaseTool, ServerMode
 from jupyter_mcp_server.utils import format_TSV
 
@@ -200,12 +199,9 @@ class ListFilesTool(BaseTool):
         if mode == ServerMode.JUPYTER_SERVER and contents_manager is not None:
             # Local mode: use contents_manager directly
             all_files = await _list_files_local(contents_manager, path, max_depth)
-        elif mode == ServerMode.MCP_SERVER:
-            # Remote mode: use HTTP client
-            config = get_config()
-            server_client = JupyterServerClient(
-                base_url=config.code_sandbox_url, token=config.code_sandbox_token
-            )
+        elif mode == ServerMode.MCP_SERVER and server_client is not None:
+            # Remote mode: reuse the shared, authenticated HTTP client
+            # (a client built fresh here carries no session cookies).
             all_files = _list_files_mcp(server_client, path, 0, None, max_depth)
         else:
             raise ValueError(f"Invalid mode or missing required clients: mode={mode}")

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -751,6 +751,16 @@ class TestPasswordAuthE2E:
         assert "use_notebook" in tool_names
 
     @pytest.mark.asyncio
+    async def test_password_auth_list_files(self, mcp_client_password, password_notebook):
+        """list_files works with password auth."""
+        async with mcp_client_password:
+            raw_result = await mcp_client_password._session.call_tool("list_files", {})
+        result = mcp_client_password._extract_text_content(raw_result)
+        assert result is not None
+        assert password_notebook in result, f"list_files did not list {password_notebook}: {result}"
+        assert "error" not in result.lower(), f"list_files returned an error entry: {result}"
+
+    @pytest.mark.asyncio
     async def test_password_auth_execute_code(self, mcp_client_password):
         """KernelClient works with password cookie/XSRF auth."""
         # Multiply two large ints so the expected value can't appear incidentally


### PR DESCRIPTION
## Root cause

`ListFilesTool.execute()`'s `MCP_SERVER` branch built a fresh `JupyterServerClient(base_url=config.code_sandbox_url, token=config.code_sandbox_token)` from `get_config()` instead of using the `server_client` parameter already passed in from `server.py:356` (`server_client=server_context.server_client`). That fresh client carries no session cookies, so on any deployment secured by `code_sandbox_password` (no static token, the case password auth exists for) it 403s while every other MCP_SERVER tool succeeds through the shared, authenticated client built in `server_context.py`.

## Fix

Reuse the passed-in `server_client` (matching every other tool's wiring) and drop the now-unused `get_config()` construction.

## Verification

- Added `test_password_auth_list_files` to `tests/test_auth.py::TestPasswordAuthE2E`, which fails on main (`Error: 403: Forbidden`) and passes with this fix, run against a real password-protected `jupyter_server`.
- Full `tests/test_auth.py` suite passes (42/42).
- `ruff check` and `mypy` on the changed files show the same pre-existing findings before and after this diff; no new issues introduced.
- Did not exercise the `contents_manager`/`JUPYTER_SERVER` branch or the rest of the MCP tool surface; this change only touches the `MCP_SERVER` branch of `list_files`.

Fixes #340
