### PR TITLE
fix(use_notebook): route document operations to the document server when split

### DIFF
--- a/docs/docs/code-sandboxes/kaggle/index.mdx
+++ b/docs/docs/code-sandboxes/kaggle/index.mdx
@@ -103,6 +103,48 @@ code sandbox values come from an active browser session:
 You can parse `CODE_SANDBOX_URL` and `CODE_SANDBOX_ID` from that URL automatically by
 setting `CODE_SANDBOX_CHANNELS_URL`.
 
+Alternatively, Kaggle's
+[external editor support](https://www.kaggle.com/product-announcements/567740)
+exposes the URL directly:
+
+1. Open your notebook on [kaggle.com](https://www.kaggle.com) and start an
+  interactive session.
+2. Open **Run** -> **Kaggle Jupyter Server**.
+3. Under **Manually Connect**, copy the **VS Code Compatible URL** — this is
+  your `CODE_SANDBOX_URL`.
+
+> The URL embeds a session JWT: treat it as a secret and don't commit it. It
+> stops working once the interactive session ends (Kaggle stops idle sessions
+> after a while).
+
+## Using it with a coding agent
+
+The interactive URL above is a standard token-authenticated Jupyter server
+endpoint, so it works as a plain `CODE_SANDBOX_URL` — no `SANDBOX_VARIANT`,
+sandbox extension, or `CODE_SANDBOX_TOKEN` required. Point `DOCUMENT_URL` at a
+local JupyterLab to keep the notebook on your machine while cells run on
+Kaggle:
+
+```json
+{
+  "mcpServers": {
+    "jupyter": {
+      "command": "uvx",
+      "args": ["jupyter-mcp-server@latest"],
+      "env": {
+        "DOCUMENT_URL": "http://localhost:8888",
+        "DOCUMENT_TOKEN": "MY_TOKEN",
+        "CODE_SANDBOX_URL": "https://kkb-production.jupyter-proxy.kaggle.net/k/12345678/eyJ.../proxy"
+      }
+    }
+  }
+}
+```
+
+The local JupyterLab needs `jupyter-collaboration` installed; without it,
+notebook tools fail with a 404 on `/api/collaboration/session/...`. The JWT
+embedded in the Kaggle URL authenticates the requests.
+
 ## Configuration
 
 Default (batch mode):

--- a/docs/docs/features/configuration/index.mdx
+++ b/docs/docs/features/configuration/index.mdx
@@ -66,7 +66,7 @@ For deployments requiring granular control over document storage and code sandbo
 #### Document Storage Variables
 | Variable | Description | Example | Default |
 |----------|-------------|---------|---------|
-| `DOCUMENT_URL` | URL for notebook file operations | `http://notebook-storage:8888` | `http://localhost:8888` |
+| `DOCUMENT_URL` | URL for notebook file operations | `http://notebook-storage:8888` | `CODE_SANDBOX_URL` value (`http://localhost:8888` if both unset) |
 | `DOCUMENT_TOKEN` | Authentication for document operations | `storage-access-token` | `None` |
 | `DOCUMENT_PASSWORD` | Password for document server authentication (alternative to token) | `storage-password` | `None` |
 | `DOCUMENT_ID` | Notebook path/ID | `shared/analysis.ipynb` | `None` |

--- a/docs/sourcey/config-fields.json
+++ b/docs/sourcey/config-fields.json
@@ -76,9 +76,9 @@
   },
   {
    "name": "document_url",
-   "type": "<class 'str'>",
-   "default": "http://localhost:8888",
-   "description": "The document URL to use, or 'local' for direct serverapp access"
+   "type": "str | None",
+   "default": null,
+   "description": "The document URL to use, or 'local' for direct serverapp access. Falls back to code_sandbox_url when unset."
   },
   {
    "name": "document_id",

--- a/docs/sourcey/configuration.md
+++ b/docs/sourcey/configuration.md
@@ -21,7 +21,7 @@ All runtime settings live on the `JupyterMCPConfig` pydantic model ([`jupyter_mc
 | `code_sandbox_channels_url` | str \| None | `None` | For the 'colab' and 'kaggle' sandbox variants, the WebSocket channels URL of a running notebook session. When set, server_url and kernel_id are parsed from it. |
 | `sandbox_environment` | str \| None | `None` | Environment name for cloud sandboxes (e.g. Datalayer/Modal). |
 | `sandbox_gpu` | str \| None | `None` | GPU flavor / accelerator for sandbox engines that support it. Examples: Modal/Datalayer -> T4, A10G, A100, H100; Kaggle batch -> NvidiaTeslaT4, NvidiaTeslaP100 (aliases T4/P100). |
-| `document_url` | str | `"http://localhost:8888"` | The document URL to use, or 'local' for direct serverapp access |
+| `document_url` | str \| None | `None` | The document URL to use, or 'local' for direct serverapp access. Falls back to code_sandbox_url when unset. |
 | `document_id` | str \| None | `None` | The document id to use. Optional - if omitted, can list and select notebooks interactively |
 | `document_token` | str \| None | `None` | The document token to use for authentication |
 | `document_password` | str \| None | `None` | Password for Jupyter document server authentication (alternative to token) |

--- a/jupyter_mcp_server/config.py
+++ b/jupyter_mcp_server/config.py
@@ -70,9 +70,12 @@ class JupyterMCPConfig(BaseModel):
     )
 
     # Document configuration
-    document_url: str = Field(
-        default="http://localhost:8888",
-        description="The document URL to use, or 'local' for direct serverapp access",
+    document_url: str | None = Field(
+        default=None,
+        description=(
+            "The document URL to use, or 'local' for direct serverapp access. "
+            "Falls back to code_sandbox_url when unset."
+        ),
     )
     document_id: str | None = Field(
         default=None,
@@ -115,6 +118,18 @@ class JupyterMCPConfig(BaseModel):
     def is_local_document(self) -> bool:
         """Check if document URL is set to local."""
         return self.document_url == "local"
+
+    # When document_url is unset, the document server is the code sandbox server.
+    # These resolvers keep that fallback rule in one place; consumers that need an
+    # actual endpoint call them, while split decisions ("did the operator ask for a
+    # separate document server?") keep reading the raw fields.
+    def resolved_document_url(self) -> str:
+        """Document server URL, falling back to the code sandbox server when unset."""
+        return self.document_url or self.code_sandbox_url
+
+    def resolved_document_token(self) -> str | None:
+        """Document server token; follows code_sandbox_token when document_url is unset."""
+        return self.code_sandbox_token if not self.document_url else self.document_token
 
     def is_local_code_sandbox(self) -> bool:
         """Check if code sandbox URL is set to local."""
@@ -202,7 +217,14 @@ def set_config(**kwargs) -> JupyterMCPConfig:
     for key, value in kwargs.items():
         if should_skip(value):
             # For optional fields, set to None; for required fields, skip (use default)
-            if key in ("code_sandbox_token", "document_token", "code_sandbox_id", "document_id", "code_sandbox_password", "document_password"):
+            if key in (
+                "code_sandbox_token",
+                "document_token",
+                "code_sandbox_id",
+                "document_id",
+                "code_sandbox_password",
+                "document_password",
+            ):
                 normalized_kwargs[key] = None
             # For required string fields like code_sandbox_url, document_url, skip the key
             # to let the default value be used

--- a/jupyter_mcp_server/models.py
+++ b/jupyter_mcp_server/models.py
@@ -11,7 +11,7 @@ from jupyter_mcp_server.utils import normalize_cell_source, safe_extract_outputs
 
 class DocumentCodeSandbox(BaseModel):
     provider: str
-    document_url: str
+    document_url: str | None = None
     document_id: str
     document_token: str
     code_sandbox_url: str

--- a/jupyter_mcp_server/notebook_manager.py
+++ b/jupyter_mcp_server/notebook_manager.py
@@ -59,8 +59,8 @@ class NotebookConnection:
             )
 
         config = get_config()
-        server_url = self.notebook_info.get("server_url", config.document_url)
-        token = self.notebook_info.get("token", config.document_token)
+        server_url = self.notebook_info.get("server_url") or config.resolved_document_url()
+        token = self.notebook_info.get("token") or config.resolved_document_token()
         path = self.notebook_info.get("path", config.document_id)
 
         from jupyter_mcp_server.server_context import ServerContext
@@ -184,8 +184,8 @@ class NotebookManager:
             "kernel": kernel,
             "is_local": is_local_mode,
             "notebook_info": {
-                "server_url": server_url or config.document_url,
-                "token": token or config.document_token,
+                "server_url": server_url or config.resolved_document_url(),
+                "token": token or config.resolved_document_token(),
                 "path": path or config.document_id,
             },
         }
@@ -411,8 +411,8 @@ class NotebookManager:
             config = get_config()
             return NotebookConnection(
                 {
-                    "server_url": config.document_url,
-                    "token": config.document_token,
+                    "server_url": config.resolved_document_url(),
+                    "token": config.resolved_document_token(),
                     "path": config.document_id,
                 }
             )

--- a/jupyter_mcp_server/server_context.py
+++ b/jupyter_mcp_server/server_context.py
@@ -23,6 +23,7 @@ class ServerContext:
     _kernel_spec_manager = None
     _session_manager = None
     _server_client = None
+    _document_client = None
     _kernel_client = None
     _code_sandbox_password_auth = None
     _document_password_auth = None
@@ -50,6 +51,7 @@ class ServerContext:
             cls._instance._kernel_spec_manager = None
             cls._instance._session_manager = None
             cls._instance._server_client = None
+            cls._instance._document_client = None
 
     def _close_auth(self):
         """Close auth sessions if present; safe to call multiple times.
@@ -237,6 +239,32 @@ class ServerContext:
         return self._server_client
 
     @property
+    def document_client(self):
+        """Return an HTTP client for document server operations.
+
+        Reuse the server client when ``document_url`` is unset or matches the
+        code sandbox URL; otherwise create a client with document auth.
+        """
+        if not self._initialized:
+            self.initialize()
+        if self._document_client is not None:
+            return self._document_client
+        config = get_config()
+        document_url = config.document_url
+        if (not document_url) or (document_url == config.code_sandbox_url):
+            return self._server_client
+        if (
+            self._document_password_auth is not None
+            and self._document_password_auth is not self._code_sandbox_password_auth
+        ):
+            client = JupyterServerClient(base_url=document_url, token=None)
+            self._document_password_auth.inject_into_session(client.http_client.session)
+        else:
+            client = JupyterServerClient(base_url=document_url, token=config.document_token)
+        self._document_client = client
+        return self._document_client
+
+    @property
     def kernel_client(self):
         if not self._initialized:
             self.initialize()
@@ -347,6 +375,10 @@ class ServerContext:
             self.relogin_code_sandbox(timeout=timeout)
             return
         self._document_password_auth.relogin(timeout=timeout)
+        if self._document_client is not None:
+            self._document_password_auth.inject_into_session(
+                self._document_client.http_client.session
+            )
         logger.info("Document session re-authenticated after cookie expiry.")
 
     @property

--- a/jupyter_mcp_server/tools/use_notebook_tool.py
+++ b/jupyter_mcp_server/tools/use_notebook_tool.py
@@ -184,13 +184,30 @@ class UseNotebookTool(BaseTool):
             except Exception as e:
                 return f"Failed to connect the Jupyter server: {e}"
 
+        # In split setups, contents operations use the document server and its auth.
+        # When the URLs match, server_client already targets the document server.
+        document_client = server_client
+        document_auth_headers = auth_headers
+        if mode == ServerMode.MCP_SERVER and server_client is not None:
+            from jupyter_mcp_server.config import get_config
+
+            config = get_config()
+            if config.document_url and config.document_url != config.code_sandbox_url:
+                from jupyter_mcp_server.server_context import ServerContext
+
+                context = ServerContext.get_instance()
+                document_client = context.document_client
+                document_auth_headers = context.document_auth_headers
+
         # Check the path exists
         if mode == ServerMode.JUPYTER_SERVER and contents_manager is not None:
             path_ok, error_msg = await self._check_path_local(
                 contents_manager, notebook_path, use_mode
             )
         elif mode == ServerMode.MCP_SERVER and server_client is not None:
-            path_ok, error_msg = await self._check_path_http(server_client, notebook_path, use_mode)
+            path_ok, error_msg = await self._check_path_http(
+                document_client, notebook_path, use_mode
+            )
         else:
             return f"Invalid mode or missing required clients: mode={mode}"
 
@@ -257,11 +274,13 @@ class UseNotebookTool(BaseTool):
                     # caller just read from the live cookie jar, so a rotated cookie
                     # cannot go stale. Token auth has no _xsrf cookie and satisfies
                     # XSRF via its own header, so nothing happens there.
-                    xsrf_token = (auth_headers or {}).get("X-XSRFToken")
-                    session = getattr(getattr(server_client, "http_client", None), "session", None)
+                    xsrf_token = (document_auth_headers or {}).get("X-XSRFToken")
+                    session = getattr(
+                        getattr(document_client, "http_client", None), "session", None
+                    )
                     if xsrf_token and session is not None:
                         session.headers["X-XSRFToken"] = xsrf_token
-                    server_client.contents.create_notebook(notebook_path, content=content)
+                    document_client.contents.create_notebook(notebook_path, content=content)
 
             # # Create/connect to kernel based on mode
             if mode == ServerMode.MCP_SERVER and server_client is not None:
@@ -327,11 +346,16 @@ class UseNotebookTool(BaseTool):
 
             # Add notebook to notebook_manager
             if mode == ServerMode.MCP_SERVER and code_sandbox_url:
+                from jupyter_mcp_server.config import get_config
+
+                # The notebook and its collaboration session live on the
+                # document server.
+                config = get_config()
                 notebook_manager.add_notebook(
                     notebook_name,
                     kernel,
-                    server_url=code_sandbox_url,
-                    token=code_sandbox_token,
+                    server_url=config.document_url,
+                    token=config.document_token,
                     path=notebook_path,
                 )
             elif mode == ServerMode.JUPYTER_SERVER and kernel_manager is not None:
@@ -399,10 +423,16 @@ class UseNotebookTool(BaseTool):
                     # JUPYTER_SERVER mode: Use ServerApp connection details
                     base_url = context.serverapp.connection_url
                     token = context.serverapp.token
-                elif mode == ServerMode.MCP_SERVER and code_sandbox_url:
-                    # MCP_SERVER mode: Use code_sandbox_url and code_sandbox_token
-                    base_url = code_sandbox_url
-                    token = code_sandbox_token
+                elif mode == ServerMode.MCP_SERVER:
+                    # In split setups, open the file in the document server's
+                    # JupyterLab, where the notebook is stored.
+                    config = get_config()
+                    if config.document_url and config.document_url != config.code_sandbox_url:
+                        base_url = config.document_url
+                        token = config.document_token
+                    elif code_sandbox_url:
+                        base_url = code_sandbox_url
+                        token = code_sandbox_token
 
                 if base_url and token:
                     try:

--- a/jupyter_mcp_server/utils.py
+++ b/jupyter_mcp_server/utils.py
@@ -160,15 +160,20 @@ def resolve_url_and_token_variables(
     document_token,
     code_sandbox_url,
     code_sandbox_token,
-) -> tuple[str, str | None, str, str | None]:
-    """Resolve merged URL/token settings with per-field precedence."""
+) -> tuple[str | None, str | None, str, str | None]:
+    """Resolve merged URL/token settings with per-field precedence.
+
+    ``resolved_document_url`` may be ``None`` when neither ``document_url``
+    nor ``jupyter_url`` is given; callers (and JupyterMCPConfig) fall back to
+    the code sandbox URL in that case rather than hardcoding localhost.
+    """
 
     if document_url is not None:
         resolved_document_url = document_url
     elif jupyter_url is not None:
         resolved_document_url = jupyter_url
     else:
-        resolved_document_url = "http://localhost:8888"
+        resolved_document_url = None
 
     if code_sandbox_url is not None:
         resolved_code_sandbox_url = code_sandbox_url
@@ -217,7 +222,7 @@ def do_start(
     code_sandbox_url: str,
     code_sandbox_id: str,
     code_sandbox_token: str,
-    document_url: str,
+    document_url: str | None,
     document_id: str,
     document_token: str,
     port: int,

--- a/tests/test_cli_typer_config.py
+++ b/tests/test_cli_typer_config.py
@@ -5,6 +5,7 @@
 
 """Typer-based config and option tests mirroring the Click config test suite."""
 
+import json
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -13,7 +14,7 @@ from typer.testing import CliRunner
 
 from jupyter_mcp_server.cli.cli import Provider, app, connect_command, stop_command
 from jupyter_mcp_server.config import JupyterMCPConfig, get_config, reset_config, set_config
-from jupyter_mcp_server.utils import mcp_auth_headers
+from jupyter_mcp_server.utils import mcp_auth_headers, resolve_url_and_token_variables
 
 
 class _Response:
@@ -31,6 +32,28 @@ def test_mcp_auth_headers_include_bearer_token():
 def test_mcp_auth_headers_empty_without_token():
     """Management CLI requests stay unauthenticated in explicit no-auth mode."""
     assert mcp_auth_headers(None) == {}
+
+
+def test_resolve_url_and_token_variables_document_url_none_when_all_unset():
+    """Resolve document_url to None (not localhost) when nothing is given."""
+    (
+        resolved_document_url,
+        resolved_document_token,
+        resolved_code_sandbox_url,
+        resolved_code_sandbox_token,
+    ) = resolve_url_and_token_variables(
+        jupyter_url=None,
+        jupyter_token=None,
+        document_url=None,
+        document_token=None,
+        code_sandbox_url=None,
+        code_sandbox_token=None,
+    )
+
+    assert resolved_document_url is None
+    assert resolved_document_token is None
+    assert resolved_code_sandbox_url == "http://localhost:8888"
+    assert resolved_code_sandbox_token is None
 
 
 def test_connect_command_sends_mcp_token():
@@ -60,6 +83,35 @@ def test_connect_command_sends_mcp_token():
         )
 
     assert seen["headers"]["Authorization"] == "Bearer client-token"
+
+
+def test_connect_command_accepts_unset_document_url():
+    """Sandbox-only connect (no document/jupyter URL) must reach the request."""
+    reset_config()
+    seen = {}
+
+    def fake_put(url, headers=None, content=None):
+        seen["content"] = content
+        return _Response()
+
+    with patch("jupyter_mcp_server.cli.commands.connect.httpx.put", fake_put):
+        connect_command(
+            jupyter_mcp_server_url="http://localhost:4040",
+            provider=Provider.jupyter,
+            jupyterlab=True,
+            open_notebook_in_ui=False,
+            code_sandbox_url="http://localhost:8888",
+            code_sandbox_id="kernel-id",
+            code_sandbox_token="sandbox-token",
+            mcp_token="client-token",
+            document_url=None,
+            document_id="notebook.ipynb",
+            document_token="doc-token",
+            jupyter_url=None,
+            jupyter_token=None,
+        )
+
+    assert json.loads(seen["content"])["document_url"] is None
 
 
 def test_stop_command_sends_mcp_token():
@@ -347,6 +399,6 @@ def test_jupyter_collaboration_is_a_required_dependency():
     matching = [Requirement(r) for r in requires if Requirement(r).name == "jupyter-collaboration"]
 
     assert matching, "jupyter-collaboration is missing from the distribution's requirements"
-    assert all(
-        r.marker is None or not r.marker.evaluate({"extra": "test"}) for r in matching
-    ), "jupyter-collaboration must not be gated behind the 'test' extra"
+    assert all(r.marker is None or not r.marker.evaluate({"extra": "test"}) for r in matching), (
+        "jupyter-collaboration must not be gated behind the 'test' extra"
+    )

--- a/tests/test_use_notebook_split_servers.py
+++ b/tests/test_use_notebook_split_servers.py
@@ -1,0 +1,306 @@
+# Copyright (c) 2024- Datalayer, Inc.
+#
+# BSD 3-Clause License
+
+"""Test use_notebook routing for split document and code sandbox servers.
+
+Contents and collaboration requests target the document server, kernel
+operations target the code sandbox, and matching URLs preserve the caller's
+client.
+"""
+
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import nbformat
+import pytest
+
+from jupyter_mcp_server.config import reset_config, set_config
+from jupyter_mcp_server.jupyter_extension.context import get_server_context
+from jupyter_mcp_server.notebook_manager import NotebookManager
+from jupyter_mcp_server.server_context import ServerContext
+from jupyter_mcp_server.tools import use_notebook_tool
+from jupyter_mcp_server.tools._base import ServerMode
+from jupyter_mcp_server.tools.use_notebook_tool import UseNotebookTool
+
+from .conftest import JUPYTER_TOKEN, _find_free_port, _start_server
+
+DOCUMENT_URL = "http://localhost:9999"
+DOCUMENT_TOKEN = "document-token"
+SANDBOX_URL = "http://localhost:8888"
+SANDBOX_TOKEN = "sandbox-token"
+
+
+class FakeFile:
+    """Minimal jupyter-server-client directory entry."""
+
+    def __init__(self, name):
+        self.name = name
+
+
+class FakeContents:
+    """Record Contents API calls instead of hitting a server."""
+
+    def __init__(self, names):
+        self._names = names
+        self.listed = []
+        self.created = []
+
+    def list_directory(self, path):
+        self.listed.append(path)
+        return [FakeFile(name) for name in self._names]
+
+    def create_notebook(self, path, content=None):
+        self.created.append(path)
+
+
+class FakeServerClient:
+    """Minimal JupyterServerClient fake used by the use_notebook tests."""
+
+    def __init__(self, names=()):
+        self.contents = FakeContents(names)
+        self.http_client = SimpleNamespace(session=SimpleNamespace(headers={}))
+
+    def get_status(self):
+        return {"version": "2.0.0"}
+
+
+class FakeKernel:
+    id = "kernel-1"
+
+
+class FakeMCPToolsClient:
+    """Stand-in for jupyter_mcp_tools' MCPToolsClient that records where it was
+    pointed and what it was asked to execute."""
+
+    calls = []
+
+    def __init__(self, base_url=None, token=None):
+        type(self).calls.append((base_url, token))
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+    async def execute_tool(self, tool_id, parameters=None):
+        type(self).calls.append((tool_id, parameters))
+        return {"success": True}
+
+
+@pytest.fixture(autouse=True)
+def _reset_config():
+    reset_config()
+    yield
+    reset_config()
+
+
+async def _execute(sandbox_client, notebook_manager, use_mode="connect", auth_headers=None):
+    return await UseNotebookTool().execute(
+        mode=ServerMode.MCP_SERVER,
+        server_client=sandbox_client,
+        notebook_manager=notebook_manager,
+        notebook_name="nb",
+        notebook_path="work/nb.ipynb",
+        use_mode=use_mode,
+        code_sandbox_url=SANDBOX_URL,
+        code_sandbox_token=SANDBOX_TOKEN,
+        auth_headers=auth_headers,
+    )
+
+
+@pytest.mark.asyncio
+async def test_split_create_does_not_inject_sandbox_xsrf(monkeypatch):
+    """Do not reuse code sandbox XSRF headers for document server requests."""
+    set_config(
+        document_url=DOCUMENT_URL,
+        code_sandbox_url=SANDBOX_URL,
+        code_sandbox_token=SANDBOX_TOKEN,
+    )
+    document_client = FakeServerClient()
+    stub = SimpleNamespace(document_client=document_client, document_auth_headers={})
+    monkeypatch.setattr(ServerContext, "get_instance", lambda: stub)
+    nm = NotebookManager()
+
+    with patch.object(
+        use_notebook_tool, "create_jupyter_sandbox_client", return_value=FakeKernel()
+    ):
+        await _execute(
+            FakeServerClient(),
+            nm,
+            use_mode="create",
+            auth_headers={"Cookie": "_xsrf=sandbox", "X-XSRFToken": "sandbox-xsrf"},
+        )
+
+    assert "work/nb.ipynb" in document_client.contents.created
+    assert "X-XSRFToken" not in document_client.http_client.session.headers
+
+
+@pytest.mark.asyncio
+async def test_split_opens_ui_on_document_server(monkeypatch):
+    """Open the notebook in the document server's JupyterLab."""
+    set_config(
+        document_url=DOCUMENT_URL,
+        document_token=DOCUMENT_TOKEN,
+        code_sandbox_url=SANDBOX_URL,
+        code_sandbox_token=SANDBOX_TOKEN,
+        open_notebook_in_ui=True,
+    )
+    get_server_context().update(context_type="MCP_SERVER", jupyterlab=True)
+    document_client = FakeServerClient(["nb.ipynb"])
+    stub = SimpleNamespace(document_client=document_client, document_auth_headers={})
+    monkeypatch.setattr(ServerContext, "get_instance", lambda: stub)
+    nm = NotebookManager()
+
+    FakeMCPToolsClient.calls = []
+    monkeypatch.setattr("jupyter_mcp_tools.client.MCPToolsClient", FakeMCPToolsClient)
+
+    with patch.object(
+        use_notebook_tool, "create_jupyter_sandbox_client", return_value=FakeKernel()
+    ):
+        await _execute(FakeServerClient(), nm)
+
+    assert FakeMCPToolsClient.calls == [
+        (DOCUMENT_URL, DOCUMENT_TOKEN),
+        ("docmanager_open", {"path": "work/nb.ipynb"}),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_same_url_keeps_caller_client(monkeypatch):
+    """Keep the caller's client when both server URLs match."""
+    set_config(
+        document_url=SANDBOX_URL,
+        code_sandbox_url=SANDBOX_URL,
+        code_sandbox_token=SANDBOX_TOKEN,
+    )
+
+    def _fail():
+        raise AssertionError("ServerContext.get_instance must not be called")
+
+    monkeypatch.setattr(ServerContext, "get_instance", _fail)
+    client = FakeServerClient(["nb.ipynb"])
+    nm = NotebookManager()
+
+    with patch.object(
+        use_notebook_tool, "create_jupyter_sandbox_client", return_value=FakeKernel()
+    ):
+        result = await _execute(client, nm)
+
+    assert "Successfully activate notebook 'nb'" in result
+    assert client.contents.listed == ["work"]
+
+
+@pytest.fixture(scope="module")
+def document_root(tmp_path_factory):
+    return tmp_path_factory.mktemp("split_document_content")
+
+
+@pytest.fixture(scope="module")
+def document_server(document_root):
+    """A second Jupyter Server, holding the notebook files."""
+    host = "localhost"
+    port = _find_free_port()
+    yield from _start_server(
+        name="JupyterLab-document",
+        host=host,
+        port=port,
+        command=[
+            "jupyter",
+            "lab",
+            "--port",
+            str(port),
+            "--IdentityProvider.token",
+            JUPYTER_TOKEN,
+            "--ip",
+            host,
+            "--ServerApp.root_dir",
+            str(document_root),
+            "--no-browser",
+        ],
+        readiness_endpoint="/api",
+        max_retries=10,
+    )
+
+
+@pytest.fixture
+def _reset_server_context():
+    ServerContext.reset()
+    yield
+    ServerContext.reset()
+
+
+@pytest.mark.asyncio
+async def test_create_writes_to_document_server_not_sandbox(
+    document_server, jupyter_server, _reset_server_context
+):
+    """use_mode="create" must put the file on the document server only."""
+    set_config(
+        document_url=document_server,
+        document_token=JUPYTER_TOKEN,
+        code_sandbox_url=jupyter_server,
+        code_sandbox_token=JUPYTER_TOKEN,
+    )
+    context = ServerContext.get_instance()
+    document_client = context.document_client
+
+    await UseNotebookTool().execute(
+        mode=ServerMode.MCP_SERVER,
+        server_client=context.server_client,
+        notebook_manager=NotebookManager(),
+        notebook_name="split",
+        notebook_path="split_create.ipynb",
+        use_mode="create",
+        code_sandbox_url=jupyter_server,
+        code_sandbox_token=JUPYTER_TOKEN,
+        auth_headers=None,
+    )
+
+    document_names = [f.name for f in document_client.contents.list_directory("")]
+    sandbox_names = [f.name for f in context.server_client.contents.list_directory("")]
+    assert "split_create.ipynb" in document_names
+    assert "split_create.ipynb" not in sandbox_names
+
+
+@pytest.mark.asyncio
+async def test_connect_to_notebook_only_on_the_document_server(
+    document_server, document_root, jupyter_server, _reset_server_context
+):
+    """The #344 repro: before the fix, the existence check and the
+    collaboration session went to the code sandbox, which has no copy of the
+    file, so this failed with a 404 on /api/collaboration/session/.
+    """
+    (document_root / "split_connect.ipynb").write_text(nbformat.writes(nbformat.v4.new_notebook()))
+
+    set_config(
+        document_url=document_server,
+        document_token=JUPYTER_TOKEN,
+        code_sandbox_url=jupyter_server,
+        code_sandbox_token=JUPYTER_TOKEN,
+    )
+    context = ServerContext.get_instance()
+    notebook_manager = NotebookManager()
+
+    result = await UseNotebookTool().execute(
+        mode=ServerMode.MCP_SERVER,
+        server_client=context.server_client,
+        notebook_manager=notebook_manager,
+        notebook_name="connect",
+        notebook_path="split_connect.ipynb",
+        use_mode="connect",
+        code_sandbox_url=jupyter_server,
+        code_sandbox_token=JUPYTER_TOKEN,
+        auth_headers=None,
+    )
+
+    assert "Successfully activate notebook 'connect'" in result
+    assert (
+        notebook_manager.get_notebook_connection("connect").notebook_info["server_url"]
+        == document_server
+    )
+
+    # execute() swallows collaboration failures, so connect explicitly: this is
+    # the request that returned the 404 in #344.
+    async with notebook_manager.get_current_connection() as notebook:
+        assert notebook is not None

--- a/tests/test_use_notebook_split_servers.py
+++ b/tests/test_use_notebook_split_servers.py
@@ -15,7 +15,7 @@ from unittest.mock import patch
 import nbformat
 import pytest
 
-from jupyter_mcp_server.config import reset_config, set_config
+from jupyter_mcp_server.config import get_config, reset_config, set_config
 from jupyter_mcp_server.jupyter_extension.context import get_server_context
 from jupyter_mcp_server.notebook_manager import NotebookManager
 from jupyter_mcp_server.server_context import ServerContext
@@ -136,6 +136,11 @@ async def test_split_create_does_not_inject_sandbox_xsrf(monkeypatch):
     assert "work/nb.ipynb" in document_client.contents.created
     assert "X-XSRFToken" not in document_client.http_client.session.headers
 
+    # The sandbox token must not leak to the (anonymous) document server.
+    notebook_info = nm.get_notebook_connection("nb").notebook_info
+    assert notebook_info["server_url"] == DOCUMENT_URL
+    assert notebook_info["token"] is None
+
 
 @pytest.mark.asyncio
 async def test_split_opens_ui_on_document_server(monkeypatch):
@@ -166,6 +171,11 @@ async def test_split_opens_ui_on_document_server(monkeypatch):
         ("docmanager_open", {"path": "work/nb.ipynb"}),
     ]
 
+    # The registered token is the explicit document_token, not the sandbox's.
+    notebook_info = nm.get_notebook_connection("nb").notebook_info
+    assert notebook_info["server_url"] == DOCUMENT_URL
+    assert notebook_info["token"] == DOCUMENT_TOKEN
+
 
 @pytest.mark.asyncio
 async def test_same_url_keeps_caller_client(monkeypatch):
@@ -190,6 +200,36 @@ async def test_same_url_keeps_caller_client(monkeypatch):
 
     assert "Successfully activate notebook 'nb'" in result
     assert client.contents.listed == ["work"]
+
+
+@pytest.mark.asyncio
+async def test_unset_document_url_keeps_caller_client(monkeypatch):
+    """Keep the caller's client and register the sandbox URL/token when
+    document_url is unset (the sandbox-only engine shape)."""
+    set_config(
+        code_sandbox_url=SANDBOX_URL,
+        code_sandbox_token=SANDBOX_TOKEN,
+    )
+    assert get_config().document_url is None
+
+    def _fail():
+        raise AssertionError("ServerContext.get_instance must not be called")
+
+    monkeypatch.setattr(ServerContext, "get_instance", _fail)
+    client = FakeServerClient(["nb.ipynb"])
+    nm = NotebookManager()
+
+    with patch.object(
+        use_notebook_tool, "create_jupyter_sandbox_client", return_value=FakeKernel()
+    ):
+        result = await _execute(client, nm)
+
+    assert "Successfully activate notebook 'nb'" in result
+    assert client.contents.listed == ["work"]
+
+    notebook_info = nm.get_notebook_connection("nb").notebook_info
+    assert notebook_info["server_url"] == SANDBOX_URL
+    assert notebook_info["token"] == SANDBOX_TOKEN
 
 
 @pytest.fixture(scope="module")


### PR DESCRIPTION
Fixes #344

## Summary

Fix `use_notebook` for setups that use separate document and code sandbox servers.

## Changes

- Route notebook existence checks, creation, collaboration registration, and optional UI opening to the document server when the URLs differ.
- Keep kernel discovery, startup, and execution on the code sandbox server.
- Use document-server authentication for document requests and never reuse code sandbox XSRF headers.
- Preserve the caller-supplied client when both URLs point to the same server.

## Verification

- I used this for a day of regular work with a local notebook and a remote RunPod GPU kernel, and it behaved as expected throughout.
- Beyond that, I had an AI agent verify several connection patterns, including a Kaggle remote kernel.
- Added `tests/test_use_notebook_split_servers.py`.
- `make test-mcp-server` and `make test-jupyter-server` pass.

### AI Verification Notes

<details>
<summary>Split-server configurations exercised</summary>

The notebook existed only on the document server in every run.

| Document server | Code sandbox |
| --- | --- |
| local, **password** | local, token |
| local, token | RunPod, **password** |
| local, token | **Kaggle** |

Confirmed in all three:

- The collaboration session is established on the document server — this is the request that returned `404 /api/collaboration/session/` in #344.
- `use_mode="create"` writes the notebook to the document server only; it never appears on the code sandbox.
- Kernels start on the code sandbox and appear in its `/api/kernels`.

Auth-specific:

- Code sandbox password auth: its cookies and `X-XSRFToken` are absent from the document client, including after notebook creation.
- Document password auth: login cookies are injected into the document client, and re-injected after `relogin_document()`.

</details>

<details>
<summary>Regression coverage of the added tests</summary>

Reverting `use_notebook_tool.py` to the pre-fix version fails 4 of the 5 tests. The one that still passes is `test_same_url_keeps_caller_client`, which covers the non-split path that this change intentionally leaves untouched.

`execute()` swallows collaboration failures, so `test_connect_to_notebook_only_on_the_document_server` opens the connection explicitly rather than relying on the returned message.

</details>
