### PR TITLE
refactor: rename clients by type and role

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -154,7 +154,7 @@ async def list_files(path: str = "", max_depth: int = 1, ...) -> str:
     return await safe_notebook_operation(
         lambda: ListFilesTool().execute(
             mode=server_context.mode,
-            server_client=server_context.server_client,
+            code_sandbox_client=server_context.code_sandbox_client,
             contents_manager=server_context.contents_manager,
             path=path,
             max_depth=max_depth,

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -154,7 +154,7 @@ async def list_files(path: str = "", max_depth: int = 1, ...) -> str:
     return await safe_notebook_operation(
         lambda: ListFilesTool().execute(
             mode=server_context.mode,
-            code_sandbox_client=server_context.code_sandbox_client,
+            sandbox_server_client=server_context.sandbox_server_client,
             contents_manager=server_context.contents_manager,
             path=path,
             max_depth=max_depth,

--- a/jupyter_mcp_server/enroll.py
+++ b/jupyter_mcp_server/enroll.py
@@ -83,7 +83,7 @@ async def auto_enroll_document(
         # Use the use_notebook_tool to properly enroll the notebook with kernel
         result = await use_notebook_tool.execute(
             mode=server_context.mode,
-            server_client=server_context.server_client,
+            code_sandbox_client=server_context.code_sandbox_client,
             notebook_name="default",
             notebook_path=config.document_id,
             use_mode="connect",

--- a/jupyter_mcp_server/enroll.py
+++ b/jupyter_mcp_server/enroll.py
@@ -83,7 +83,7 @@ async def auto_enroll_document(
         # Use the use_notebook_tool to properly enroll the notebook with kernel
         result = await use_notebook_tool.execute(
             mode=server_context.mode,
-            code_sandbox_client=server_context.code_sandbox_client,
+            sandbox_server_client=server_context.sandbox_server_client,
             notebook_name="default",
             notebook_path=config.document_id,
             use_mode="connect",

--- a/jupyter_mcp_server/server.py
+++ b/jupyter_mcp_server/server.py
@@ -391,7 +391,7 @@ async def list_files(
     return await safe_notebook_operation(
         lambda: ListFilesTool().execute(
             mode=server_context.mode,
-            code_sandbox_client=server_context.code_sandbox_client,
+            sandbox_server_client=server_context.sandbox_server_client,
             contents_manager=server_context.contents_manager,
             path=path,
             max_depth=max_depth,
@@ -426,7 +426,7 @@ async def list_kernels() -> (
     return await safe_notebook_operation(
         lambda: ListKernelsTool().execute(
             mode=server_context.mode,
-            code_sandbox_client=server_context.code_sandbox_client,
+            sandbox_server_client=server_context.sandbox_server_client,
             kernel_manager=server_context.kernel_manager,
             kernel_spec_manager=server_context.kernel_spec_manager,
         )
@@ -471,7 +471,7 @@ async def use_notebook(
     result = await safe_notebook_operation(
         lambda: UseNotebookTool().execute(
             mode=server_context.mode,
-            code_sandbox_client=server_context.code_sandbox_client,
+            sandbox_server_client=server_context.sandbox_server_client,
             notebook_name=notebook_name,
             notebook_path=notebook_path,
             use_mode=mode,
@@ -601,7 +601,7 @@ async def read_notebook(
     return await safe_notebook_operation(
         lambda: ReadNotebookTool().execute(
             mode=server_context.mode,
-            code_sandbox_client=server_context.code_sandbox_client,
+            sandbox_server_client=server_context.sandbox_server_client,
             contents_manager=server_context.contents_manager,
             notebook_manager=notebook_manager,
             notebook_name=notebook_name,
@@ -643,7 +643,7 @@ async def insert_cell(
     return await safe_notebook_operation(
         lambda: InsertCellTool().execute(
             mode=server_context.mode,
-            code_sandbox_client=server_context.code_sandbox_client,
+            sandbox_server_client=server_context.sandbox_server_client,
             contents_manager=server_context.contents_manager,
             kernel_manager=server_context.kernel_manager,
             notebook_manager=notebook_manager,
@@ -680,7 +680,7 @@ async def overwrite_cell_source(
     return await safe_notebook_operation(
         lambda: OverwriteCellSourceTool().execute(
             mode=server_context.mode,
-            code_sandbox_client=server_context.code_sandbox_client,
+            sandbox_server_client=server_context.sandbox_server_client,
             contents_manager=server_context.contents_manager,
             kernel_manager=server_context.kernel_manager,
             notebook_manager=notebook_manager,
@@ -722,7 +722,7 @@ async def edit_cell_source(
     return await safe_notebook_operation(
         lambda: EditCellSourceTool().execute(
             mode=server_context.mode,
-            code_sandbox_client=server_context.code_sandbox_client,
+            sandbox_server_client=server_context.sandbox_server_client,
             contents_manager=server_context.contents_manager,
             kernel_manager=server_context.kernel_manager,
             notebook_manager=notebook_manager,
@@ -773,7 +773,7 @@ async def execute_cell(
     return await safe_notebook_operation(
         lambda: ExecuteCellTool().execute(
             mode=server_context.mode,
-            code_sandbox_client=server_context.code_sandbox_client,
+            sandbox_server_client=server_context.sandbox_server_client,
             contents_manager=server_context.contents_manager,
             kernel_manager=server_context.kernel_manager,
             notebook_manager=notebook_manager,
@@ -829,7 +829,7 @@ async def insert_execute_code_cell(
     insert_result = await safe_notebook_operation(
         lambda: InsertCellTool().execute(
             mode=server_context.mode,
-            code_sandbox_client=server_context.code_sandbox_client,
+            sandbox_server_client=server_context.sandbox_server_client,
             contents_manager=server_context.contents_manager,
             kernel_manager=server_context.kernel_manager,
             notebook_manager=notebook_manager,
@@ -851,7 +851,7 @@ async def insert_execute_code_cell(
     return await safe_notebook_operation(
         lambda: ExecuteCellTool().execute(
             mode=server_context.mode,
-            code_sandbox_client=server_context.code_sandbox_client,
+            sandbox_server_client=server_context.sandbox_server_client,
             contents_manager=server_context.contents_manager,
             kernel_manager=server_context.kernel_manager,
             notebook_manager=notebook_manager,
@@ -895,7 +895,7 @@ async def read_cell(
     return await safe_notebook_operation(
         lambda: ReadCellTool().execute(
             mode=server_context.mode,
-            code_sandbox_client=server_context.code_sandbox_client,
+            sandbox_server_client=server_context.sandbox_server_client,
             contents_manager=server_context.contents_manager,
             notebook_manager=notebook_manager,
             cell_index=cell_index,
@@ -935,7 +935,7 @@ async def delete_cell(
     return await safe_notebook_operation(
         lambda: DeleteCellTool().execute(
             mode=server_context.mode,
-            code_sandbox_client=server_context.code_sandbox_client,
+            sandbox_server_client=server_context.sandbox_server_client,
             contents_manager=server_context.contents_manager,
             kernel_manager=server_context.kernel_manager,
             notebook_manager=notebook_manager,
@@ -969,7 +969,7 @@ async def clear_cell_output(
     return await safe_notebook_operation(
         lambda: ClearCellOutputTool().execute(
             mode=server_context.mode,
-            code_sandbox_client=server_context.code_sandbox_client,
+            sandbox_server_client=server_context.sandbox_server_client,
             contents_manager=server_context.contents_manager,
             kernel_manager=server_context.kernel_manager,
             notebook_manager=notebook_manager,
@@ -1010,7 +1010,7 @@ async def move_cell(
     return await safe_notebook_operation(
         lambda: MoveCellTool().execute(
             mode=server_context.mode,
-            code_sandbox_client=server_context.code_sandbox_client,
+            sandbox_server_client=server_context.sandbox_server_client,
             contents_manager=server_context.contents_manager,
             kernel_manager=server_context.kernel_manager,
             notebook_manager=notebook_manager,
@@ -1094,7 +1094,7 @@ async def execute_code(
     return await safe_notebook_operation(
         lambda: ExecuteCodeTool().execute(
             mode=server_context.mode,
-            code_sandbox_client=server_context.code_sandbox_client,
+            sandbox_server_client=server_context.sandbox_server_client,
             kernel_manager=server_context.kernel_manager,
             notebook_manager=notebook_manager,
             code=code,
@@ -1174,7 +1174,7 @@ async def jupyter_cite(
     return await safe_notebook_operation(
         lambda: JupyterCitePrompt().execute(
             mode=server_context.mode,
-            code_sandbox_client=server_context.code_sandbox_client,
+            sandbox_server_client=server_context.sandbox_server_client,
             contents_manager=server_context.contents_manager,
             notebook_manager=notebook_manager,
             cell_indices=cell_indices,

--- a/jupyter_mcp_server/server.py
+++ b/jupyter_mcp_server/server.py
@@ -391,7 +391,7 @@ async def list_files(
     return await safe_notebook_operation(
         lambda: ListFilesTool().execute(
             mode=server_context.mode,
-            server_client=server_context.server_client,
+            code_sandbox_client=server_context.code_sandbox_client,
             contents_manager=server_context.contents_manager,
             path=path,
             max_depth=max_depth,
@@ -426,7 +426,7 @@ async def list_kernels() -> (
     return await safe_notebook_operation(
         lambda: ListKernelsTool().execute(
             mode=server_context.mode,
-            server_client=server_context.server_client,
+            code_sandbox_client=server_context.code_sandbox_client,
             kernel_manager=server_context.kernel_manager,
             kernel_spec_manager=server_context.kernel_spec_manager,
         )
@@ -471,7 +471,7 @@ async def use_notebook(
     result = await safe_notebook_operation(
         lambda: UseNotebookTool().execute(
             mode=server_context.mode,
-            server_client=server_context.server_client,
+            code_sandbox_client=server_context.code_sandbox_client,
             notebook_name=notebook_name,
             notebook_path=notebook_path,
             use_mode=mode,
@@ -601,7 +601,7 @@ async def read_notebook(
     return await safe_notebook_operation(
         lambda: ReadNotebookTool().execute(
             mode=server_context.mode,
-            server_client=server_context.server_client,
+            code_sandbox_client=server_context.code_sandbox_client,
             contents_manager=server_context.contents_manager,
             notebook_manager=notebook_manager,
             notebook_name=notebook_name,
@@ -643,7 +643,7 @@ async def insert_cell(
     return await safe_notebook_operation(
         lambda: InsertCellTool().execute(
             mode=server_context.mode,
-            server_client=server_context.server_client,
+            code_sandbox_client=server_context.code_sandbox_client,
             contents_manager=server_context.contents_manager,
             kernel_manager=server_context.kernel_manager,
             notebook_manager=notebook_manager,
@@ -680,7 +680,7 @@ async def overwrite_cell_source(
     return await safe_notebook_operation(
         lambda: OverwriteCellSourceTool().execute(
             mode=server_context.mode,
-            server_client=server_context.server_client,
+            code_sandbox_client=server_context.code_sandbox_client,
             contents_manager=server_context.contents_manager,
             kernel_manager=server_context.kernel_manager,
             notebook_manager=notebook_manager,
@@ -722,7 +722,7 @@ async def edit_cell_source(
     return await safe_notebook_operation(
         lambda: EditCellSourceTool().execute(
             mode=server_context.mode,
-            server_client=server_context.server_client,
+            code_sandbox_client=server_context.code_sandbox_client,
             contents_manager=server_context.contents_manager,
             kernel_manager=server_context.kernel_manager,
             notebook_manager=notebook_manager,
@@ -773,7 +773,7 @@ async def execute_cell(
     return await safe_notebook_operation(
         lambda: ExecuteCellTool().execute(
             mode=server_context.mode,
-            server_client=server_context.server_client,
+            code_sandbox_client=server_context.code_sandbox_client,
             contents_manager=server_context.contents_manager,
             kernel_manager=server_context.kernel_manager,
             notebook_manager=notebook_manager,
@@ -829,7 +829,7 @@ async def insert_execute_code_cell(
     insert_result = await safe_notebook_operation(
         lambda: InsertCellTool().execute(
             mode=server_context.mode,
-            server_client=server_context.server_client,
+            code_sandbox_client=server_context.code_sandbox_client,
             contents_manager=server_context.contents_manager,
             kernel_manager=server_context.kernel_manager,
             notebook_manager=notebook_manager,
@@ -851,7 +851,7 @@ async def insert_execute_code_cell(
     return await safe_notebook_operation(
         lambda: ExecuteCellTool().execute(
             mode=server_context.mode,
-            server_client=server_context.server_client,
+            code_sandbox_client=server_context.code_sandbox_client,
             contents_manager=server_context.contents_manager,
             kernel_manager=server_context.kernel_manager,
             notebook_manager=notebook_manager,
@@ -895,7 +895,7 @@ async def read_cell(
     return await safe_notebook_operation(
         lambda: ReadCellTool().execute(
             mode=server_context.mode,
-            server_client=server_context.server_client,
+            code_sandbox_client=server_context.code_sandbox_client,
             contents_manager=server_context.contents_manager,
             notebook_manager=notebook_manager,
             cell_index=cell_index,
@@ -935,7 +935,7 @@ async def delete_cell(
     return await safe_notebook_operation(
         lambda: DeleteCellTool().execute(
             mode=server_context.mode,
-            server_client=server_context.server_client,
+            code_sandbox_client=server_context.code_sandbox_client,
             contents_manager=server_context.contents_manager,
             kernel_manager=server_context.kernel_manager,
             notebook_manager=notebook_manager,
@@ -969,7 +969,7 @@ async def clear_cell_output(
     return await safe_notebook_operation(
         lambda: ClearCellOutputTool().execute(
             mode=server_context.mode,
-            server_client=server_context.server_client,
+            code_sandbox_client=server_context.code_sandbox_client,
             contents_manager=server_context.contents_manager,
             kernel_manager=server_context.kernel_manager,
             notebook_manager=notebook_manager,
@@ -1010,7 +1010,7 @@ async def move_cell(
     return await safe_notebook_operation(
         lambda: MoveCellTool().execute(
             mode=server_context.mode,
-            server_client=server_context.server_client,
+            code_sandbox_client=server_context.code_sandbox_client,
             contents_manager=server_context.contents_manager,
             kernel_manager=server_context.kernel_manager,
             notebook_manager=notebook_manager,
@@ -1094,7 +1094,7 @@ async def execute_code(
     return await safe_notebook_operation(
         lambda: ExecuteCodeTool().execute(
             mode=server_context.mode,
-            server_client=server_context.server_client,
+            code_sandbox_client=server_context.code_sandbox_client,
             kernel_manager=server_context.kernel_manager,
             notebook_manager=notebook_manager,
             code=code,
@@ -1174,7 +1174,7 @@ async def jupyter_cite(
     return await safe_notebook_operation(
         lambda: JupyterCitePrompt().execute(
             mode=server_context.mode,
-            server_client=server_context.server_client,
+            code_sandbox_client=server_context.code_sandbox_client,
             contents_manager=server_context.contents_manager,
             notebook_manager=notebook_manager,
             cell_indices=cell_indices,

--- a/jupyter_mcp_server/server_context.py
+++ b/jupyter_mcp_server/server_context.py
@@ -22,7 +22,7 @@ class ServerContext:
     _kernel_manager = None
     _kernel_spec_manager = None
     _session_manager = None
-    _server_client = None
+    _code_sandbox_client = None
     _document_client = None
     _code_sandbox_password_auth = None
     _document_password_auth = None
@@ -49,7 +49,7 @@ class ServerContext:
             cls._instance._kernel_manager = None
             cls._instance._kernel_spec_manager = None
             cls._instance._session_manager = None
-            cls._instance._server_client = None
+            cls._instance._code_sandbox_client = None
             cls._instance._document_client = None
 
     def _close_auth(self):
@@ -130,13 +130,15 @@ class ServerContext:
                     logger.warning(
                         "Both code_sandbox_password and code_sandbox_token are set. Password auth takes precedence."
                     )
-                self._server_client = JupyterServerClient(base_url=code_sandbox_url, token=None)
-                self._code_sandbox_password_auth.inject_into_session(
-                    self._server_client.http_client.session
+                self._code_sandbox_client = JupyterServerClient(
+                    base_url=code_sandbox_url, token=None
                 )
-                self._install_code_sandbox_auth_retry(self._server_client)
+                self._code_sandbox_password_auth.inject_into_session(
+                    self._code_sandbox_client.http_client.session
+                )
+                self._install_code_sandbox_auth_retry(self._code_sandbox_client)
             else:
-                self._server_client = JupyterServerClient(
+                self._code_sandbox_client = JupyterServerClient(
                     base_url=code_sandbox_url, token=config.code_sandbox_token
                 )
                 if not config.code_sandbox_token:
@@ -145,7 +147,7 @@ class ServerContext:
                     # auth, JupyterHub single-user servers, --IdentityProvider.token='').
                     self._code_sandbox_password_auth = self._try_anonymous_auth(code_sandbox_url)
                     self._code_sandbox_password_auth.inject_into_session(
-                        self._server_client.http_client.session
+                        self._code_sandbox_client.http_client.session
                     )
 
             # Document auth — only needed when the document server is explicitly
@@ -247,10 +249,10 @@ class ServerContext:
         return self._session_manager
 
     @property
-    def server_client(self):
+    def code_sandbox_client(self):
         if not self._initialized:
             self.initialize()
-        return self._server_client
+        return self._code_sandbox_client
 
     @property
     def document_client(self):
@@ -266,7 +268,7 @@ class ServerContext:
         config = get_config()
         document_url = config.document_url
         if (not document_url) or (document_url == config.code_sandbox_url):
-            return self._server_client
+            return self._code_sandbox_client
         if (
             self._document_password_auth is not None
             and self._document_password_auth is not self._code_sandbox_password_auth
@@ -291,8 +293,8 @@ class ServerContext:
             self.initialize()
         if self._code_sandbox_password_auth is None:
             return {}
-        if self._server_client is not None:
-            session = self._server_client.http_client.session
+        if self._code_sandbox_client is not None:
+            session = self._code_sandbox_client.http_client.session
             cookies = dict(session.cookies)
             if cookies:
                 cookie_header = "; ".join(f"{name}={value}" for name, value in cookies.items())
@@ -322,8 +324,8 @@ class ServerContext:
             return self.code_sandbox_auth_headers
         return self._document_password_auth.get_headers()
 
-    def _install_code_sandbox_auth_retry(self, server_client: JupyterServerClient) -> None:
-        """Make every request through `server_client` retry once on a 401/403.
+    def _install_code_sandbox_auth_retry(self, code_sandbox_client: JupyterServerClient) -> None:
+        """Make every request through `code_sandbox_client` retry once on a 401/403.
 
         The collaboration/document path already survives a cookie expiry via
         `NotebookConnection._get_ws_url`, which catches the error, calls
@@ -334,7 +336,7 @@ class ServerContext:
         """
         from jupyter_server_client.exceptions import AuthenticationError, ForbiddenError
 
-        original_request = server_client.http_client.request
+        original_request = code_sandbox_client.http_client.request
 
         def request_with_relogin(*args, **kwargs):
             try:
@@ -348,7 +350,7 @@ class ServerContext:
                 self.relogin_code_sandbox()
                 return original_request(*args, **kwargs)
 
-        server_client.http_client.request = request_with_relogin
+        code_sandbox_client.http_client.request = request_with_relogin
 
     def relogin_code_sandbox(self, timeout: float = 10.0) -> None:
         """Re-authenticate the code sandbox server session after cookie expiry.
@@ -362,9 +364,9 @@ class ServerContext:
         if self._code_sandbox_password_auth is None:
             return
         self._code_sandbox_password_auth.relogin(timeout=timeout)
-        if self._server_client is not None:
+        if self._code_sandbox_client is not None:
             self._code_sandbox_password_auth.inject_into_session(
-                self._server_client.http_client.session
+                self._code_sandbox_client.http_client.session
             )
         logger.info("Code sandbox session re-authenticated after cookie expiry.")
 

--- a/jupyter_mcp_server/server_context.py
+++ b/jupyter_mcp_server/server_context.py
@@ -22,8 +22,8 @@ class ServerContext:
     _kernel_manager = None
     _kernel_spec_manager = None
     _session_manager = None
-    _code_sandbox_client = None
-    _document_client = None
+    _sandbox_server_client = None
+    _document_server_client = None
     _code_sandbox_password_auth = None
     _document_password_auth = None
     _initialized = False
@@ -49,8 +49,8 @@ class ServerContext:
             cls._instance._kernel_manager = None
             cls._instance._kernel_spec_manager = None
             cls._instance._session_manager = None
-            cls._instance._code_sandbox_client = None
-            cls._instance._document_client = None
+            cls._instance._sandbox_server_client = None
+            cls._instance._document_server_client = None
 
     def _close_auth(self):
         """Close auth sessions if present; safe to call multiple times.
@@ -130,15 +130,15 @@ class ServerContext:
                     logger.warning(
                         "Both code_sandbox_password and code_sandbox_token are set. Password auth takes precedence."
                     )
-                self._code_sandbox_client = JupyterServerClient(
+                self._sandbox_server_client = JupyterServerClient(
                     base_url=code_sandbox_url, token=None
                 )
                 self._code_sandbox_password_auth.inject_into_session(
-                    self._code_sandbox_client.http_client.session
+                    self._sandbox_server_client.http_client.session
                 )
-                self._install_code_sandbox_auth_retry(self._code_sandbox_client)
+                self._install_code_sandbox_auth_retry(self._sandbox_server_client)
             else:
-                self._code_sandbox_client = JupyterServerClient(
+                self._sandbox_server_client = JupyterServerClient(
                     base_url=code_sandbox_url, token=config.code_sandbox_token
                 )
                 if not config.code_sandbox_token:
@@ -147,7 +147,7 @@ class ServerContext:
                     # auth, JupyterHub single-user servers, --IdentityProvider.token='').
                     self._code_sandbox_password_auth = self._try_anonymous_auth(code_sandbox_url)
                     self._code_sandbox_password_auth.inject_into_session(
-                        self._code_sandbox_client.http_client.session
+                        self._sandbox_server_client.http_client.session
                     )
 
             # Document auth — only needed when the document server is explicitly
@@ -249,13 +249,13 @@ class ServerContext:
         return self._session_manager
 
     @property
-    def code_sandbox_client(self):
+    def sandbox_server_client(self):
         if not self._initialized:
             self.initialize()
-        return self._code_sandbox_client
+        return self._sandbox_server_client
 
     @property
-    def document_client(self):
+    def document_server_client(self):
         """Return an HTTP client for document server operations.
 
         Reuse the server client when ``document_url`` is unset or matches the
@@ -263,12 +263,12 @@ class ServerContext:
         """
         if not self._initialized:
             self.initialize()
-        if self._document_client is not None:
-            return self._document_client
+        if self._document_server_client is not None:
+            return self._document_server_client
         config = get_config()
         document_url = config.document_url
         if (not document_url) or (document_url == config.code_sandbox_url):
-            return self._code_sandbox_client
+            return self._sandbox_server_client
         if (
             self._document_password_auth is not None
             and self._document_password_auth is not self._code_sandbox_password_auth
@@ -277,8 +277,8 @@ class ServerContext:
             self._document_password_auth.inject_into_session(client.http_client.session)
         else:
             client = JupyterServerClient(base_url=document_url, token=config.document_token)
-        self._document_client = client
-        return self._document_client
+        self._document_server_client = client
+        return self._document_server_client
 
     @property
     def code_sandbox_auth_headers(self) -> dict[str, str]:
@@ -293,8 +293,8 @@ class ServerContext:
             self.initialize()
         if self._code_sandbox_password_auth is None:
             return {}
-        if self._code_sandbox_client is not None:
-            session = self._code_sandbox_client.http_client.session
+        if self._sandbox_server_client is not None:
+            session = self._sandbox_server_client.http_client.session
             cookies = dict(session.cookies)
             if cookies:
                 cookie_header = "; ".join(f"{name}={value}" for name, value in cookies.items())
@@ -324,8 +324,8 @@ class ServerContext:
             return self.code_sandbox_auth_headers
         return self._document_password_auth.get_headers()
 
-    def _install_code_sandbox_auth_retry(self, code_sandbox_client: JupyterServerClient) -> None:
-        """Make every request through `code_sandbox_client` retry once on a 401/403.
+    def _install_code_sandbox_auth_retry(self, sandbox_server_client: JupyterServerClient) -> None:
+        """Make every request through `sandbox_server_client` retry once on a 401/403.
 
         The collaboration/document path already survives a cookie expiry via
         `NotebookConnection._get_ws_url`, which catches the error, calls
@@ -336,7 +336,7 @@ class ServerContext:
         """
         from jupyter_server_client.exceptions import AuthenticationError, ForbiddenError
 
-        original_request = code_sandbox_client.http_client.request
+        original_request = sandbox_server_client.http_client.request
 
         def request_with_relogin(*args, **kwargs):
             try:
@@ -350,7 +350,7 @@ class ServerContext:
                 self.relogin_code_sandbox()
                 return original_request(*args, **kwargs)
 
-        code_sandbox_client.http_client.request = request_with_relogin
+        sandbox_server_client.http_client.request = request_with_relogin
 
     def relogin_code_sandbox(self, timeout: float = 10.0) -> None:
         """Re-authenticate the code sandbox server session after cookie expiry.
@@ -364,9 +364,9 @@ class ServerContext:
         if self._code_sandbox_password_auth is None:
             return
         self._code_sandbox_password_auth.relogin(timeout=timeout)
-        if self._code_sandbox_client is not None:
+        if self._sandbox_server_client is not None:
             self._code_sandbox_password_auth.inject_into_session(
-                self._code_sandbox_client.http_client.session
+                self._sandbox_server_client.http_client.session
             )
         logger.info("Code sandbox session re-authenticated after cookie expiry.")
 
@@ -385,9 +385,9 @@ class ServerContext:
             self.relogin_code_sandbox(timeout=timeout)
             return
         self._document_password_auth.relogin(timeout=timeout)
-        if self._document_client is not None:
+        if self._document_server_client is not None:
             self._document_password_auth.inject_into_session(
-                self._document_client.http_client.session
+                self._document_server_client.http_client.session
             )
         logger.info("Document session re-authenticated after cookie expiry.")
 

--- a/jupyter_mcp_server/server_modes.py
+++ b/jupyter_mcp_server/server_modes.py
@@ -17,9 +17,10 @@ def get_server_mode_and_clients() -> (
     """Determine server mode and get appropriate clients/managers.
 
     Returns:
-        Tuple of (mode, code_sandbox_client, contents_manager, kernel_manager, kernel_spec_manager)
+        Tuple of (mode, sandbox_server_client, contents_manager, kernel_manager,
+        kernel_spec_manager)
         - mode: "local" if using local API, "http" if using HTTP clients
-        - code_sandbox_client: JupyterServerClient or None
+        - sandbox_server_client: JupyterServerClient or None
         - contents_manager: Local contents manager or None
         - kernel_manager: Local kernel manager or None
         - kernel_spec_manager: Local kernel spec manager or None
@@ -46,11 +47,11 @@ def get_server_mode_and_clients() -> (
         pass
 
     # MCP_SERVER mode with HTTP clients
-    code_sandbox_client = JupyterServerClient(
+    sandbox_server_client = JupyterServerClient(
         base_url=config.code_sandbox_url, token=config.code_sandbox_token
     )
 
-    return ("http", code_sandbox_client, None, None, None)
+    return ("http", sandbox_server_client, None, None, None)
 
 
 def is_local_mode() -> bool:

--- a/jupyter_mcp_server/server_modes.py
+++ b/jupyter_mcp_server/server_modes.py
@@ -17,9 +17,9 @@ def get_server_mode_and_clients() -> (
     """Determine server mode and get appropriate clients/managers.
 
     Returns:
-        Tuple of (mode, server_client, contents_manager, kernel_manager, kernel_spec_manager)
+        Tuple of (mode, code_sandbox_client, contents_manager, kernel_manager, kernel_spec_manager)
         - mode: "local" if using local API, "http" if using HTTP clients
-        - server_client: JupyterServerClient or None
+        - code_sandbox_client: JupyterServerClient or None
         - contents_manager: Local contents manager or None
         - kernel_manager: Local kernel manager or None
         - kernel_spec_manager: Local kernel spec manager or None
@@ -46,9 +46,11 @@ def get_server_mode_and_clients() -> (
         pass
 
     # MCP_SERVER mode with HTTP clients
-    server_client = JupyterServerClient(base_url=config.code_sandbox_url, token=config.code_sandbox_token)
+    code_sandbox_client = JupyterServerClient(
+        base_url=config.code_sandbox_url, token=config.code_sandbox_token
+    )
 
-    return ("http", server_client, None, None, None)
+    return ("http", code_sandbox_client, None, None, None)
 
 
 def is_local_mode() -> bool:

--- a/jupyter_mcp_server/tools/_base.py
+++ b/jupyter_mcp_server/tools/_base.py
@@ -34,7 +34,7 @@ class BaseTool(ABC):
     async def execute(
         self,
         mode: ServerMode,
-        server_client: JupyterServerClient | None = None,
+        code_sandbox_client: JupyterServerClient | None = None,
         contents_manager: Any | None = None,
         kernel_manager: Any | None = None,
         kernel_spec_manager: Any | None = None,
@@ -44,7 +44,7 @@ class BaseTool(ABC):
 
         Args:
             mode: ServerMode indicating MCP_SERVER or JUPYTER_SERVER
-            server_client: JupyterServerClient for HTTP access (MCP_SERVER mode)
+            code_sandbox_client: JupyterServerClient for HTTP access (MCP_SERVER mode)
             contents_manager: Direct access to contents manager (JUPYTER_SERVER mode)
             kernel_manager: Direct access to kernel manager (JUPYTER_SERVER mode)
             kernel_spec_manager: Direct access to kernel spec manager (JUPYTER_SERVER mode)

--- a/jupyter_mcp_server/tools/_base.py
+++ b/jupyter_mcp_server/tools/_base.py
@@ -34,7 +34,7 @@ class BaseTool(ABC):
     async def execute(
         self,
         mode: ServerMode,
-        code_sandbox_client: JupyterServerClient | None = None,
+        sandbox_server_client: JupyterServerClient | None = None,
         contents_manager: Any | None = None,
         kernel_manager: Any | None = None,
         kernel_spec_manager: Any | None = None,
@@ -44,7 +44,7 @@ class BaseTool(ABC):
 
         Args:
             mode: ServerMode indicating MCP_SERVER or JUPYTER_SERVER
-            code_sandbox_client: JupyterServerClient for HTTP access (MCP_SERVER mode)
+            sandbox_server_client: JupyterServerClient for HTTP access (MCP_SERVER mode)
             contents_manager: Direct access to contents manager (JUPYTER_SERVER mode)
             kernel_manager: Direct access to kernel manager (JUPYTER_SERVER mode)
             kernel_spec_manager: Direct access to kernel spec manager (JUPYTER_SERVER mode)

--- a/jupyter_mcp_server/tools/clear_cell_output_tool.py
+++ b/jupyter_mcp_server/tools/clear_cell_output_tool.py
@@ -128,7 +128,7 @@ class ClearCellOutputTool(BaseTool):
     async def execute(
         self,
         mode: ServerMode,
-        server_client: JupyterServerClient | None = None,
+        code_sandbox_client: JupyterServerClient | None = None,
         contents_manager: Any | None = None,
         kernel_manager: Any | None = None,
         kernel_spec_manager: Any | None = None,
@@ -157,7 +157,7 @@ class ClearCellOutputTool(BaseTool):
 
         Args:
             mode: Server mode (MCP_SERVER or JUPYTER_SERVER)
-            server_client: HTTP client for MCP_SERVER mode
+            code_sandbox_client: HTTP client for MCP_SERVER mode
             contents_manager: Direct API access for JUPYTER_SERVER mode
             notebook_manager: Notebook manager instance
             cell_index: Index of the code cell to clear (0-based)

--- a/jupyter_mcp_server/tools/clear_cell_output_tool.py
+++ b/jupyter_mcp_server/tools/clear_cell_output_tool.py
@@ -128,7 +128,7 @@ class ClearCellOutputTool(BaseTool):
     async def execute(
         self,
         mode: ServerMode,
-        code_sandbox_client: JupyterServerClient | None = None,
+        sandbox_server_client: JupyterServerClient | None = None,
         contents_manager: Any | None = None,
         kernel_manager: Any | None = None,
         kernel_spec_manager: Any | None = None,
@@ -157,7 +157,7 @@ class ClearCellOutputTool(BaseTool):
 
         Args:
             mode: Server mode (MCP_SERVER or JUPYTER_SERVER)
-            code_sandbox_client: HTTP client for MCP_SERVER mode
+            sandbox_server_client: HTTP client for MCP_SERVER mode
             contents_manager: Direct API access for JUPYTER_SERVER mode
             notebook_manager: Notebook manager instance
             cell_index: Index of the code cell to clear (0-based)

--- a/jupyter_mcp_server/tools/delete_cell_tool.py
+++ b/jupyter_mcp_server/tools/delete_cell_tool.py
@@ -143,7 +143,7 @@ class DeleteCellTool(BaseTool):
     async def execute(
         self,
         mode: ServerMode,
-        server_client: JupyterServerClient | None = None,
+        code_sandbox_client: JupyterServerClient | None = None,
         contents_manager: Any | None = None,
         kernel_manager: Any | None = None,
         kernel_spec_manager: Any | None = None,
@@ -173,7 +173,7 @@ class DeleteCellTool(BaseTool):
 
         Args:
             mode: Server mode (MCP_SERVER or JUPYTER_SERVER)
-            server_client: HTTP client for MCP_SERVER mode
+            code_sandbox_client: HTTP client for MCP_SERVER mode
             contents_manager: Direct API access for JUPYTER_SERVER mode
             notebook_manager: Notebook manager instance
             cell_index: Index of the cell to delete (0-based)

--- a/jupyter_mcp_server/tools/delete_cell_tool.py
+++ b/jupyter_mcp_server/tools/delete_cell_tool.py
@@ -143,7 +143,7 @@ class DeleteCellTool(BaseTool):
     async def execute(
         self,
         mode: ServerMode,
-        code_sandbox_client: JupyterServerClient | None = None,
+        sandbox_server_client: JupyterServerClient | None = None,
         contents_manager: Any | None = None,
         kernel_manager: Any | None = None,
         kernel_spec_manager: Any | None = None,
@@ -173,7 +173,7 @@ class DeleteCellTool(BaseTool):
 
         Args:
             mode: Server mode (MCP_SERVER or JUPYTER_SERVER)
-            code_sandbox_client: HTTP client for MCP_SERVER mode
+            sandbox_server_client: HTTP client for MCP_SERVER mode
             contents_manager: Direct API access for JUPYTER_SERVER mode
             notebook_manager: Notebook manager instance
             cell_index: Index of the cell to delete (0-based)

--- a/jupyter_mcp_server/tools/edit_cell_source_tool.py
+++ b/jupyter_mcp_server/tools/edit_cell_source_tool.py
@@ -175,7 +175,7 @@ class EditCellSourceTool(BaseTool):
     async def execute(
         self,
         mode: ServerMode,
-        code_sandbox_client: JupyterServerClient | None = None,
+        sandbox_server_client: JupyterServerClient | None = None,
         contents_manager: Any | None = None,
         kernel_manager: Any | None = None,
         kernel_spec_manager: Any | None = None,

--- a/jupyter_mcp_server/tools/edit_cell_source_tool.py
+++ b/jupyter_mcp_server/tools/edit_cell_source_tool.py
@@ -175,7 +175,7 @@ class EditCellSourceTool(BaseTool):
     async def execute(
         self,
         mode: ServerMode,
-        server_client: JupyterServerClient | None = None,
+        code_sandbox_client: JupyterServerClient | None = None,
         contents_manager: Any | None = None,
         kernel_manager: Any | None = None,
         kernel_spec_manager: Any | None = None,

--- a/jupyter_mcp_server/tools/execute_cell_tool.py
+++ b/jupyter_mcp_server/tools/execute_cell_tool.py
@@ -213,7 +213,7 @@ class ExecuteCellTool(BaseTool):
     async def execute(
         self,
         mode: ServerMode,
-        code_sandbox_client=None,
+        sandbox_server_client=None,
         contents_manager=None,
         kernel_manager=None,
         kernel_spec_manager=None,

--- a/jupyter_mcp_server/tools/execute_cell_tool.py
+++ b/jupyter_mcp_server/tools/execute_cell_tool.py
@@ -213,7 +213,7 @@ class ExecuteCellTool(BaseTool):
     async def execute(
         self,
         mode: ServerMode,
-        server_client=None,
+        code_sandbox_client=None,
         contents_manager=None,
         kernel_manager=None,
         kernel_spec_manager=None,

--- a/jupyter_mcp_server/tools/execute_code_tool.py
+++ b/jupyter_mcp_server/tools/execute_code_tool.py
@@ -54,7 +54,7 @@ class ExecuteCodeTool(BaseTool):
         )
 
     def _connect_to_kernel(
-        self, kernel_id: str, code_sandbox_client: JupyterServerClient | None
+        self, kernel_id: str, sandbox_server_client: JupyterServerClient | None
     ) -> tuple[CodeSandboxClient | None, str | None]:
         """Connect to an existing kernel by ID (MCP_SERVER mode).
 
@@ -65,8 +65,8 @@ class ExecuteCodeTool(BaseTool):
         from jupyter_mcp_server.sandbox_client import create_jupyter_sandbox_client
         from jupyter_mcp_server.server_context import ServerContext
 
-        if code_sandbox_client is not None:
-            kernels = code_sandbox_client.kernels.list_kernels()
+        if sandbox_server_client is not None:
+            kernels = sandbox_server_client.kernels.list_kernels()
             if not any(kernel.id == kernel_id for kernel in kernels):
                 return None, (
                     f"[ERROR: Kernel '{kernel_id}' not found in jupyter server, please check "
@@ -80,7 +80,7 @@ class ExecuteCodeTool(BaseTool):
         # password auth would be unauthenticated, since code_sandbox_token is typically
         # None in that mode.
         auth_headers = ServerContext.get_instance().code_sandbox_auth_headers
-        sandbox_client = create_jupyter_sandbox_client(
+        code_sandbox_client = create_jupyter_sandbox_client(
             server_url=config.code_sandbox_url,
             token=None if auth_headers else config.code_sandbox_token,
             kernel_id=kernel_id,
@@ -89,7 +89,7 @@ class ExecuteCodeTool(BaseTool):
             headers=auth_headers or None,
             logger=logger,
         )
-        return cast(CodeSandboxClient, sandbox_client), None
+        return cast(CodeSandboxClient, code_sandbox_client), None
 
     async def _execute_via_notebook_manager(
         self,
@@ -100,7 +100,7 @@ class ExecuteCodeTool(BaseTool):
         wait_for_kernel_idle_fn,
         safe_extract_outputs_fn,
         kernel_id: str = None,
-        code_sandbox_client=None,
+        sandbox_server_client=None,
         progress_callback=None,
         progress_interval: int = 5,
     ) -> list[str | ImageContent]:
@@ -118,21 +118,21 @@ class ExecuteCodeTool(BaseTool):
         # in the finally below, and never shut down.
         borrowed_sandbox: CodeSandboxClient | None = None
         if kernel_id is not None and kernel_id != current_kernel_id:
-            sandbox_client, error = self._connect_to_kernel(kernel_id, code_sandbox_client)
+            code_sandbox_client, error = self._connect_to_kernel(kernel_id, sandbox_server_client)
             if error is not None:
                 return [error]
-            if sandbox_client is None:
+            if code_sandbox_client is None:
                 return ["[ERROR: Failed to connect to kernel]"]
-            borrowed_sandbox = sandbox_client
+            borrowed_sandbox = code_sandbox_client
             kid = kernel_id
         else:
-            sandbox_client = notebook_manager.get_kernel(current_notebook)
+            code_sandbox_client = notebook_manager.get_kernel(current_notebook)
 
-            if not sandbox_client:
+            if not code_sandbox_client:
                 # Ensure kernel is alive
-                sandbox_client = ensure_kernel_alive_fn()
+                code_sandbox_client = ensure_kernel_alive_fn()
 
-            if isinstance(sandbox_client, dict):
+            if isinstance(code_sandbox_client, dict):
                 return [
                     "[ERROR: Kernel metadata found instead of an active CodeSandboxClient in MCP_SERVER mode]"
                 ]
@@ -141,7 +141,7 @@ class ExecuteCodeTool(BaseTool):
 
         try:
             return await self._execute_on_kernel(
-                sandbox_client=sandbox_client,
+                code_sandbox_client=code_sandbox_client,
                 kid=kid,
                 code=code,
                 timeout=timeout,
@@ -164,18 +164,16 @@ class ExecuteCodeTool(BaseTool):
                 else:
                     self._release_borrowed_kernel(borrowed_sandbox, kid)
 
-    def _release_borrowed_kernel(
-        self, sandbox_client: CodeSandboxClient, kid: str
-    ) -> None:
+    def _release_borrowed_kernel(self, code_sandbox_client: CodeSandboxClient, kid: str) -> None:
         """Stop a borrowed kernel connection without shutting the kernel down."""
         try:
-            sandbox_client.stop(shutdown_kernel=False)
+            code_sandbox_client.stop(shutdown_kernel=False)
         except Exception as stop_err:
             logger.warning(f"Failed to release kernel {kid}: {stop_err}")
 
     async def _execute_on_kernel(
         self,
-        sandbox_client: CodeSandboxClient,
+        code_sandbox_client: CodeSandboxClient,
         kid: str,
         code: str,
         timeout: int,
@@ -186,7 +184,7 @@ class ExecuteCodeTool(BaseTool):
     ) -> list[str | ImageContent]:
         """Run code on an already-resolved sandbox client (MCP_SERVER mode)."""
         # Wait for kernel to be idle before executing
-        await wait_for_kernel_idle_fn(sandbox_client, max_wait_seconds=30)
+        await wait_for_kernel_idle_fn(code_sandbox_client, max_wait_seconds=30)
 
         logger.info(f"Executing IPython code (MCP_SERVER) with timeout {timeout}s: {code[:100]}...")
 
@@ -199,8 +197,10 @@ class ExecuteCodeTool(BaseTool):
         )
 
         try:
-            execution_task = asyncio.create_task(asyncio.to_thread(sandbox_client.execute, code))
-            track_pending_execution(sandbox_client, execution_task)
+            execution_task = asyncio.create_task(
+                asyncio.to_thread(code_sandbox_client.execute, code)
+            )
+            track_pending_execution(code_sandbox_client, execution_task)
 
             start_time = asyncio.get_event_loop().time()
             last_progress_emit = 0.0
@@ -212,8 +212,8 @@ class ExecuteCodeTool(BaseTool):
                 elapsed = asyncio.get_event_loop().time() - start_time
                 if elapsed >= timeout:
                     try:
-                        if sandbox_client and hasattr(sandbox_client, "interrupt"):
-                            sandbox_client.interrupt()
+                        if code_sandbox_client and hasattr(code_sandbox_client, "interrupt"):
+                            code_sandbox_client.interrupt()
                             logger.info("Sent interrupt signal to kernel due to timeout")
                     except Exception as interrupt_err:
                         logger.error(f"Failed to interrupt kernel: {interrupt_err}")
@@ -285,7 +285,7 @@ class ExecuteCodeTool(BaseTool):
     async def execute(
         self,
         mode: ServerMode,
-        code_sandbox_client=None,
+        sandbox_server_client=None,
         contents_manager=None,
         kernel_manager=None,
         kernel_spec_manager=None,
@@ -305,7 +305,8 @@ class ExecuteCodeTool(BaseTool):
 
         Args:
             mode: Server mode (MCP_SERVER or JUPYTER_SERVER)
-            code_sandbox_client: JupyterServerClient (used to resolve kernel_id in MCP_SERVER mode)
+            sandbox_server_client: JupyterServerClient (used to resolve kernel_id in
+                MCP_SERVER mode)
             contents_manager: Contents manager (not used)
             kernel_manager: Kernel manager (for JUPYTER_SERVER mode)
             kernel_spec_manager: Kernel spec manager (not used)
@@ -376,7 +377,7 @@ class ExecuteCodeTool(BaseTool):
                 wait_for_kernel_idle_fn=wait_for_kernel_idle_fn,
                 safe_extract_outputs_fn=safe_extract_outputs_fn,
                 kernel_id=kernel_id,
-                code_sandbox_client=code_sandbox_client,
+                sandbox_server_client=sandbox_server_client,
                 progress_callback=progress_callback,
                 progress_interval=progress_interval,
             )

--- a/jupyter_mcp_server/tools/execute_code_tool.py
+++ b/jupyter_mcp_server/tools/execute_code_tool.py
@@ -54,7 +54,7 @@ class ExecuteCodeTool(BaseTool):
         )
 
     def _connect_to_kernel(
-        self, kernel_id: str, server_client: JupyterServerClient | None
+        self, kernel_id: str, code_sandbox_client: JupyterServerClient | None
     ) -> tuple[CodeSandboxClient | None, str | None]:
         """Connect to an existing kernel by ID (MCP_SERVER mode).
 
@@ -65,8 +65,8 @@ class ExecuteCodeTool(BaseTool):
         from jupyter_mcp_server.sandbox_client import create_jupyter_sandbox_client
         from jupyter_mcp_server.server_context import ServerContext
 
-        if server_client is not None:
-            kernels = server_client.kernels.list_kernels()
+        if code_sandbox_client is not None:
+            kernels = code_sandbox_client.kernels.list_kernels()
             if not any(kernel.id == kernel_id for kernel in kernels):
                 return None, (
                     f"[ERROR: Kernel '{kernel_id}' not found in jupyter server, please check "
@@ -100,7 +100,7 @@ class ExecuteCodeTool(BaseTool):
         wait_for_kernel_idle_fn,
         safe_extract_outputs_fn,
         kernel_id: str = None,
-        server_client=None,
+        code_sandbox_client=None,
         progress_callback=None,
         progress_interval: int = 5,
     ) -> list[str | ImageContent]:
@@ -118,7 +118,7 @@ class ExecuteCodeTool(BaseTool):
         # in the finally below, and never shut down.
         borrowed_sandbox: CodeSandboxClient | None = None
         if kernel_id is not None and kernel_id != current_kernel_id:
-            sandbox_client, error = self._connect_to_kernel(kernel_id, server_client)
+            sandbox_client, error = self._connect_to_kernel(kernel_id, code_sandbox_client)
             if error is not None:
                 return [error]
             if sandbox_client is None:
@@ -285,7 +285,7 @@ class ExecuteCodeTool(BaseTool):
     async def execute(
         self,
         mode: ServerMode,
-        server_client=None,
+        code_sandbox_client=None,
         contents_manager=None,
         kernel_manager=None,
         kernel_spec_manager=None,
@@ -305,7 +305,7 @@ class ExecuteCodeTool(BaseTool):
 
         Args:
             mode: Server mode (MCP_SERVER or JUPYTER_SERVER)
-            server_client: JupyterServerClient (used to resolve kernel_id in MCP_SERVER mode)
+            code_sandbox_client: JupyterServerClient (used to resolve kernel_id in MCP_SERVER mode)
             contents_manager: Contents manager (not used)
             kernel_manager: Kernel manager (for JUPYTER_SERVER mode)
             kernel_spec_manager: Kernel spec manager (not used)
@@ -376,7 +376,7 @@ class ExecuteCodeTool(BaseTool):
                 wait_for_kernel_idle_fn=wait_for_kernel_idle_fn,
                 safe_extract_outputs_fn=safe_extract_outputs_fn,
                 kernel_id=kernel_id,
-                server_client=server_client,
+                code_sandbox_client=code_sandbox_client,
                 progress_callback=progress_callback,
                 progress_interval=progress_interval,
             )

--- a/jupyter_mcp_server/tools/insert_cell_tool.py
+++ b/jupyter_mcp_server/tools/insert_cell_tool.py
@@ -180,7 +180,7 @@ class InsertCellTool(BaseTool):
     async def execute(
         self,
         mode: ServerMode,
-        code_sandbox_client: JupyterServerClient | None = None,
+        sandbox_server_client: JupyterServerClient | None = None,
         contents_manager: Any | None = None,
         kernel_manager: Any | None = None,
         kernel_spec_manager: Any | None = None,
@@ -217,7 +217,7 @@ class InsertCellTool(BaseTool):
 
         Args:
             mode: Server mode (MCP_SERVER or JUPYTER_SERVER)
-            code_sandbox_client: HTTP client for MCP_SERVER mode
+            sandbox_server_client: HTTP client for MCP_SERVER mode
             contents_manager: Direct API access for JUPYTER_SERVER mode
             notebook_manager: Notebook manager instance
             cell_index: Target index for insertion (0-based, -1 to append)

--- a/jupyter_mcp_server/tools/insert_cell_tool.py
+++ b/jupyter_mcp_server/tools/insert_cell_tool.py
@@ -180,7 +180,7 @@ class InsertCellTool(BaseTool):
     async def execute(
         self,
         mode: ServerMode,
-        server_client: JupyterServerClient | None = None,
+        code_sandbox_client: JupyterServerClient | None = None,
         contents_manager: Any | None = None,
         kernel_manager: Any | None = None,
         kernel_spec_manager: Any | None = None,
@@ -217,7 +217,7 @@ class InsertCellTool(BaseTool):
 
         Args:
             mode: Server mode (MCP_SERVER or JUPYTER_SERVER)
-            server_client: HTTP client for MCP_SERVER mode
+            code_sandbox_client: HTTP client for MCP_SERVER mode
             contents_manager: Direct API access for JUPYTER_SERVER mode
             notebook_manager: Notebook manager instance
             cell_index: Target index for insertion (0-based, -1 to append)

--- a/jupyter_mcp_server/tools/jupyter_cite_prompt.py
+++ b/jupyter_mcp_server/tools/jupyter_cite_prompt.py
@@ -121,7 +121,7 @@ class JupyterCitePrompt(BaseTool):
     async def execute(
         self,
         mode: ServerMode,
-        code_sandbox_client: JupyterServerClient | None = None,
+        sandbox_server_client: JupyterServerClient | None = None,
         contents_manager: Any | None = None,
         notebook_manager: NotebookManager | None = None,
         cell_indices: str | None = None,
@@ -167,9 +167,9 @@ class JupyterCitePrompt(BaseTool):
             notebook_path = notebook_manager.get_notebook_path(notebook_name)
             loaded_from_contents = False
 
-            if code_sandbox_client is not None and notebook_path:
+            if sandbox_server_client is not None and notebook_path:
                 try:
-                    model = code_sandbox_client.contents.get(
+                    model = sandbox_server_client.contents.get(
                         notebook_path, content=True, type="notebook"
                     )
                     content = model.content if hasattr(model, "content") else model.get("content")

--- a/jupyter_mcp_server/tools/jupyter_cite_prompt.py
+++ b/jupyter_mcp_server/tools/jupyter_cite_prompt.py
@@ -121,7 +121,7 @@ class JupyterCitePrompt(BaseTool):
     async def execute(
         self,
         mode: ServerMode,
-        server_client: JupyterServerClient | None = None,
+        code_sandbox_client: JupyterServerClient | None = None,
         contents_manager: Any | None = None,
         notebook_manager: NotebookManager | None = None,
         cell_indices: str | None = None,
@@ -167,9 +167,11 @@ class JupyterCitePrompt(BaseTool):
             notebook_path = notebook_manager.get_notebook_path(notebook_name)
             loaded_from_contents = False
 
-            if server_client is not None and notebook_path:
+            if code_sandbox_client is not None and notebook_path:
                 try:
-                    model = server_client.contents.get(notebook_path, content=True, type="notebook")
+                    model = code_sandbox_client.contents.get(
+                        notebook_path, content=True, type="notebook"
+                    )
                     content = model.content if hasattr(model, "content") else model.get("content")
                     if isinstance(content, dict):
                         notebook = Notebook(**content)

--- a/jupyter_mcp_server/tools/list_files_tool.py
+++ b/jupyter_mcp_server/tools/list_files_tool.py
@@ -25,7 +25,7 @@ def format_size(size_bytes: int) -> str:
 
 
 def _list_files_mcp(
-    server_client,
+    code_sandbox_client,
     current_path: str = "",
     current_depth: int = 0,
     files: list[dict] | None = None,
@@ -34,7 +34,7 @@ def _list_files_mcp(
     """Recursively list all files and directories in the Jupyter server.
 
     Args:
-        server_client: JupyterServerClient instance
+        code_sandbox_client: JupyterServerClient instance
         current_path: Current directory path
         current_depth: Current recursion depth
         files: Accumulated files list
@@ -47,7 +47,7 @@ def _list_files_mcp(
         files = []
 
     try:
-        contents = server_client.contents.list_directory(current_path)
+        contents = code_sandbox_client.contents.list_directory(current_path)
         for item in contents:
             full_path = f"{current_path}/{item.name}" if current_path else item.name
 
@@ -75,7 +75,7 @@ def _list_files_mcp(
             # max_depth=0 means no recursion (list current directory only)
             # max_depth=1 means recurse 1 level deep, etc.
             if item.type == "directory" and current_depth < max_depth:
-                _list_files_mcp(server_client, full_path, current_depth + 1, files, max_depth)
+                _list_files_mcp(code_sandbox_client, full_path, current_depth + 1, files, max_depth)
 
     except Exception as e:
         # If we can't access a directory, add an error entry
@@ -165,7 +165,7 @@ class ListFilesTool(BaseTool):
     async def execute(
         self,
         mode: ServerMode,
-        server_client: JupyterServerClient | None = None,
+        code_sandbox_client: JupyterServerClient | None = None,
         contents_manager: Any | None = None,
         kernel_manager: Any | None = None,
         kernel_spec_manager: Any | None = None,
@@ -182,7 +182,7 @@ class ListFilesTool(BaseTool):
 
         Args:
             mode: Server mode (MCP_SERVER or JUPYTER_SERVER)
-            server_client: JupyterServerClient for MCP_SERVER mode
+            code_sandbox_client: JupyterServerClient for MCP_SERVER mode
             contents_manager: Direct API access for JUPYTER_SERVER mode
             path: The starting path to list from (empty string means root directory)
             max_depth: Maximum depth to recurse into subdirectories (0 means list current directory only, default: 1)
@@ -199,10 +199,10 @@ class ListFilesTool(BaseTool):
         if mode == ServerMode.JUPYTER_SERVER and contents_manager is not None:
             # Local mode: use contents_manager directly
             all_files = await _list_files_local(contents_manager, path, max_depth)
-        elif mode == ServerMode.MCP_SERVER and server_client is not None:
+        elif mode == ServerMode.MCP_SERVER and code_sandbox_client is not None:
             # Remote mode: reuse the shared, authenticated HTTP client
             # (a client built fresh here carries no session cookies).
-            all_files = _list_files_mcp(server_client, path, 0, None, max_depth)
+            all_files = _list_files_mcp(code_sandbox_client, path, 0, None, max_depth)
         else:
             raise ValueError(f"Invalid mode or missing required clients: mode={mode}")
 

--- a/jupyter_mcp_server/tools/list_files_tool.py
+++ b/jupyter_mcp_server/tools/list_files_tool.py
@@ -25,7 +25,7 @@ def format_size(size_bytes: int) -> str:
 
 
 def _list_files_mcp(
-    code_sandbox_client,
+    sandbox_server_client,
     current_path: str = "",
     current_depth: int = 0,
     files: list[dict] | None = None,
@@ -34,7 +34,7 @@ def _list_files_mcp(
     """Recursively list all files and directories in the Jupyter server.
 
     Args:
-        code_sandbox_client: JupyterServerClient instance
+        sandbox_server_client: JupyterServerClient instance
         current_path: Current directory path
         current_depth: Current recursion depth
         files: Accumulated files list
@@ -47,7 +47,7 @@ def _list_files_mcp(
         files = []
 
     try:
-        contents = code_sandbox_client.contents.list_directory(current_path)
+        contents = sandbox_server_client.contents.list_directory(current_path)
         for item in contents:
             full_path = f"{current_path}/{item.name}" if current_path else item.name
 
@@ -75,7 +75,9 @@ def _list_files_mcp(
             # max_depth=0 means no recursion (list current directory only)
             # max_depth=1 means recurse 1 level deep, etc.
             if item.type == "directory" and current_depth < max_depth:
-                _list_files_mcp(code_sandbox_client, full_path, current_depth + 1, files, max_depth)
+                _list_files_mcp(
+                    sandbox_server_client, full_path, current_depth + 1, files, max_depth
+                )
 
     except Exception as e:
         # If we can't access a directory, add an error entry
@@ -165,7 +167,7 @@ class ListFilesTool(BaseTool):
     async def execute(
         self,
         mode: ServerMode,
-        code_sandbox_client: JupyterServerClient | None = None,
+        sandbox_server_client: JupyterServerClient | None = None,
         contents_manager: Any | None = None,
         kernel_manager: Any | None = None,
         kernel_spec_manager: Any | None = None,
@@ -182,7 +184,7 @@ class ListFilesTool(BaseTool):
 
         Args:
             mode: Server mode (MCP_SERVER or JUPYTER_SERVER)
-            code_sandbox_client: JupyterServerClient for MCP_SERVER mode
+            sandbox_server_client: JupyterServerClient for MCP_SERVER mode
             contents_manager: Direct API access for JUPYTER_SERVER mode
             path: The starting path to list from (empty string means root directory)
             max_depth: Maximum depth to recurse into subdirectories (0 means list current directory only, default: 1)
@@ -199,10 +201,10 @@ class ListFilesTool(BaseTool):
         if mode == ServerMode.JUPYTER_SERVER and contents_manager is not None:
             # Local mode: use contents_manager directly
             all_files = await _list_files_local(contents_manager, path, max_depth)
-        elif mode == ServerMode.MCP_SERVER and code_sandbox_client is not None:
+        elif mode == ServerMode.MCP_SERVER and sandbox_server_client is not None:
             # Remote mode: reuse the shared, authenticated HTTP client
             # (a client built fresh here carries no session cookies).
-            all_files = _list_files_mcp(code_sandbox_client, path, 0, None, max_depth)
+            all_files = _list_files_mcp(sandbox_server_client, path, 0, None, max_depth)
         else:
             raise ValueError(f"Invalid mode or missing required clients: mode={mode}")
 

--- a/jupyter_mcp_server/tools/list_kernels_tool.py
+++ b/jupyter_mcp_server/tools/list_kernels_tool.py
@@ -15,17 +15,19 @@ from jupyter_mcp_server.utils import format_TSV
 class ListKernelsTool(BaseTool):
     """List all available kernels in the Jupyter server."""
 
-    def _list_kernels_http(self, code_sandbox_client: JupyterServerClient) -> list[dict[str, str]]:
+    def _list_kernels_http(
+        self, sandbox_server_client: JupyterServerClient
+    ) -> list[dict[str, str]]:
         """List kernels using HTTP API (MCP_SERVER mode)."""
         try:
             # Get all kernels from the Jupyter server
-            kernels = code_sandbox_client.kernels.list_kernels()
+            kernels = sandbox_server_client.kernels.list_kernels()
 
             if not kernels:
                 return []
 
             # Get kernel specifications for additional details
-            kernels_specs = code_sandbox_client.kernelspecs.list_kernelspecs()
+            kernels_specs = sandbox_server_client.kernelspecs.list_kernelspecs()
 
             # Create enhanced kernel information list
             output = []
@@ -153,7 +155,7 @@ class ListKernelsTool(BaseTool):
     async def execute(
         self,
         mode: ServerMode,
-        code_sandbox_client: JupyterServerClient | None = None,
+        sandbox_server_client: JupyterServerClient | None = None,
         contents_manager: Any | None = None,
         kernel_manager: Any | None = None,
         kernel_spec_manager: Any | None = None,
@@ -163,7 +165,7 @@ class ListKernelsTool(BaseTool):
 
         Args:
             mode: Server mode (MCP_SERVER or JUPYTER_SERVER)
-            code_sandbox_client: HTTP client for MCP_SERVER mode
+            sandbox_server_client: HTTP client for MCP_SERVER mode
             kernel_manager: Direct kernel manager access for JUPYTER_SERVER mode
             kernel_spec_manager: Kernel spec manager for JUPYTER_SERVER mode
             **kwargs: Additional parameters (unused)
@@ -174,8 +176,8 @@ class ListKernelsTool(BaseTool):
         # Get kernel info based on mode
         if mode == ServerMode.JUPYTER_SERVER and kernel_manager is not None:
             kernel_list = await self._list_kernels_local(kernel_manager, kernel_spec_manager)
-        elif mode == ServerMode.MCP_SERVER and code_sandbox_client is not None:
-            kernel_list = self._list_kernels_http(code_sandbox_client)
+        elif mode == ServerMode.MCP_SERVER and sandbox_server_client is not None:
+            kernel_list = self._list_kernels_http(sandbox_server_client)
         else:
             raise ValueError(f"Invalid mode or missing required managers/clients: mode={mode}")
 

--- a/jupyter_mcp_server/tools/list_kernels_tool.py
+++ b/jupyter_mcp_server/tools/list_kernels_tool.py
@@ -15,17 +15,17 @@ from jupyter_mcp_server.utils import format_TSV
 class ListKernelsTool(BaseTool):
     """List all available kernels in the Jupyter server."""
 
-    def _list_kernels_http(self, server_client: JupyterServerClient) -> list[dict[str, str]]:
+    def _list_kernels_http(self, code_sandbox_client: JupyterServerClient) -> list[dict[str, str]]:
         """List kernels using HTTP API (MCP_SERVER mode)."""
         try:
             # Get all kernels from the Jupyter server
-            kernels = server_client.kernels.list_kernels()
+            kernels = code_sandbox_client.kernels.list_kernels()
 
             if not kernels:
                 return []
 
             # Get kernel specifications for additional details
-            kernels_specs = server_client.kernelspecs.list_kernelspecs()
+            kernels_specs = code_sandbox_client.kernelspecs.list_kernelspecs()
 
             # Create enhanced kernel information list
             output = []
@@ -153,7 +153,7 @@ class ListKernelsTool(BaseTool):
     async def execute(
         self,
         mode: ServerMode,
-        server_client: JupyterServerClient | None = None,
+        code_sandbox_client: JupyterServerClient | None = None,
         contents_manager: Any | None = None,
         kernel_manager: Any | None = None,
         kernel_spec_manager: Any | None = None,
@@ -163,7 +163,7 @@ class ListKernelsTool(BaseTool):
 
         Args:
             mode: Server mode (MCP_SERVER or JUPYTER_SERVER)
-            server_client: HTTP client for MCP_SERVER mode
+            code_sandbox_client: HTTP client for MCP_SERVER mode
             kernel_manager: Direct kernel manager access for JUPYTER_SERVER mode
             kernel_spec_manager: Kernel spec manager for JUPYTER_SERVER mode
             **kwargs: Additional parameters (unused)
@@ -174,8 +174,8 @@ class ListKernelsTool(BaseTool):
         # Get kernel info based on mode
         if mode == ServerMode.JUPYTER_SERVER and kernel_manager is not None:
             kernel_list = await self._list_kernels_local(kernel_manager, kernel_spec_manager)
-        elif mode == ServerMode.MCP_SERVER and server_client is not None:
-            kernel_list = self._list_kernels_http(server_client)
+        elif mode == ServerMode.MCP_SERVER and code_sandbox_client is not None:
+            kernel_list = self._list_kernels_http(code_sandbox_client)
         else:
             raise ValueError(f"Invalid mode or missing required managers/clients: mode={mode}")
 

--- a/jupyter_mcp_server/tools/list_notebooks_tool.py
+++ b/jupyter_mcp_server/tools/list_notebooks_tool.py
@@ -17,7 +17,7 @@ class ListNotebooksTool(BaseTool):
     async def execute(
         self,
         mode: ServerMode,
-        server_client: Any | None = None,
+        code_sandbox_client: Any | None = None,
         contents_manager: Any | None = None,
         kernel_manager: Any | None = None,
         kernel_spec_manager: Any | None = None,

--- a/jupyter_mcp_server/tools/list_notebooks_tool.py
+++ b/jupyter_mcp_server/tools/list_notebooks_tool.py
@@ -17,7 +17,7 @@ class ListNotebooksTool(BaseTool):
     async def execute(
         self,
         mode: ServerMode,
-        code_sandbox_client: Any | None = None,
+        sandbox_server_client: Any | None = None,
         contents_manager: Any | None = None,
         kernel_manager: Any | None = None,
         kernel_spec_manager: Any | None = None,

--- a/jupyter_mcp_server/tools/move_cell_tool.py
+++ b/jupyter_mcp_server/tools/move_cell_tool.py
@@ -164,7 +164,7 @@ class MoveCellTool(BaseTool):
     async def execute(
         self,
         mode: ServerMode,
-        code_sandbox_client: JupyterServerClient | None = None,
+        sandbox_server_client: JupyterServerClient | None = None,
         contents_manager: Any | None = None,
         kernel_manager: Any | None = None,
         kernel_spec_manager: Any | None = None,

--- a/jupyter_mcp_server/tools/move_cell_tool.py
+++ b/jupyter_mcp_server/tools/move_cell_tool.py
@@ -164,7 +164,7 @@ class MoveCellTool(BaseTool):
     async def execute(
         self,
         mode: ServerMode,
-        server_client: JupyterServerClient | None = None,
+        code_sandbox_client: JupyterServerClient | None = None,
         contents_manager: Any | None = None,
         kernel_manager: Any | None = None,
         kernel_spec_manager: Any | None = None,

--- a/jupyter_mcp_server/tools/overwrite_cell_source_tool.py
+++ b/jupyter_mcp_server/tools/overwrite_cell_source_tool.py
@@ -157,7 +157,7 @@ class OverwriteCellSourceTool(BaseTool):
     async def execute(
         self,
         mode: ServerMode,
-        code_sandbox_client: JupyterServerClient | None = None,
+        sandbox_server_client: JupyterServerClient | None = None,
         contents_manager: Any | None = None,
         kernel_manager: Any | None = None,
         kernel_spec_manager: Any | None = None,
@@ -193,7 +193,7 @@ class OverwriteCellSourceTool(BaseTool):
 
         Args:
             mode: Server mode (MCP_SERVER or JUPYTER_SERVER)
-            code_sandbox_client: HTTP client for MCP_SERVER mode
+            sandbox_server_client: HTTP client for MCP_SERVER mode
             contents_manager: Direct API access for JUPYTER_SERVER mode
             notebook_manager: Notebook manager instance
             cell_index: Index of the cell to overwrite (0-based)

--- a/jupyter_mcp_server/tools/overwrite_cell_source_tool.py
+++ b/jupyter_mcp_server/tools/overwrite_cell_source_tool.py
@@ -157,7 +157,7 @@ class OverwriteCellSourceTool(BaseTool):
     async def execute(
         self,
         mode: ServerMode,
-        server_client: JupyterServerClient | None = None,
+        code_sandbox_client: JupyterServerClient | None = None,
         contents_manager: Any | None = None,
         kernel_manager: Any | None = None,
         kernel_spec_manager: Any | None = None,
@@ -193,7 +193,7 @@ class OverwriteCellSourceTool(BaseTool):
 
         Args:
             mode: Server mode (MCP_SERVER or JUPYTER_SERVER)
-            server_client: HTTP client for MCP_SERVER mode
+            code_sandbox_client: HTTP client for MCP_SERVER mode
             contents_manager: Direct API access for JUPYTER_SERVER mode
             notebook_manager: Notebook manager instance
             cell_index: Index of the cell to overwrite (0-based)

--- a/jupyter_mcp_server/tools/read_cell_tool.py
+++ b/jupyter_mcp_server/tools/read_cell_tool.py
@@ -27,7 +27,7 @@ class ReadCellTool(BaseTool):
     async def execute(
         self,
         mode: ServerMode,
-        code_sandbox_client: JupyterServerClient | None = None,
+        sandbox_server_client: JupyterServerClient | None = None,
         contents_manager: Any | None = None,
         kernel_manager: Any | None = None,
         kernel_spec_manager: Any | None = None,

--- a/jupyter_mcp_server/tools/read_cell_tool.py
+++ b/jupyter_mcp_server/tools/read_cell_tool.py
@@ -27,7 +27,7 @@ class ReadCellTool(BaseTool):
     async def execute(
         self,
         mode: ServerMode,
-        server_client: JupyterServerClient | None = None,
+        code_sandbox_client: JupyterServerClient | None = None,
         contents_manager: Any | None = None,
         kernel_manager: Any | None = None,
         kernel_spec_manager: Any | None = None,

--- a/jupyter_mcp_server/tools/read_notebook_tool.py
+++ b/jupyter_mcp_server/tools/read_notebook_tool.py
@@ -22,7 +22,7 @@ class ReadNotebookTool(BaseTool):
     async def execute(
         self,
         mode: ServerMode,
-        code_sandbox_client: JupyterServerClient | None = None,
+        sandbox_server_client: JupyterServerClient | None = None,
         contents_manager: Any | None = None,
         notebook_manager: NotebookManager | None = None,
         notebook_name: str = None,

--- a/jupyter_mcp_server/tools/read_notebook_tool.py
+++ b/jupyter_mcp_server/tools/read_notebook_tool.py
@@ -22,7 +22,7 @@ class ReadNotebookTool(BaseTool):
     async def execute(
         self,
         mode: ServerMode,
-        server_client: JupyterServerClient | None = None,
+        code_sandbox_client: JupyterServerClient | None = None,
         contents_manager: Any | None = None,
         notebook_manager: NotebookManager | None = None,
         notebook_name: str = None,

--- a/jupyter_mcp_server/tools/restart_notebook_tool.py
+++ b/jupyter_mcp_server/tools/restart_notebook_tool.py
@@ -55,7 +55,7 @@ class RestartNotebookTool(BaseTool):
     async def execute(
         self,
         mode: ServerMode,
-        server_client: JupyterServerClient | None = None,
+        code_sandbox_client: JupyterServerClient | None = None,
         contents_manager: Any | None = None,
         kernel_manager: Any | None = None,
         kernel_spec_manager: Any | None = None,

--- a/jupyter_mcp_server/tools/restart_notebook_tool.py
+++ b/jupyter_mcp_server/tools/restart_notebook_tool.py
@@ -55,7 +55,7 @@ class RestartNotebookTool(BaseTool):
     async def execute(
         self,
         mode: ServerMode,
-        code_sandbox_client: JupyterServerClient | None = None,
+        sandbox_server_client: JupyterServerClient | None = None,
         contents_manager: Any | None = None,
         kernel_manager: Any | None = None,
         kernel_spec_manager: Any | None = None,

--- a/jupyter_mcp_server/tools/unuse_notebook_tool.py
+++ b/jupyter_mcp_server/tools/unuse_notebook_tool.py
@@ -21,7 +21,7 @@ class UnuseNotebookTool(BaseTool):
     async def execute(
         self,
         mode: ServerMode,
-        code_sandbox_client: JupyterServerClient | None = None,
+        sandbox_server_client: JupyterServerClient | None = None,
         contents_manager: Any | None = None,
         kernel_manager: Any | None = None,
         kernel_spec_manager: Any | None = None,

--- a/jupyter_mcp_server/tools/unuse_notebook_tool.py
+++ b/jupyter_mcp_server/tools/unuse_notebook_tool.py
@@ -21,7 +21,7 @@ class UnuseNotebookTool(BaseTool):
     async def execute(
         self,
         mode: ServerMode,
-        server_client: JupyterServerClient | None = None,
+        code_sandbox_client: JupyterServerClient | None = None,
         contents_manager: Any | None = None,
         kernel_manager: Any | None = None,
         kernel_spec_manager: Any | None = None,

--- a/jupyter_mcp_server/tools/use_notebook_tool.py
+++ b/jupyter_mcp_server/tools/use_notebook_tool.py
@@ -68,7 +68,7 @@ class UseNotebookTool(BaseTool):
         return {"id": kernel_id}
 
     async def _check_path_http(
-        self, server_client: JupyterServerClient, notebook_path: str, mode: str
+        self, code_sandbox_client: JupyterServerClient, notebook_path: str, mode: str
     ) -> tuple[bool, str | None]:
         """Check if path exists using HTTP API."""
         path = Path(notebook_path)
@@ -76,9 +76,9 @@ class UseNotebookTool(BaseTool):
             parent_path = path.parent.as_posix() if path.parent.as_posix() != "." else ""
 
             if parent_path:
-                dir_contents = server_client.contents.list_directory(parent_path)
+                dir_contents = code_sandbox_client.contents.list_directory(parent_path)
             else:
-                dir_contents = server_client.contents.list_directory("")
+                dir_contents = code_sandbox_client.contents.list_directory("")
 
             file_exists = any(file.name == path.name for file in dir_contents)
             if mode == "connect":
@@ -141,7 +141,7 @@ class UseNotebookTool(BaseTool):
     async def execute(
         self,
         mode: ServerMode,
-        server_client: JupyterServerClient | None = None,
+        code_sandbox_client: JupyterServerClient | None = None,
         contents_manager: Any | None = None,
         kernel_manager: Any | None = None,
         kernel_spec_manager: Any | None = None,
@@ -161,7 +161,7 @@ class UseNotebookTool(BaseTool):
 
         Args:
             mode: Server mode (MCP_SERVER or JUPYTER_SERVER)
-            server_client: HTTP client for MCP_SERVER mode
+            code_sandbox_client: HTTP client for MCP_SERVER mode
             contents_manager: Direct API access for JUPYTER_SERVER mode
             kernel_manager: Direct kernel manager for JUPYTER_SERVER mode
             session_manager: Session manager for creating kernel-notebook associations
@@ -178,17 +178,17 @@ class UseNotebookTool(BaseTool):
             Success message with notebook information
         """
         # Check server connectivity (HTTP mode only)
-        if mode == ServerMode.MCP_SERVER and server_client is not None:
+        if mode == ServerMode.MCP_SERVER and code_sandbox_client is not None:
             try:
-                server_client.get_status()
+                code_sandbox_client.get_status()
             except Exception as e:
                 return f"Failed to connect the Jupyter server: {e}"
 
         # In split setups, contents operations use the document server and its auth.
-        # When the URLs match, server_client already targets the document server.
-        document_client = server_client
+        # When the URLs match, code_sandbox_client already targets the document server.
+        document_client = code_sandbox_client
         document_auth_headers = auth_headers
-        if mode == ServerMode.MCP_SERVER and server_client is not None:
+        if mode == ServerMode.MCP_SERVER and code_sandbox_client is not None:
             from jupyter_mcp_server.config import get_config
 
             config = get_config()
@@ -204,7 +204,7 @@ class UseNotebookTool(BaseTool):
             path_ok, error_msg = await self._check_path_local(
                 contents_manager, notebook_path, use_mode
             )
-        elif mode == ServerMode.MCP_SERVER and server_client is not None:
+        elif mode == ServerMode.MCP_SERVER and code_sandbox_client is not None:
             path_ok, error_msg = await self._check_path_http(
                 document_client, notebook_path, use_mode
             )
@@ -265,7 +265,7 @@ class UseNotebookTool(BaseTool):
                             path=notebook_path,
                         )
                     )
-                elif mode == ServerMode.MCP_SERVER and server_client is not None:
+                elif mode == ServerMode.MCP_SERVER and code_sandbox_client is not None:
                     # Creating a notebook is a state-changing PUT to /api/contents,
                     # which Jupyter's XSRF protection guards. Under password auth the
                     # injected session carries the _xsrf cookie but not the matching
@@ -283,9 +283,9 @@ class UseNotebookTool(BaseTool):
                     document_client.contents.create_notebook(notebook_path, content=content)
 
             # # Create/connect to kernel based on mode
-            if mode == ServerMode.MCP_SERVER and server_client is not None:
+            if mode == ServerMode.MCP_SERVER and code_sandbox_client is not None:
                 if kernel_id is not None:
-                    kernels = server_client.kernels.list_kernels()
+                    kernels = code_sandbox_client.kernels.list_kernels()
                     kernel_exists = any(kernel.id == kernel_id for kernel in kernels)
                     if not kernel_exists:
                         return f"Kernel '{kernel_id}' not found in jupyter server, please check whether the kernel already exists using 'list_kernels' tool."

--- a/jupyter_mcp_server/tools/use_notebook_tool.py
+++ b/jupyter_mcp_server/tools/use_notebook_tool.py
@@ -68,7 +68,7 @@ class UseNotebookTool(BaseTool):
         return {"id": kernel_id}
 
     async def _check_path_http(
-        self, code_sandbox_client: JupyterServerClient, notebook_path: str, mode: str
+        self, sandbox_server_client: JupyterServerClient, notebook_path: str, mode: str
     ) -> tuple[bool, str | None]:
         """Check if path exists using HTTP API."""
         path = Path(notebook_path)
@@ -76,9 +76,9 @@ class UseNotebookTool(BaseTool):
             parent_path = path.parent.as_posix() if path.parent.as_posix() != "." else ""
 
             if parent_path:
-                dir_contents = code_sandbox_client.contents.list_directory(parent_path)
+                dir_contents = sandbox_server_client.contents.list_directory(parent_path)
             else:
-                dir_contents = code_sandbox_client.contents.list_directory("")
+                dir_contents = sandbox_server_client.contents.list_directory("")
 
             file_exists = any(file.name == path.name for file in dir_contents)
             if mode == "connect":
@@ -141,7 +141,7 @@ class UseNotebookTool(BaseTool):
     async def execute(
         self,
         mode: ServerMode,
-        code_sandbox_client: JupyterServerClient | None = None,
+        sandbox_server_client: JupyterServerClient | None = None,
         contents_manager: Any | None = None,
         kernel_manager: Any | None = None,
         kernel_spec_manager: Any | None = None,
@@ -161,7 +161,7 @@ class UseNotebookTool(BaseTool):
 
         Args:
             mode: Server mode (MCP_SERVER or JUPYTER_SERVER)
-            code_sandbox_client: HTTP client for MCP_SERVER mode
+            sandbox_server_client: HTTP client for MCP_SERVER mode
             contents_manager: Direct API access for JUPYTER_SERVER mode
             kernel_manager: Direct kernel manager for JUPYTER_SERVER mode
             session_manager: Session manager for creating kernel-notebook associations
@@ -178,17 +178,17 @@ class UseNotebookTool(BaseTool):
             Success message with notebook information
         """
         # Check server connectivity (HTTP mode only)
-        if mode == ServerMode.MCP_SERVER and code_sandbox_client is not None:
+        if mode == ServerMode.MCP_SERVER and sandbox_server_client is not None:
             try:
-                code_sandbox_client.get_status()
+                sandbox_server_client.get_status()
             except Exception as e:
                 return f"Failed to connect the Jupyter server: {e}"
 
         # In split setups, contents operations use the document server and its auth.
-        # When the URLs match, code_sandbox_client already targets the document server.
-        document_client = code_sandbox_client
+        # When the URLs match, sandbox_server_client already targets the document server.
+        document_server_client = sandbox_server_client
         document_auth_headers = auth_headers
-        if mode == ServerMode.MCP_SERVER and code_sandbox_client is not None:
+        if mode == ServerMode.MCP_SERVER and sandbox_server_client is not None:
             from jupyter_mcp_server.config import get_config
 
             config = get_config()
@@ -196,7 +196,7 @@ class UseNotebookTool(BaseTool):
                 from jupyter_mcp_server.server_context import ServerContext
 
                 context = ServerContext.get_instance()
-                document_client = context.document_client
+                document_server_client = context.document_server_client
                 document_auth_headers = context.document_auth_headers
 
         # Check the path exists
@@ -204,9 +204,9 @@ class UseNotebookTool(BaseTool):
             path_ok, error_msg = await self._check_path_local(
                 contents_manager, notebook_path, use_mode
             )
-        elif mode == ServerMode.MCP_SERVER and code_sandbox_client is not None:
+        elif mode == ServerMode.MCP_SERVER and sandbox_server_client is not None:
             path_ok, error_msg = await self._check_path_http(
-                document_client, notebook_path, use_mode
+                document_server_client, notebook_path, use_mode
             )
         else:
             return f"Invalid mode or missing required clients: mode={mode}"
@@ -265,7 +265,7 @@ class UseNotebookTool(BaseTool):
                             path=notebook_path,
                         )
                     )
-                elif mode == ServerMode.MCP_SERVER and code_sandbox_client is not None:
+                elif mode == ServerMode.MCP_SERVER and sandbox_server_client is not None:
                     # Creating a notebook is a state-changing PUT to /api/contents,
                     # which Jupyter's XSRF protection guards. Under password auth the
                     # injected session carries the _xsrf cookie but not the matching
@@ -276,16 +276,16 @@ class UseNotebookTool(BaseTool):
                     # XSRF via its own header, so nothing happens there.
                     xsrf_token = (document_auth_headers or {}).get("X-XSRFToken")
                     session = getattr(
-                        getattr(document_client, "http_client", None), "session", None
+                        getattr(document_server_client, "http_client", None), "session", None
                     )
                     if xsrf_token and session is not None:
                         session.headers["X-XSRFToken"] = xsrf_token
-                    document_client.contents.create_notebook(notebook_path, content=content)
+                    document_server_client.contents.create_notebook(notebook_path, content=content)
 
             # # Create/connect to kernel based on mode
-            if mode == ServerMode.MCP_SERVER and code_sandbox_client is not None:
+            if mode == ServerMode.MCP_SERVER and sandbox_server_client is not None:
                 if kernel_id is not None:
-                    kernels = code_sandbox_client.kernels.list_kernels()
+                    kernels = sandbox_server_client.kernels.list_kernels()
                     kernel_exists = any(kernel.id == kernel_id for kernel in kernels)
                     if not kernel_exists:
                         return f"Kernel '{kernel_id}' not found in jupyter server, please check whether the kernel already exists using 'list_kernels' tool."

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -508,7 +508,7 @@ class TestServerContextAuthHeaders:
         from jupyter_mcp_server.tools import ServerMode
         context._mode = ServerMode.MCP_SERVER
         context._code_sandbox_password_auth = None
-        context._code_sandbox_client = MagicMock()
+        context._sandbox_server_client = MagicMock()
         context._initialized = True
 
         assert context.auth_headers == {}
@@ -532,7 +532,7 @@ class TestServerContextAuthHeaders:
         mock_session.cookies.set("_xsrf", "fresh_token")
         mock_session.cookies.set("username-localhost", "user1")
         mock_client.http_client.session = mock_session
-        context._code_sandbox_client = mock_client
+        context._sandbox_server_client = mock_client
 
         headers = context.auth_headers
         assert "X-XSRFToken" in headers
@@ -556,7 +556,7 @@ class TestServerContextAuthHeaders:
         mock_session = MagicMock()
         mock_session.cookies = RequestsCookieJar()  # empty jar
         mock_client.http_client.session = mock_session
-        context._code_sandbox_client = mock_client
+        context._sandbox_server_client = mock_client
 
         headers = context.auth_headers
         assert headers == {"Cookie": "login=cookie", "X-XSRFToken": "login_xsrf"}
@@ -603,7 +603,7 @@ class TestServerContextAuthHeaders:
         jar.set("_xsrf", "fresh")
         jar.set("session", "fresh-session")
         mock_client.http_client.session.cookies = jar
-        context._code_sandbox_client = mock_client
+        context._sandbox_server_client = mock_client
 
         # document_auth_headers should return the FRESH code sandbox cookies,
         # not the stale login-time snapshot
@@ -629,7 +629,7 @@ class TestServerContextAuthHeaders:
 
         mock_client = MagicMock()
         mock_client.http_client.session.cookies = RequestsCookieJar()
-        context._code_sandbox_client = mock_client
+        context._sandbox_server_client = mock_client
 
         # document_auth_headers should come from document_auth, not code sandbox
         headers = context.document_auth_headers
@@ -871,12 +871,12 @@ class TestNotebookConnectionAuth:
         context._code_sandbox_password_auth = mock_auth
         # Share code sandbox auth with document since URLs match in this test
         context._document_password_auth = mock_auth
-        context._code_sandbox_client = MagicMock()
+        context._sandbox_server_client = MagicMock()
         mock_session = MagicMock()
         mock_session.cookies = RequestsCookieJar()
         mock_session.cookies.set("_xsrf", "tok")
         mock_session.cookies.set("session", "abc")
-        context._code_sandbox_client.http_client.session = mock_session
+        context._sandbox_server_client.http_client.session = mock_session
 
         return NotebookConnection(
             notebook_info={

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -508,7 +508,7 @@ class TestServerContextAuthHeaders:
         from jupyter_mcp_server.tools import ServerMode
         context._mode = ServerMode.MCP_SERVER
         context._code_sandbox_password_auth = None
-        context._server_client = MagicMock()
+        context._code_sandbox_client = MagicMock()
         context._initialized = True
 
         assert context.auth_headers == {}
@@ -532,7 +532,7 @@ class TestServerContextAuthHeaders:
         mock_session.cookies.set("_xsrf", "fresh_token")
         mock_session.cookies.set("username-localhost", "user1")
         mock_client.http_client.session = mock_session
-        context._server_client = mock_client
+        context._code_sandbox_client = mock_client
 
         headers = context.auth_headers
         assert "X-XSRFToken" in headers
@@ -556,7 +556,7 @@ class TestServerContextAuthHeaders:
         mock_session = MagicMock()
         mock_session.cookies = RequestsCookieJar()  # empty jar
         mock_client.http_client.session = mock_session
-        context._server_client = mock_client
+        context._code_sandbox_client = mock_client
 
         headers = context.auth_headers
         assert headers == {"Cookie": "login=cookie", "X-XSRFToken": "login_xsrf"}
@@ -603,7 +603,7 @@ class TestServerContextAuthHeaders:
         jar.set("_xsrf", "fresh")
         jar.set("session", "fresh-session")
         mock_client.http_client.session.cookies = jar
-        context._server_client = mock_client
+        context._code_sandbox_client = mock_client
 
         # document_auth_headers should return the FRESH code sandbox cookies,
         # not the stale login-time snapshot
@@ -629,7 +629,7 @@ class TestServerContextAuthHeaders:
 
         mock_client = MagicMock()
         mock_client.http_client.session.cookies = RequestsCookieJar()
-        context._server_client = mock_client
+        context._code_sandbox_client = mock_client
 
         # document_auth_headers should come from document_auth, not code sandbox
         headers = context.document_auth_headers
@@ -871,12 +871,12 @@ class TestNotebookConnectionAuth:
         context._code_sandbox_password_auth = mock_auth
         # Share code sandbox auth with document since URLs match in this test
         context._document_password_auth = mock_auth
-        context._server_client = MagicMock()
+        context._code_sandbox_client = MagicMock()
         mock_session = MagicMock()
         mock_session.cookies = RequestsCookieJar()
         mock_session.cookies.set("_xsrf", "tok")
         mock_session.cookies.set("session", "abc")
-        context._server_client.http_client.session = mock_session
+        context._code_sandbox_client.http_client.session = mock_session
 
         return NotebookConnection(
             notebook_info={

--- a/tests/test_execute_cell_stream.py
+++ b/tests/test_execute_cell_stream.py
@@ -73,7 +73,7 @@ async def _run_stream(cell, execute_impl, timeout_seconds, kernel):
     manager = FakeNotebookManager(FakeNotebook(cell, execute_impl))
     return await ExecuteCellTool().execute(
         mode=ServerMode.MCP_SERVER,
-        code_sandbox_client=None,
+        sandbox_server_client=None,
         contents_manager=None,
         kernel_manager=None,
         kernel_spec_manager=None,

--- a/tests/test_execute_cell_stream.py
+++ b/tests/test_execute_cell_stream.py
@@ -73,7 +73,7 @@ async def _run_stream(cell, execute_impl, timeout_seconds, kernel):
     manager = FakeNotebookManager(FakeNotebook(cell, execute_impl))
     return await ExecuteCellTool().execute(
         mode=ServerMode.MCP_SERVER,
-        server_client=None,
+        code_sandbox_client=None,
         contents_manager=None,
         kernel_manager=None,
         kernel_spec_manager=None,

--- a/tests/test_execute_code_borrowed_kernel_stop_race.py
+++ b/tests/test_execute_code_borrowed_kernel_stop_race.py
@@ -67,7 +67,7 @@ class BorrowedKernelExecuteCodeTool(ExecuteCodeTool):
     def __init__(self, fake_kernel):
         self._fake_kernel = fake_kernel
 
-    def _connect_to_kernel(self, kernel_id, code_sandbox_client):
+    def _connect_to_kernel(self, kernel_id, sandbox_server_client):
         return self._fake_kernel, None
 
 

--- a/tests/test_execute_code_borrowed_kernel_stop_race.py
+++ b/tests/test_execute_code_borrowed_kernel_stop_race.py
@@ -67,7 +67,7 @@ class BorrowedKernelExecuteCodeTool(ExecuteCodeTool):
     def __init__(self, fake_kernel):
         self._fake_kernel = fake_kernel
 
-    def _connect_to_kernel(self, kernel_id, server_client):
+    def _connect_to_kernel(self, kernel_id, code_sandbox_client):
         return self._fake_kernel, None
 
 

--- a/tests/test_execute_code_kernel_id.py
+++ b/tests/test_execute_code_kernel_id.py
@@ -23,7 +23,7 @@ from jupyter_mcp_server.utils import safe_extract_outputs, wait_for_kernel_idle
 from .conftest import JUPYTER_TOKEN
 
 
-def _seed(server_client, kernel, marker, timeout=60):
+def _seed(code_sandbox_client, kernel, marker, timeout=60):
     """Wait for a kernel to be ready, then give it its identity.
 
     A kernel is created asynchronously, so ``start()`` returns while the server may
@@ -33,7 +33,7 @@ def _seed(server_client, kernel, marker, timeout=60):
     here rather than as a puzzling timeout inside the assertion under test.
     """
     deadline = time.monotonic() + timeout
-    while server_client.kernels.get_kernel(kernel.id).execution_state != "idle":
+    while code_sandbox_client.kernels.get_kernel(kernel.id).execution_state != "idle":
         if time.monotonic() > deadline:
             raise AssertionError(f"kernel {kernel.id} was not ready within {timeout}s")
         time.sleep(0.1)
@@ -45,10 +45,10 @@ def _seed(server_client, kernel, marker, timeout=60):
 @pytest.fixture
 def targeting_setup(jupyter_server):
     """Two live kernels, each holding a distinct MARKER, with the first bound to
-    the current notebook. Yields (notebook_manager, server_client, raw_kernel_id).
+    the current notebook. Yields (notebook_manager, code_sandbox_client, raw_kernel_id).
     """
     set_config(code_sandbox_url=jupyter_server, code_sandbox_token=JUPYTER_TOKEN)
-    server_client = JupyterServerClient(base_url=jupyter_server, token=JUPYTER_TOKEN)
+    code_sandbox_client = JupyterServerClient(base_url=jupyter_server, token=JUPYTER_TOKEN)
 
     current_kernel = create_jupyter_sandbox_client(
         server_url=jupyter_server,
@@ -63,8 +63,8 @@ def targeting_setup(jupyter_server):
 
     try:
         # Give each kernel its own identity so the assertion cannot pass by luck.
-        _seed(server_client, current_kernel, "current-notebook-kernel")
-        _seed(server_client, raw_kernel, "raw-kernel")
+        _seed(code_sandbox_client, current_kernel, "current-notebook-kernel")
+        _seed(code_sandbox_client, raw_kernel, "raw-kernel")
 
         notebook_manager = NotebookManager()
         notebook_manager.add_notebook(
@@ -76,20 +76,20 @@ def targeting_setup(jupyter_server):
         )
         notebook_manager.set_current_notebook("nb")
 
-        yield notebook_manager, server_client, raw_kernel.id
+        yield notebook_manager, code_sandbox_client, raw_kernel.id
     finally:
         current_kernel.stop()
         raw_kernel.stop()
         reset_config()
 
 
-async def _execute(notebook_manager, server_client, code, kernel_id=None):
+async def _execute(notebook_manager, code_sandbox_client, code, kernel_id=None):
     def _no_kernel_expected():
         raise AssertionError("the current notebook already has a kernel")
 
     return await ExecuteCodeTool().execute(
         mode=ServerMode.MCP_SERVER,
-        server_client=server_client,
+        code_sandbox_client=code_sandbox_client,
         notebook_manager=notebook_manager,
         code=code,
         timeout=30,
@@ -103,10 +103,10 @@ async def _execute(notebook_manager, server_client, code, kernel_id=None):
 @pytest.mark.asyncio
 async def test_execute_code_runs_in_the_requested_kernel(targeting_setup):
     """kernel_id must select the kernel the code runs in, not be discarded."""
-    notebook_manager, server_client, raw_kernel_id = targeting_setup
+    notebook_manager, code_sandbox_client, raw_kernel_id = targeting_setup
 
     outputs = await _execute(
-        notebook_manager, server_client, "print(MARKER)", kernel_id=raw_kernel_id
+        notebook_manager, code_sandbox_client, "print(MARKER)", kernel_id=raw_kernel_id
     )
 
     assert "raw-kernel" in "".join(str(output) for output in outputs)
@@ -116,14 +116,14 @@ async def test_execute_code_runs_in_the_requested_kernel(targeting_setup):
 async def test_execute_code_leaves_the_targeted_kernel_running(targeting_setup):
     """The targeted kernel is borrowed, so it must survive the call and keep its
     state: releasing the connection must not shut a kernel down."""
-    notebook_manager, server_client, raw_kernel_id = targeting_setup
+    notebook_manager, code_sandbox_client, raw_kernel_id = targeting_setup
 
-    await _execute(notebook_manager, server_client, "print(MARKER)", kernel_id=raw_kernel_id)
+    await _execute(notebook_manager, code_sandbox_client, "print(MARKER)", kernel_id=raw_kernel_id)
 
-    assert any(kernel.id == raw_kernel_id for kernel in server_client.kernels.list_kernels())
+    assert any(kernel.id == raw_kernel_id for kernel in code_sandbox_client.kernels.list_kernels())
 
     outputs = await _execute(
-        notebook_manager, server_client, "print(MARKER)", kernel_id=raw_kernel_id
+        notebook_manager, code_sandbox_client, "print(MARKER)", kernel_id=raw_kernel_id
     )
     assert "raw-kernel" in "".join(str(output) for output in outputs)
 
@@ -131,9 +131,9 @@ async def test_execute_code_leaves_the_targeted_kernel_running(targeting_setup):
 @pytest.mark.asyncio
 async def test_execute_code_without_kernel_id_uses_the_current_notebook(targeting_setup):
     """Omitting kernel_id keeps the documented default: the current notebook's kernel."""
-    notebook_manager, server_client, _ = targeting_setup
+    notebook_manager, code_sandbox_client, _ = targeting_setup
 
-    outputs = await _execute(notebook_manager, server_client, "print(MARKER)")
+    outputs = await _execute(notebook_manager, code_sandbox_client, "print(MARKER)")
 
     assert "current-notebook-kernel" in "".join(str(output) for output in outputs)
 
@@ -142,10 +142,10 @@ async def test_execute_code_without_kernel_id_uses_the_current_notebook(targetin
 async def test_execute_code_reports_an_unknown_kernel_id(targeting_setup):
     """An unknown kernel_id must be reported, never silently redirected to
     whichever kernel happens to be current."""
-    notebook_manager, server_client, _ = targeting_setup
+    notebook_manager, code_sandbox_client, _ = targeting_setup
 
     outputs = await _execute(
-        notebook_manager, server_client, "print(MARKER)", kernel_id="no-such-kernel"
+        notebook_manager, code_sandbox_client, "print(MARKER)", kernel_id="no-such-kernel"
     )
 
     joined = "".join(str(output) for output in outputs)

--- a/tests/test_execute_code_kernel_id.py
+++ b/tests/test_execute_code_kernel_id.py
@@ -23,7 +23,7 @@ from jupyter_mcp_server.utils import safe_extract_outputs, wait_for_kernel_idle
 from .conftest import JUPYTER_TOKEN
 
 
-def _seed(code_sandbox_client, kernel, marker, timeout=60):
+def _seed(sandbox_server_client, kernel, marker, timeout=60):
     """Wait for a kernel to be ready, then give it its identity.
 
     A kernel is created asynchronously, so ``start()`` returns while the server may
@@ -33,7 +33,7 @@ def _seed(code_sandbox_client, kernel, marker, timeout=60):
     here rather than as a puzzling timeout inside the assertion under test.
     """
     deadline = time.monotonic() + timeout
-    while code_sandbox_client.kernels.get_kernel(kernel.id).execution_state != "idle":
+    while sandbox_server_client.kernels.get_kernel(kernel.id).execution_state != "idle":
         if time.monotonic() > deadline:
             raise AssertionError(f"kernel {kernel.id} was not ready within {timeout}s")
         time.sleep(0.1)
@@ -45,10 +45,10 @@ def _seed(code_sandbox_client, kernel, marker, timeout=60):
 @pytest.fixture
 def targeting_setup(jupyter_server):
     """Two live kernels, each holding a distinct MARKER, with the first bound to
-    the current notebook. Yields (notebook_manager, code_sandbox_client, raw_kernel_id).
+    the current notebook. Yields (notebook_manager, sandbox_server_client, raw_kernel_id).
     """
     set_config(code_sandbox_url=jupyter_server, code_sandbox_token=JUPYTER_TOKEN)
-    code_sandbox_client = JupyterServerClient(base_url=jupyter_server, token=JUPYTER_TOKEN)
+    sandbox_server_client = JupyterServerClient(base_url=jupyter_server, token=JUPYTER_TOKEN)
 
     current_kernel = create_jupyter_sandbox_client(
         server_url=jupyter_server,
@@ -63,8 +63,8 @@ def targeting_setup(jupyter_server):
 
     try:
         # Give each kernel its own identity so the assertion cannot pass by luck.
-        _seed(code_sandbox_client, current_kernel, "current-notebook-kernel")
-        _seed(code_sandbox_client, raw_kernel, "raw-kernel")
+        _seed(sandbox_server_client, current_kernel, "current-notebook-kernel")
+        _seed(sandbox_server_client, raw_kernel, "raw-kernel")
 
         notebook_manager = NotebookManager()
         notebook_manager.add_notebook(
@@ -76,20 +76,20 @@ def targeting_setup(jupyter_server):
         )
         notebook_manager.set_current_notebook("nb")
 
-        yield notebook_manager, code_sandbox_client, raw_kernel.id
+        yield notebook_manager, sandbox_server_client, raw_kernel.id
     finally:
         current_kernel.stop()
         raw_kernel.stop()
         reset_config()
 
 
-async def _execute(notebook_manager, code_sandbox_client, code, kernel_id=None):
+async def _execute(notebook_manager, sandbox_server_client, code, kernel_id=None):
     def _no_kernel_expected():
         raise AssertionError("the current notebook already has a kernel")
 
     return await ExecuteCodeTool().execute(
         mode=ServerMode.MCP_SERVER,
-        code_sandbox_client=code_sandbox_client,
+        sandbox_server_client=sandbox_server_client,
         notebook_manager=notebook_manager,
         code=code,
         timeout=30,
@@ -103,10 +103,10 @@ async def _execute(notebook_manager, code_sandbox_client, code, kernel_id=None):
 @pytest.mark.asyncio
 async def test_execute_code_runs_in_the_requested_kernel(targeting_setup):
     """kernel_id must select the kernel the code runs in, not be discarded."""
-    notebook_manager, code_sandbox_client, raw_kernel_id = targeting_setup
+    notebook_manager, sandbox_server_client, raw_kernel_id = targeting_setup
 
     outputs = await _execute(
-        notebook_manager, code_sandbox_client, "print(MARKER)", kernel_id=raw_kernel_id
+        notebook_manager, sandbox_server_client, "print(MARKER)", kernel_id=raw_kernel_id
     )
 
     assert "raw-kernel" in "".join(str(output) for output in outputs)
@@ -116,14 +116,18 @@ async def test_execute_code_runs_in_the_requested_kernel(targeting_setup):
 async def test_execute_code_leaves_the_targeted_kernel_running(targeting_setup):
     """The targeted kernel is borrowed, so it must survive the call and keep its
     state: releasing the connection must not shut a kernel down."""
-    notebook_manager, code_sandbox_client, raw_kernel_id = targeting_setup
+    notebook_manager, sandbox_server_client, raw_kernel_id = targeting_setup
 
-    await _execute(notebook_manager, code_sandbox_client, "print(MARKER)", kernel_id=raw_kernel_id)
+    await _execute(
+        notebook_manager, sandbox_server_client, "print(MARKER)", kernel_id=raw_kernel_id
+    )
 
-    assert any(kernel.id == raw_kernel_id for kernel in code_sandbox_client.kernels.list_kernels())
+    assert any(
+        kernel.id == raw_kernel_id for kernel in sandbox_server_client.kernels.list_kernels()
+    )
 
     outputs = await _execute(
-        notebook_manager, code_sandbox_client, "print(MARKER)", kernel_id=raw_kernel_id
+        notebook_manager, sandbox_server_client, "print(MARKER)", kernel_id=raw_kernel_id
     )
     assert "raw-kernel" in "".join(str(output) for output in outputs)
 
@@ -131,9 +135,9 @@ async def test_execute_code_leaves_the_targeted_kernel_running(targeting_setup):
 @pytest.mark.asyncio
 async def test_execute_code_without_kernel_id_uses_the_current_notebook(targeting_setup):
     """Omitting kernel_id keeps the documented default: the current notebook's kernel."""
-    notebook_manager, code_sandbox_client, _ = targeting_setup
+    notebook_manager, sandbox_server_client, _ = targeting_setup
 
-    outputs = await _execute(notebook_manager, code_sandbox_client, "print(MARKER)")
+    outputs = await _execute(notebook_manager, sandbox_server_client, "print(MARKER)")
 
     assert "current-notebook-kernel" in "".join(str(output) for output in outputs)
 
@@ -142,10 +146,10 @@ async def test_execute_code_without_kernel_id_uses_the_current_notebook(targetin
 async def test_execute_code_reports_an_unknown_kernel_id(targeting_setup):
     """An unknown kernel_id must be reported, never silently redirected to
     whichever kernel happens to be current."""
-    notebook_manager, code_sandbox_client, _ = targeting_setup
+    notebook_manager, sandbox_server_client, _ = targeting_setup
 
     outputs = await _execute(
-        notebook_manager, code_sandbox_client, "print(MARKER)", kernel_id="no-such-kernel"
+        notebook_manager, sandbox_server_client, "print(MARKER)", kernel_id="no-such-kernel"
     )
 
     joined = "".join(str(output) for output in outputs)

--- a/tests/test_execute_code_orphaned_timeout.py
+++ b/tests/test_execute_code_orphaned_timeout.py
@@ -57,7 +57,7 @@ async def test_execute_code_timeout_leaves_kernel_marked_busy_until_thread_finis
     kernel = FakeKernel(lambda: time.sleep(_ORPHANED_TASK_SLEEP))
 
     result = await ExecuteCodeTool()._execute_on_kernel(
-        sandbox_client=kernel,
+        code_sandbox_client=kernel,
         kid="kernel-1",
         code="time.sleep(60)",
         timeout=0,
@@ -83,7 +83,7 @@ async def test_wait_for_kernel_idle_blocks_until_orphaned_execute_code_finishes(
     kernel = FakeKernel(lambda: time.sleep(_ORPHANED_TASK_SLEEP))
 
     await ExecuteCodeTool()._execute_on_kernel(
-        sandbox_client=kernel,
+        code_sandbox_client=kernel,
         kid="kernel-1",
         code="time.sleep(60)",
         timeout=0,

--- a/tests/test_execute_orphaned_timeout.py
+++ b/tests/test_execute_orphaned_timeout.py
@@ -78,7 +78,7 @@ async def _run_stream(cell, execute_impl, timeout_seconds, kernel):
     manager = FakeNotebookManager(FakeNotebook(cell, execute_impl))
     return await ExecuteCellTool().execute(
         mode=ServerMode.MCP_SERVER,
-        server_client=None,
+        code_sandbox_client=None,
         contents_manager=None,
         kernel_manager=None,
         kernel_spec_manager=None,

--- a/tests/test_execute_orphaned_timeout.py
+++ b/tests/test_execute_orphaned_timeout.py
@@ -78,7 +78,7 @@ async def _run_stream(cell, execute_impl, timeout_seconds, kernel):
     manager = FakeNotebookManager(FakeNotebook(cell, execute_impl))
     return await ExecuteCellTool().execute(
         mode=ServerMode.MCP_SERVER,
-        code_sandbox_client=None,
+        sandbox_server_client=None,
         contents_manager=None,
         kernel_manager=None,
         kernel_spec_manager=None,

--- a/tests/test_use_notebook_reconnect_interval.py
+++ b/tests/test_use_notebook_reconnect_interval.py
@@ -66,7 +66,7 @@ async def test_use_notebook_mcp_server_forwards_reconnect_interval(configured_re
     ) as mock_create:
         await UseNotebookTool().execute(
             mode=ServerMode.MCP_SERVER,
-            code_sandbox_client=FakeServerClient(),
+            sandbox_server_client=FakeServerClient(),
             notebook_manager=NotebookManager(),
             notebook_name="nb",
             notebook_path="nb.ipynb",
@@ -92,7 +92,7 @@ async def test_use_notebook_mcp_server_defaults_reconnect_interval_to_zero(confi
     ) as mock_create:
         await UseNotebookTool().execute(
             mode=ServerMode.MCP_SERVER,
-            code_sandbox_client=FakeServerClient(),
+            sandbox_server_client=FakeServerClient(),
             notebook_manager=NotebookManager(),
             notebook_name="nb2",
             notebook_path="nb2.ipynb",

--- a/tests/test_use_notebook_reconnect_interval.py
+++ b/tests/test_use_notebook_reconnect_interval.py
@@ -66,7 +66,7 @@ async def test_use_notebook_mcp_server_forwards_reconnect_interval(configured_re
     ) as mock_create:
         await UseNotebookTool().execute(
             mode=ServerMode.MCP_SERVER,
-            server_client=FakeServerClient(),
+            code_sandbox_client=FakeServerClient(),
             notebook_manager=NotebookManager(),
             notebook_name="nb",
             notebook_path="nb.ipynb",
@@ -92,7 +92,7 @@ async def test_use_notebook_mcp_server_defaults_reconnect_interval_to_zero(confi
     ) as mock_create:
         await UseNotebookTool().execute(
             mode=ServerMode.MCP_SERVER,
-            server_client=FakeServerClient(),
+            code_sandbox_client=FakeServerClient(),
             notebook_manager=NotebookManager(),
             notebook_name="nb2",
             notebook_path="nb2.ipynb",

--- a/tests/test_use_notebook_split_servers.py
+++ b/tests/test_use_notebook_split_servers.py
@@ -99,7 +99,7 @@ def _reset_config():
 async def _execute(sandbox_client, notebook_manager, use_mode="connect", auth_headers=None):
     return await UseNotebookTool().execute(
         mode=ServerMode.MCP_SERVER,
-        server_client=sandbox_client,
+        code_sandbox_client=sandbox_client,
         notebook_manager=notebook_manager,
         notebook_name="nb",
         notebook_path="work/nb.ipynb",
@@ -287,7 +287,7 @@ async def test_create_writes_to_document_server_not_sandbox(
 
     await UseNotebookTool().execute(
         mode=ServerMode.MCP_SERVER,
-        server_client=context.server_client,
+        code_sandbox_client=context.code_sandbox_client,
         notebook_manager=NotebookManager(),
         notebook_name="split",
         notebook_path="split_create.ipynb",
@@ -298,7 +298,7 @@ async def test_create_writes_to_document_server_not_sandbox(
     )
 
     document_names = [f.name for f in document_client.contents.list_directory("")]
-    sandbox_names = [f.name for f in context.server_client.contents.list_directory("")]
+    sandbox_names = [f.name for f in context.code_sandbox_client.contents.list_directory("")]
     assert "split_create.ipynb" in document_names
     assert "split_create.ipynb" not in sandbox_names
 
@@ -324,7 +324,7 @@ async def test_connect_to_notebook_only_on_the_document_server(
 
     result = await UseNotebookTool().execute(
         mode=ServerMode.MCP_SERVER,
-        server_client=context.server_client,
+        code_sandbox_client=context.code_sandbox_client,
         notebook_manager=notebook_manager,
         notebook_name="connect",
         notebook_path="split_connect.ipynb",

--- a/tests/test_use_notebook_split_servers.py
+++ b/tests/test_use_notebook_split_servers.py
@@ -96,10 +96,10 @@ def _reset_config():
     reset_config()
 
 
-async def _execute(sandbox_client, notebook_manager, use_mode="connect", auth_headers=None):
+async def _execute(sandbox_server_client, notebook_manager, use_mode="connect", auth_headers=None):
     return await UseNotebookTool().execute(
         mode=ServerMode.MCP_SERVER,
-        code_sandbox_client=sandbox_client,
+        sandbox_server_client=sandbox_server_client,
         notebook_manager=notebook_manager,
         notebook_name="nb",
         notebook_path="work/nb.ipynb",
@@ -118,8 +118,8 @@ async def test_split_create_does_not_inject_sandbox_xsrf(monkeypatch):
         code_sandbox_url=SANDBOX_URL,
         code_sandbox_token=SANDBOX_TOKEN,
     )
-    document_client = FakeServerClient()
-    stub = SimpleNamespace(document_client=document_client, document_auth_headers={})
+    document_server_client = FakeServerClient()
+    stub = SimpleNamespace(document_server_client=document_server_client, document_auth_headers={})
     monkeypatch.setattr(ServerContext, "get_instance", lambda: stub)
     nm = NotebookManager()
 
@@ -133,8 +133,8 @@ async def test_split_create_does_not_inject_sandbox_xsrf(monkeypatch):
             auth_headers={"Cookie": "_xsrf=sandbox", "X-XSRFToken": "sandbox-xsrf"},
         )
 
-    assert "work/nb.ipynb" in document_client.contents.created
-    assert "X-XSRFToken" not in document_client.http_client.session.headers
+    assert "work/nb.ipynb" in document_server_client.contents.created
+    assert "X-XSRFToken" not in document_server_client.http_client.session.headers
 
     # The sandbox token must not leak to the (anonymous) document server.
     notebook_info = nm.get_notebook_connection("nb").notebook_info
@@ -153,8 +153,8 @@ async def test_split_opens_ui_on_document_server(monkeypatch):
         open_notebook_in_ui=True,
     )
     get_server_context().update(context_type="MCP_SERVER", jupyterlab=True)
-    document_client = FakeServerClient(["nb.ipynb"])
-    stub = SimpleNamespace(document_client=document_client, document_auth_headers={})
+    document_server_client = FakeServerClient(["nb.ipynb"])
+    stub = SimpleNamespace(document_server_client=document_server_client, document_auth_headers={})
     monkeypatch.setattr(ServerContext, "get_instance", lambda: stub)
     nm = NotebookManager()
 
@@ -283,11 +283,11 @@ async def test_create_writes_to_document_server_not_sandbox(
         code_sandbox_token=JUPYTER_TOKEN,
     )
     context = ServerContext.get_instance()
-    document_client = context.document_client
+    document_server_client = context.document_server_client
 
     await UseNotebookTool().execute(
         mode=ServerMode.MCP_SERVER,
-        code_sandbox_client=context.code_sandbox_client,
+        sandbox_server_client=context.sandbox_server_client,
         notebook_manager=NotebookManager(),
         notebook_name="split",
         notebook_path="split_create.ipynb",
@@ -297,8 +297,8 @@ async def test_create_writes_to_document_server_not_sandbox(
         auth_headers=None,
     )
 
-    document_names = [f.name for f in document_client.contents.list_directory("")]
-    sandbox_names = [f.name for f in context.code_sandbox_client.contents.list_directory("")]
+    document_names = [f.name for f in document_server_client.contents.list_directory("")]
+    sandbox_names = [f.name for f in context.sandbox_server_client.contents.list_directory("")]
     assert "split_create.ipynb" in document_names
     assert "split_create.ipynb" not in sandbox_names
 
@@ -324,7 +324,7 @@ async def test_connect_to_notebook_only_on_the_document_server(
 
     result = await UseNotebookTool().execute(
         mode=ServerMode.MCP_SERVER,
-        code_sandbox_client=context.code_sandbox_client,
+        sandbox_server_client=context.sandbox_server_client,
         notebook_manager=notebook_manager,
         notebook_name="connect",
         notebook_path="split_connect.ipynb",

--- a/tests/test_use_notebook_ui_open.py
+++ b/tests/test_use_notebook_ui_open.py
@@ -97,7 +97,7 @@ async def _switch_to_nb2(notebook_manager):
     get_server_context().update(context_type="MCP_SERVER", jupyterlab=True)
     return await UseNotebookTool().execute(
         mode=ServerMode.MCP_SERVER,
-        server_client=FakeServerClient(["nb1.ipynb", "nb2.ipynb"]),
+        code_sandbox_client=FakeServerClient(["nb1.ipynb", "nb2.ipynb"]),
         notebook_manager=notebook_manager,
         notebook_name="nb2",
         notebook_path="work/nb2.ipynb",
@@ -140,7 +140,7 @@ async def test_ui_open_stays_off_when_jupyterlab_mode_disabled():
     get_server_context().update(context_type="MCP_SERVER", jupyterlab=False)
     await UseNotebookTool().execute(
         mode=ServerMode.MCP_SERVER,
-        server_client=FakeServerClient(["nb1.ipynb", "nb2.ipynb"]),
+        code_sandbox_client=FakeServerClient(["nb1.ipynb", "nb2.ipynb"]),
         notebook_manager=nm,
         notebook_name="nb2",
         notebook_path="work/nb2.ipynb",

--- a/tests/test_use_notebook_ui_open.py
+++ b/tests/test_use_notebook_ui_open.py
@@ -97,7 +97,7 @@ async def _switch_to_nb2(notebook_manager):
     get_server_context().update(context_type="MCP_SERVER", jupyterlab=True)
     return await UseNotebookTool().execute(
         mode=ServerMode.MCP_SERVER,
-        code_sandbox_client=FakeServerClient(["nb1.ipynb", "nb2.ipynb"]),
+        sandbox_server_client=FakeServerClient(["nb1.ipynb", "nb2.ipynb"]),
         notebook_manager=notebook_manager,
         notebook_name="nb2",
         notebook_path="work/nb2.ipynb",
@@ -140,7 +140,7 @@ async def test_ui_open_stays_off_when_jupyterlab_mode_disabled():
     get_server_context().update(context_type="MCP_SERVER", jupyterlab=False)
     await UseNotebookTool().execute(
         mode=ServerMode.MCP_SERVER,
-        code_sandbox_client=FakeServerClient(["nb1.ipynb", "nb2.ipynb"]),
+        sandbox_server_client=FakeServerClient(["nb1.ipynb", "nb2.ipynb"]),
         notebook_manager=nm,
         notebook_name="nb2",
         notebook_path="work/nb2.ipynb",


### PR DESCRIPTION
Follows up on https://github.com/datalayer/jupyter-mcp-server/pull/351#discussion_r3733629148.

`server_client` is only ever built from `code_sandbox_url` and is never set in `JUPYTER_SERVER` mode, so it has always been the code sandbox's HTTP client. The generic name only became misleading once `document_client` was added.

Only rename & fold: the new name is longer, so three lines needed wrapping. No other changes.

---

After this rename, the name is close to #354's `CodeSandboxClient`:

[pokutuna/jupyter-mcp-server@212da92 - jupyter_mcp_server/tools/execute_code_tool.py#L121](https://github.com/pokutuna/jupyter-mcp-server/blob/212da9262ba1d044e2e0f25f71a1daa05c5e7523/jupyter_mcp_server/tools/execute_code_tool.py#L121)
```python
sandbox_client, error = self._connect_to_kernel(kernel_id, code_sandbox_client)
```

`code_sandbox_client` is a `JupyterServerClient` (HTTP),
`sandbox_client` is a `CodeSandboxClient` (kernel).

Slightly confusing, though probably not worth churning over. OK to leave as is?