### PR TITLE
fix(execute_code): stop the kernel client's channels when execution raises

### DIFF
--- a/jupyter_mcp_server/utils.py
+++ b/jupyter_mcp_server/utils.py
@@ -1118,6 +1118,8 @@ async def execute_code_local(
 
         logger = logging.getLogger(__name__)
 
+    client: Any = None
+
     try:
         # Get kernel manager
         kernel_manager = serverapp.kernel_manager
@@ -1308,6 +1310,12 @@ async def execute_code_local(
     except Exception as e:
         logger.error(f"Error executing code locally: {e}")
         return [f"[ERROR: {e!s}]"]
+
+    finally:
+        # lkm.client() hands back a fresh client per call, so channels left
+        # running here are never reclaimed.
+        if client is not None and client.channels_running:
+            client.stop_channels()
 
 
 async def execute_cell_local(

--- a/tests/test_execute_code_local_channel_cleanup.py
+++ b/tests/test_execute_code_local_channel_cleanup.py
@@ -1,0 +1,107 @@
+# Copyright (c) 2024- Datalayer, Inc.
+#
+# BSD 3-Clause License
+
+"""Regression test for execute_code_local leaking the kernel client's channels.
+
+stop_channels() is reached on the timeout and success paths only, so an
+exception raised after the channels are open falls through to the generic
+handler with the sockets still bound. A BEFORE_EXECUTE hook with
+propagate_errors=True is the shortest supported way to raise there.
+"""
+
+import pytest
+
+from jupyter_mcp_server.hooks import HookEvent, HookRegistry
+from jupyter_mcp_server.utils import execute_code_local
+
+
+class FailingBeforeExecuteHandler:
+    """Raises out of BEFORE_EXECUTE, which fires just after start_channels()."""
+
+    propagate_errors = True
+
+    async def on_event(self, event: HookEvent, **kwargs) -> None:
+        if event == HookEvent.BEFORE_EXECUTE:
+            raise RuntimeError("handler failed")
+
+
+class FakeKernelClient:
+    def __init__(self):
+        self.channels_running = False
+        self.start_calls = 0
+        self.stop_calls = 0
+
+    def start_channels(self):
+        self.start_calls += 1
+        self.channels_running = True
+
+    def stop_channels(self):
+        self.stop_calls += 1
+        self.channels_running = False
+
+
+class FakeKernel:
+    def __init__(self, client):
+        self.session = object()
+        self._client = client
+
+    def client(self):
+        return self._client
+
+
+class FakeKernelManager:
+    """Stands in for the pinned_superclass.get_kernel(manager, kernel_id) lookup."""
+
+    def __init__(self, kernel):
+        self._kernel = kernel
+
+    @property
+    def pinned_superclass(self):
+        return self
+
+    def get_kernel(self, kernel_manager, kernel_id):
+        return self._kernel
+
+
+class FakeServerApp:
+    def __init__(self, kernel_manager):
+        self.kernel_manager = kernel_manager
+
+
+@pytest.fixture(autouse=True)
+def reset_registry():
+    HookRegistry.reset()
+    yield
+    HookRegistry.reset()
+
+
+@pytest.mark.asyncio
+async def test_channels_stopped_when_execution_raises():
+    client = FakeKernelClient()
+    serverapp = FakeServerApp(FakeKernelManager(FakeKernel(client)))
+    HookRegistry.get_instance().register(FailingBeforeExecuteHandler())
+
+    result = await execute_code_local(serverapp, "notebook.ipynb", "1 + 1", "kernel-1")
+
+    assert result == ["[ERROR: handler failed]"]
+    assert client.start_calls == 1
+    assert client.stop_calls == 1
+    assert client.channels_running is False
+
+
+@pytest.mark.asyncio
+async def test_no_cleanup_attempted_when_the_kernel_lookup_fails():
+    class ExplodingKernelManager:
+        @property
+        def pinned_superclass(self):
+            return self
+
+        def get_kernel(self, kernel_manager, kernel_id):
+            raise KeyError(kernel_id)
+
+    result = await execute_code_local(
+        FakeServerApp(ExplodingKernelManager()), "notebook.ipynb", "1 + 1", "missing"
+    )
+
+    assert result == ["[ERROR: 'missing']"]


### PR DESCRIPTION
`execute_code_local` creates its own kernel client and opens its channels:

```python
client = lkm.client()

if not client.channels_running:
    client.start_channels()
```

`stop_channels()` is reached on the timeout return and on the normal return at the end of the `try` body, and nowhere else. An exception raised between those two points lands in the generic `except Exception`, which returns `[ERROR: ...]` with the sockets still bound. Since `lkm.client()` hands back a fresh client on every call, nothing else holds a reference to it and the descriptors are never reclaimed.

The reachable trigger is a `BEFORE_EXECUTE` hook handler with `propagate_errors=True`: `HookRegistry.fire` re-raises for those, and the hook fires immediately after the channels start. A kernel that dies mid-execution reaches the same handler.

A `finally` now stops the channels on every exit. `client` is initialised to `None` before the `try` because that handler also covers failures from before the client exists, an unknown `kernel_id` being the obvious one, and the `channels_running` guard leaves the timeout and success paths at exactly one `stop_channels()` call.

### Verification

- `tests/test_execute_code_local_channel_cleanup.py::test_channels_stopped_when_execution_raises` fails on `main` (`stop_calls == 0`) and passes here.
- Against a real kernel in `python:3.11-slim`, the failing-hook path goes from 13 leaked descriptors with `channels_running == True` to 0 and `False`. An ordinary run returns `['2']` with one `stop_channels()` call and the same descriptor count on both sides. Script and numbers are in #357.
- `pytest tests/` gives the same results on `main` and on this branch: 270 vs 272 passed, the two extra being the new tests, with the same pre-existing `test_span_log_summary` failure and the same 117 live-server errors on both. `ruff check .` output is identical between the two.
- Not checked: the fault path end to end through the `execute_code` tool. The reproduction calls `execute_code_local` directly.

Fixes #357
