### PR TITLE
fix(deps): update to jupyter-collaboration 5 by removing leftover datalayer_pycrdt install steps

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -118,8 +118,6 @@ jupyter-mcp-server start \
 # Start JupyterLab server for MCP integration
 make jupyterlab
 # Equivalent to:
-pip uninstall -y pycrdt datalayer_pycrdt
-pip install datalayer_pycrdt
 jupyter lab \
   --port 8888 \
   --ip 0.0.0.0 \
@@ -221,7 +219,6 @@ docker run -i --rm \
 
 - **Core deps**: Defined in `pyproject.toml` dependencies section
 - **Dev deps**: Use `[test,lint,typing]` optional dependencies
-- **Special handling**: `datalayer_pycrdt` has specific version requirements (0.12.17)
 
 ### CI/CD Pipeline Expectations
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -45,8 +45,6 @@ jobs:
           python -m pip install ".[test]"
           # Optional extension used by sandbox-related tests.
           python -m pip install ./ext/sandboxes
-          pip uninstall -y pycrdt datalayer_pycrdt
-          pip install datalayer_pycrdt==0.12.17
 
       - name: Test the extension
         run: |

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -101,9 +101,7 @@ When adding tests for new features or modifying existing tools, ensure your test
 1. **Set Up Your Environment:**
 
    ```bash
-   pip install jupyterlab==4.4.1 jupyter-collaboration==4.0.2 ipykernel
-   pip uninstall -y pycrdt datalayer_pycrdt
-   pip install datalayer_pycrdt==0.12.17
+   pip install jupyterlab==4.4.1 jupyter-collaboration==4.0.2 ipykernel pycrdt
    ```
 
 1. **Start Jupyter Server:**

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,9 +15,7 @@ ENV PIP_NO_CACHE_DIR=1 \
     PIP_DISABLE_PIP_VERSION_CHECK=1
 RUN python -m pip install --upgrade pip wheel setuptools && pip --version
 
-RUN pip install --no-cache-dir -e . && \
-    pip uninstall -y pycrdt datalayer_pycrdt && \
-    pip install --no-cache-dir datalayer_pycrdt==0.12.17
+RUN pip install --no-cache-dir -e .
 
 EXPOSE 4040
 

--- a/Makefile
+++ b/Makefile
@@ -126,8 +126,6 @@ start-jupyter-server-extension: ## start jupyter server with MCP extension
 	  --port 4040
 
 jupyterlab: ## start jupyterlab for the mcp server
-	pip uninstall -y pycrdt datalayer_pycrdt
-	pip install datalayer_pycrdt
 	@exec echo
 	@exec echo curl http://localhost:8888/lab?token=MY_TOKEN
 	@exec echo

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ dependencies = [
     "jupyter-server-nbmodel",
     "jupyter-server-client",
     "jupyter_server>=1.6,<3",
-    "jupyter-collaboration<5",
+    "jupyter-collaboration",
     "tornado>=6.1",
     "traitlets>=5.0",
     "mcp[cli]>=1.10.1,<2",


### PR DESCRIPTION
Fixes #348

## What

- Remove the `pip uninstall -y pycrdt datalayer_pycrdt` / `pip install datalayer_pycrdt==0.12.17` step from `.github/workflows/test.yml`, `Dockerfile`, `Makefile`, `CONTRIBUTING.md`, and `.github/copilot-instructions.md`.
- Allow jupyter-collaboration 5 again by reverting the `<5` bound added in #347.

## Background

- #240 / #241
  - Switched the project to upstream pycrdt.
- #242
  - Removed `datalayer_pycrdt` from the `test` extra, but the install steps above were left behind.
  - They stayed harmless while jupyter-collaboration 4.x kept jupyter-ydoc below 4.0, which still used the old `UndoManager(doc=...)` API.
- #347
  - jupyter-collaboration 5.0.0 (Aug 3) pulls in jupyter-ydoc 4.x, which follows the new pycrdt >=0.14 API (`doc` argument removed). Swapping in `datalayer_pycrdt 0.12.17` (old API) on top of that makes every Y document creation raise `RuntimeError: UndoManager must be created with doc or scopes` — the reported failures, all `[mcp_server]` cases, are downstream of this. Pinned `<5` as a stopgap.

Verified locally: every file from the #348 failure list passes on the jupyter-collaboration 5.0.0 stack, with no code changes to jupyter_mcp_server.
