### PR TITLE
fix(auth): retry code sandbox requests after a session-cookie expiry

### DIFF
--- a/docs/docs/reference/security/index.mdx
+++ b/docs/docs/reference/security/index.mdx
@@ -182,6 +182,10 @@ This is useful when:
 3. These cookies are injected into all HTTP requests (API calls, kernel operations) and WebSocket connections (notebook collaboration)
 4. The `X-XSRFToken` header is automatically included in requests that require XSRF protection
 
+### Session Expiry Recovery
+
+Password-authenticated sessions can expire or be invalidated while the MCP server is running (server restart, cookie TTL, etc). When a request to the code sandbox server returns 401 or 403, the MCP server performs the `/login` flow again to obtain a fresh session, then retries the original request once. This only re-runs the login (a new session, not the old expired one), so it recovers automatically instead of surfacing an auth error on every subsequent tool call. The document/collaboration path has the equivalent behavior on its own WebSocket connection.
+
 ### Configuration
 
 #### Simplified (Same Password for Both Servers)

--- a/jupyter_mcp_server/server_context.py
+++ b/jupyter_mcp_server/server_context.py
@@ -104,6 +104,7 @@ class ServerContext:
                     logger.warning("Both code_sandbox_password and code_sandbox_token are set. Password auth takes precedence.")
                 self._server_client = JupyterServerClient(base_url=code_sandbox_url, token=None)
                 self._code_sandbox_password_auth.inject_into_session(self._server_client.http_client.session)
+                self._install_code_sandbox_auth_retry(self._server_client)
             else:
                 self._server_client = JupyterServerClient(base_url=code_sandbox_url, token=config.code_sandbox_token)
 
@@ -255,6 +256,34 @@ class ServerContext:
         if self._document_password_auth is self._code_sandbox_password_auth:
             return self.code_sandbox_auth_headers
         return self._document_password_auth.get_headers()
+
+    def _install_code_sandbox_auth_retry(self, server_client: JupyterServerClient) -> None:
+        """Make every request through `server_client` retry once on a 401/403.
+
+        The collaboration/document path already survives a cookie expiry via
+        `NotebookConnection._get_ws_url`, which catches the error, calls
+        `relogin_document()`, and retries. Every kernel/contents/kernelspec
+        call from the tools goes through `JupyterServerClient`'s single
+        `http_client.request()` instead, so wrapping that one method gives all
+        of them the same protection without touching each call site.
+        """
+        from jupyter_server_client.exceptions import AuthenticationError, ForbiddenError
+
+        original_request = server_client.http_client.request
+
+        def request_with_relogin(*args, **kwargs):
+            try:
+                return original_request(*args, **kwargs)
+            except (AuthenticationError, ForbiddenError) as error:
+                logger.warning(
+                    "Code sandbox request returned %s, session cookie likely "
+                    "expired. Re-authenticating and retrying.",
+                    error.status_code,
+                )
+                self.relogin_code_sandbox()
+                return original_request(*args, **kwargs)
+
+        server_client.http_client.request = request_with_relogin
 
     def relogin_code_sandbox(self, timeout: float = 10.0) -> None:
         """Re-authenticate the code sandbox server session after cookie expiry.

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -584,6 +584,88 @@ class TestServerContextAuthHeaders:
 
 
 # ---------------------------------------------------------------------------
+# Code sandbox retry-on-expiry tests
+# ---------------------------------------------------------------------------
+
+
+class TestCodeSandboxAuthRetry:
+    """Tests for ServerContext._install_code_sandbox_auth_retry.
+
+    Covers the retry wrapper in isolation, at the single `http_client.request`
+    choke point every `kernels`/`contents`/`kernelspecs` call goes through, so
+    they cover `list_kernels`, `list_files`, `create_notebook`, etc. without
+    a case per call site.
+    """
+
+    def setup_method(self):
+        reset_config()
+        ServerContext.reset()
+        ServerContext._instance = None
+
+    def teardown_method(self):
+        reset_config()
+        ServerContext.reset()
+        ServerContext._instance = None
+
+    def test_retries_once_after_401_then_succeeds(self):
+        """A 401 from the wrapped request triggers one relogin and retry."""
+        from jupyter_server_client.exceptions import AuthenticationError
+
+        context = ServerContext.get_instance()
+        context.relogin_code_sandbox = MagicMock()
+
+        mock_client = MagicMock()
+        calls = {"n": 0}
+
+        def flaky_request(*args, **kwargs):
+            calls["n"] += 1
+            if calls["n"] == 1:
+                raise AuthenticationError("expired", status_code=401)
+            return {"ok": True}
+
+        mock_client.http_client.request = flaky_request
+        context._install_code_sandbox_auth_retry(mock_client)
+
+        result = mock_client.http_client.request("GET", "/api/kernels")
+
+        assert result == {"ok": True}
+        assert calls["n"] == 2
+        context.relogin_code_sandbox.assert_called_once()
+
+    def test_propagates_persistent_failure(self):
+        """A 403 that survives the relogin still surfaces to the caller."""
+        from jupyter_server_client.exceptions import ForbiddenError
+
+        context = ServerContext.get_instance()
+        context.relogin_code_sandbox = MagicMock()
+
+        mock_client = MagicMock()
+        mock_client.http_client.request = MagicMock(
+            side_effect=ForbiddenError("nope", status_code=403)
+        )
+        context._install_code_sandbox_auth_retry(mock_client)
+
+        with pytest.raises(ForbiddenError):
+            mock_client.http_client.request("GET", "/api/kernels")
+
+        context.relogin_code_sandbox.assert_called_once()
+
+    def test_success_without_expiry_does_not_relogin(self):
+        """A request that succeeds on the first try never triggers relogin."""
+        context = ServerContext.get_instance()
+        context.relogin_code_sandbox = MagicMock()
+
+        mock_client = MagicMock()
+        mock_client.http_client.request = MagicMock(return_value={"ok": True})
+        context._install_code_sandbox_auth_retry(mock_client)
+
+        result = mock_client.http_client.request("GET", "/api/kernels")
+
+        assert result == {"ok": True}
+        context.relogin_code_sandbox.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
 # NotebookConnection auth headers tests
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
`relogin_code_sandbox()` re-authenticates the code sandbox password session, but the only thing that ever calls it is `relogin_document()`'s shared-auth branch, which fires only when `document_url` and `code_sandbox_url` are the same server. Every tool call that goes through `server_client` directly (`list_kernels`, `list_files`, `create_notebook`, kernelspecs, get_status) has no protection against an expired or invalidated password-auth session, unlike the document/collaboration path, which already retries once on a 401/403 (`NotebookConnection._get_ws_url`).

`JupyterServerClient`'s `kernels`/`contents`/`kernelspecs`/`sessions` managers all funnel through one method, `http_client.request()`. This wraps that single choke point so a 401/403 triggers one `relogin_code_sandbox()` call and a retry, installed once when the password-authenticated `server_client` is built. No call site changes needed, and it covers every current and future caller through `server_client`, not just the five identified in the issue.

- New `TestCodeSandboxAuthRetry` (retry-then-succeed, persistent-failure-propagates, no-retry-when-healthy) fails with `AttributeError` on unmodified `main` and passes on this branch (`python:3.11-slim`, `jupyter-server-client==0.1.1`).
- Full `tests/test_auth.py`: 45 passed, same container.
- `ruff check` + `mypy` on both changed files: identical error count to unmodified `main` (22 ruff / the same missing-stubs class on `jupyter_server_client`), so nothing new; `header-license-fix` clean except the pre-existing `.github/copilot-instructions.md` failure.
- Not verified: a genuine end-to-end 401 through a real password-authed server. The short-cookie fixture this suite uses elsewhere can't trigger one here, because `inject_into_session` copies cookies by name/value only, so the copy in `server_client.http_client.session` never carries the original cookie's expiry; the mocked-exception tests above are what stand behind this fix instead.

Fixes #342