### PR TITLE
fix(use_notebook): reject create at a path that already exists

### DIFF
--- a/jupyter_mcp_server/tools/use_notebook_tool.py
+++ b/jupyter_mcp_server/tools/use_notebook_tool.py
@@ -80,12 +80,18 @@ class UseNotebookTool(BaseTool):
             else:
                 dir_contents = server_client.contents.list_directory("")
 
+            file_exists = any(file.name == path.name for file in dir_contents)
             if mode == "connect":
-                file_exists = any(file.name == path.name for file in dir_contents)
                 if not file_exists:
                     return (
                         False,
                         f"'{notebook_path}' not found in jupyter server, please check the notebook already exists.",
+                    )
+            elif mode == "create":
+                if file_exists:
+                    return (
+                        False,
+                        f"'{notebook_path}' already exists in jupyter server, please use a different path or use_mode='connect' to open it.",
                     )
 
             return True, None
@@ -113,12 +119,18 @@ class UseNotebookTool(BaseTool):
                 contents_manager.get(parent_path, content=True, type="directory")
             )
 
+            file_exists = any(item["name"] == path.name for item in model.get("content", []))
             if mode == "connect":
-                file_exists = any(item["name"] == path.name for item in model.get("content", []))
                 if not file_exists:
                     return (
                         False,
                         f"'{notebook_path}' not found in jupyter server, please check the notebook already exists.",
+                    )
+            elif mode == "create":
+                if file_exists:
+                    return (
+                        False,
+                        f"'{notebook_path}' already exists in jupyter server, please use a different path or use_mode='connect' to open it.",
                     )
 
             return True, None

--- a/tests/test_use_notebook_create_overwrite_repro.py
+++ b/tests/test_use_notebook_create_overwrite_repro.py
@@ -1,0 +1,78 @@
+# Copyright (c) 2024- Datalayer, Inc.
+#
+# BSD 3-Clause License
+
+"""Repro: use_notebook(use_mode="create") against a REAL jupyter_server
+contents manager silently overwrites an existing notebook file on disk.
+
+Unlike test_use_notebook_create_local.py's RecordingContentsManager (which
+always reports an empty directory), this drives UseNotebookTool against
+jupyter_server's own AsyncFileContentsManager pointed at a real temp
+directory, so the file-exists / overwrite semantics are the production
+manager's, not a stand-in's.
+"""
+
+import tempfile
+from pathlib import Path
+
+import nbformat
+import pytest
+from jupyter_server.services.contents.filemanager import AsyncFileContentsManager
+
+from jupyter_mcp_server.notebook_manager import NotebookManager
+from jupyter_mcp_server.tools._base import ServerMode
+from jupyter_mcp_server.tools.use_notebook_tool import UseNotebookTool
+
+
+class RecordingKernelManager:
+    async def start_kernel(self):
+        return "kernel-1"
+
+    def get_kernel(self, kernel_id):
+        return object()
+
+    def get_connection_info(self, kernel_id):
+        return {"shell_port": 1}
+
+
+class RecordingSessionManager:
+    async def create_session(self, path=None, kernel_id=None, type=None, name=None):
+        return {"id": "session-1"}
+
+
+@pytest.mark.asyncio
+async def test_create_mode_overwrites_an_existing_notebook_on_real_contents_manager():
+    """A second, independent use_notebook(use_mode="create") call at a path
+    that already holds real work must not destroy it."""
+    with tempfile.TemporaryDirectory() as root_dir:
+        contents_manager = AsyncFileContentsManager(root_dir=root_dir)
+
+        # Simulate a notebook that already has real user work in it, written
+        # directly (as an earlier session's use_notebook(create) call would
+        # have done via this exact tool).
+        real_work = nbformat.v4.new_notebook(
+            cells=[nbformat.v4.new_code_cell("df = load_customer_data()  # 3 hours of work")]
+        )
+        (Path(root_dir) / "analysis.ipynb").write_text(nbformat.writes(real_work))
+
+        # A second, independent client (fresh NotebookManager => tool has no
+        # record of "analysis" being in use) calls use_notebook(create) at
+        # the SAME path.
+        await UseNotebookTool().execute(
+            mode=ServerMode.JUPYTER_SERVER,
+            contents_manager=contents_manager,
+            kernel_manager=RecordingKernelManager(),
+            session_manager=RecordingSessionManager(),
+            notebook_manager=NotebookManager(),
+            notebook_name="analysis_second_client",
+            notebook_path="analysis.ipynb",
+            use_mode="create",
+        )
+
+        on_disk = nbformat.reads(
+            (Path(root_dir) / "analysis.ipynb").read_text(), as_version=4
+        )
+        assert on_disk.cells[0].source == "df = load_customer_data()  # 3 hours of work", (
+            "use_notebook(create) silently overwrote an existing notebook: "
+            f"cells on disk are now {[c.source for c in on_disk.cells]!r}"
+        )


### PR DESCRIPTION
`use_notebook(use_mode="create")` never checks whether `notebook_path` already exists before writing to it, in either server mode. `_check_path_local`/`_check_path_http` only compute `file_exists` for `use_mode == "connect"`; the `"create"` branch verifies only that the parent directory exists and returns `(True, None)` unconditionally. Execution then goes straight to `contents_manager.new(...)` (JUPYTER_SERVER) or `server_client.contents.create_notebook(...)` (MCP_SERVER), both plain overwrites when the path already resolves to a file. The guard above that path check (`notebook_name in notebook_manager`) only catches the case where the same client already has this notebook open under its own in-memory manager, so a second, independent client creating at a path someone else's session already has real work in destroys that work with no warning.

Fix: compute `file_exists` for both modes, and for `"create"` return an error when the path is already taken, mirroring the message `"connect"` already gives for the opposite case.

## Verification

- New test `tests/test_use_notebook_create_overwrite_repro.py` drives `UseNotebookTool` against jupyter_server's own `AsyncFileContentsManager` (not a stand-in) pointed at a real temp directory: fails on `main` (a pre-seeded notebook's cell is silently replaced by the create skeleton), passes on this branch.
- Existing `tests/test_use_notebook_create_local.py` and `tests/test_use_notebook_reconnect_interval.py` still pass unchanged (their fake managers report an empty directory, so the new check is a no-op for them, as it should be).
- Ran the full `make test-mcp-server` suite: this branch reproduces the same 30 failed / 9 errors as unmodified `main` in an identical container, so nothing here regresses (or fixes) those; they are pre-existing and unrelated to this file.
- Not verified: the MCP_SERVER (HTTP) path against a live Jupyter server; the fix there follows the same pattern the existing `"connect"` check on that function already uses, exercised in this PR only via the fake-`server_client` unit tests.

Fixes #345
