### PR TITLE
fix(hooks): fire AFTER_EXECUTE on the JUPYTER_SERVER-mode error exits

### DIFF
--- a/jupyter_mcp_server/utils.py
+++ b/jupyter_mcp_server/utils.py
@@ -932,6 +932,12 @@ async def execute_via_execution_stack(
     if logger is None:
         logger = default_logging.getLogger(__name__)
 
+    # hook_ctx is set once BEFORE_EXECUTE has fired; every exit past that point
+    # owes exactly one AFTER_EXECUTE carrying this context back to the handlers.
+    # The cancellation handler re-raises into the outer one, hence the flag.
+    hook_ctx = None
+    after_execute_fired = False
+
     try:
         # Get the ExecutionStack from the jupyter_server_nbmodel extension
         nbmodel_extensions = serverapp.extension_manager.extension_apps.get(
@@ -1029,7 +1035,17 @@ async def execute_via_execution_stack(
                     # Check for pending input (shouldn't happen with allow_stdin=False)
                     if "input_request" in result:
                         logger.warning("Unexpected input request during execution")
-                        return ["[ERROR: Unexpected input request]"]
+                        input_request_output = ["[ERROR: Unexpected input request]"]
+                        await HookRegistry.get_instance().fire(
+                            HookEvent.AFTER_EXECUTE,
+                            code=code,
+                            kernel_id=kernel_id,
+                            metadata=metadata,
+                            outputs=input_request_output,
+                            error=RuntimeError("Unexpected input request during execution"),
+                            context=hook_ctx,
+                        )
+                        return input_request_output
 
                     # Extract outputs
                     outputs = result.get("outputs", [])
@@ -1040,9 +1056,19 @@ async def execute_via_execution_stack(
 
                         try:
                             outputs = json.loads(outputs)
-                        except json.JSONDecodeError:
+                        except json.JSONDecodeError as decode_err:
                             logger.error(f"Failed to parse outputs JSON: {outputs}")
-                            return ["[ERROR: Invalid output format]"]
+                            decode_error_output = ["[ERROR: Invalid output format]"]
+                            await HookRegistry.get_instance().fire(
+                                HookEvent.AFTER_EXECUTE,
+                                code=code,
+                                kernel_id=kernel_id,
+                                metadata=metadata,
+                                outputs=decode_error_output,
+                                error=decode_err,
+                                context=hook_ctx,
+                            )
+                            return decode_error_output
 
                     if outputs:
                         formatted = safe_extract_outputs(outputs)
@@ -1080,7 +1106,7 @@ async def execute_via_execution_stack(
                 # Still pending, wait before next poll
                 await asyncio.sleep(poll_interval)
 
-        except (asyncio.CancelledError, TimeoutError):
+        except (asyncio.CancelledError, TimeoutError) as interrupt_err:
             # Clean up the orphaned execution request to prevent subsequent
             # execute_cell calls from hanging on stale state.
             logger.warning(
@@ -1091,10 +1117,32 @@ async def execute_via_execution_stack(
                 execution_stack.cancel(kernel_id)
             except Exception as cancel_err:
                 logger.error(f"Failed to cancel execution on kernel {kernel_id}: {cancel_err}")
+            # CancelledError does not reach the handler below (it is not an
+            # Exception), so this execution's AFTER_EXECUTE has to be fired here.
+            await HookRegistry.get_instance().fire(
+                HookEvent.AFTER_EXECUTE,
+                code=code,
+                kernel_id=kernel_id,
+                metadata=metadata,
+                outputs=[],
+                error=interrupt_err,
+                context=hook_ctx,
+            )
+            after_execute_fired = True
             raise
 
     except Exception as e:
         logger.error(f"Error executing via ExecutionStack: {e}", exc_info=True)
+        if hook_ctx is not None and not after_execute_fired:
+            await HookRegistry.get_instance().fire(
+                HookEvent.AFTER_EXECUTE,
+                code=code,
+                kernel_id=kernel_id,
+                metadata=metadata,
+                outputs=[],
+                error=e,
+                context=hook_ctx,
+            )
         return [f"[ERROR: {e!s}]"]
 
 
@@ -1131,6 +1179,10 @@ async def execute_code_local(
         logger = logging.getLogger(__name__)
 
     client: Any = None
+
+    # Set once BEFORE_EXECUTE has fired; every exit past that point owes
+    # exactly one AFTER_EXECUTE carrying this context back to the handlers.
+    hook_ctx = None
 
     try:
         # Get kernel manager
@@ -1210,7 +1262,17 @@ async def execute_code_local(
                 logger.warning(
                     f"Code execution timeout after {timeout}s, collected {len(outputs)} outputs"
                 )
-                return [f"[TIMEOUT ERROR: Code execution exceeded {timeout} seconds]"]
+                timeout_output = [f"[TIMEOUT ERROR: Code execution exceeded {timeout} seconds]"]
+                await HookRegistry.get_instance().fire(
+                    HookEvent.AFTER_EXECUTE,
+                    code=code,
+                    kernel_id=kernel_id,
+                    metadata={},
+                    outputs=timeout_output,
+                    error=asyncio.TimeoutError(),
+                    context=hook_ctx,
+                )
+                return timeout_output
 
             # Use shorter poll timeout during grace period
             poll_timeout = (
@@ -1321,6 +1383,16 @@ async def execute_code_local(
 
     except Exception as e:
         logger.error(f"Error executing code locally: {e}")
+        if hook_ctx is not None:
+            await HookRegistry.get_instance().fire(
+                HookEvent.AFTER_EXECUTE,
+                code=code,
+                kernel_id=kernel_id,
+                metadata={},
+                outputs=[],
+                error=e,
+                context=hook_ctx,
+            )
         return [f"[ERROR: {e!s}]"]
 
     finally:

--- a/mcpb/manifest.json
+++ b/mcpb/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": "0.4",
   "name": "jupyter-mcp-server",
   "display_name": "Jupyter MCP Server",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "Connect AI agents to Jupyter Notebooks - execute code, manage notebooks, and interact with kernels in real-time",
   "long_description": "The Jupyter MCP Server enables AI agents like Claude to connect to and manage Jupyter Notebooks in real-time. It provides 14 tools to execute code, manage notebooks, read and write cells, and interact with Jupyter kernels through the standardized Model Context Protocol.\n\n**Requirements:** You need a running Jupyter server (JupyterLab or Jupyter Notebook) to connect to. Start one with:\n```\npip install jupyterlab\njupyter lab --port 8888 --IdentityProvider.token MY_TOKEN\n```",
   "author": {

--- a/mcpb/pyproject.toml
+++ b/mcpb/pyproject.toml
@@ -4,7 +4,7 @@
 
 [project]
 name = "jupyter-mcp-server-mcpb"
-version = "1.3.0"
+version = "1.3.1"
 description = "Jupyter MCP Server - MCPB bundle for one-click installation in Claude Desktop"
 requires-python = ">=3.10"
 dependencies = [

--- a/tests/test_execute_hook_pairing.py
+++ b/tests/test_execute_hook_pairing.py
@@ -1,0 +1,362 @@
+# Copyright (c) 2024- Datalayer, Inc.
+#
+# BSD 3-Clause License
+
+"""BEFORE_EXECUTE / AFTER_EXECUTE pairing on the JUPYTER_SERVER-mode exits.
+
+A handler stashes per-execution state in the context BEFORE_EXECUTE returns and
+releases it on AFTER_EXECUTE (OTelHookHandler ends its span there, and
+SimpleSpanProcessor exports on end), so every exit past the BEFORE fire owes
+exactly one AFTER, error paths included.
+"""
+
+import asyncio
+import json
+
+import pytest
+import zmq
+import zmq.asyncio
+
+from jupyter_mcp_server.hooks import HookEvent, HookRegistry
+from jupyter_mcp_server.otel_hook import create_otel_handler
+from jupyter_mcp_server.utils import execute_code_local, execute_via_execution_stack
+
+
+class RecordingHandler:
+    """Records every event, stashing state in the context like OTelHookHandler."""
+
+    propagate_errors = False
+
+    def __init__(self):
+        self.events: list[tuple[HookEvent, dict]] = []
+
+    async def on_event(self, event: HookEvent, **kwargs) -> None:
+        if event == HookEvent.BEFORE_EXECUTE:
+            kwargs["context"]["_recorded_execution"] = kwargs.get("code")
+        self.events.append((event, kwargs))
+
+    def of_type(self, event: HookEvent) -> list[dict]:
+        return [kwargs for recorded, kwargs in self.events if recorded == event]
+
+
+@pytest.fixture(autouse=True)
+def reset_registry():
+    HookRegistry.reset()
+    yield
+    HookRegistry.reset()
+
+
+@pytest.fixture
+def handler():
+    recorder = RecordingHandler()
+    HookRegistry.get_instance().register(recorder)
+    return recorder
+
+
+def assert_paired(handler: RecordingHandler) -> dict:
+    """Assert exactly one BEFORE_EXECUTE, one AFTER_EXECUTE, one shared context."""
+    before = handler.of_type(HookEvent.BEFORE_EXECUTE)
+    after = handler.of_type(HookEvent.AFTER_EXECUTE)
+    assert len(before) == 1, f"expected 1 BEFORE_EXECUTE, got {len(before)}"
+    assert len(after) == 1, f"expected 1 AFTER_EXECUTE, got {len(after)}"
+    assert after[0]["context"] is before[0]["context"], (
+        "AFTER_EXECUTE must carry the context BEFORE_EXECUTE returned, so a "
+        "handler can release the state it stashed there"
+    )
+    assert "_recorded_execution" in after[0]["context"]
+    return after[0]
+
+
+# --------------------------------------------------------------------------
+# execute_via_execution_stack (jupyter-server-nbmodel installed)
+# --------------------------------------------------------------------------
+
+
+class _ExecutionStack:
+    """Stand-in for jupyter_server_nbmodel's ExecutionStack. *results* is what
+    get() returns per poll; *get_error* is raised from get() instead."""
+
+    def __init__(self, results=(), get_error=None):
+        self._results = iter(results)
+        self._get_error = get_error
+        self.cancelled: list[str] = []
+
+    def put(self, kernel_id, code, metadata):
+        return "request-id"
+
+    def get(self, kernel_id, request_id):
+        if self._get_error is not None:
+            raise self._get_error
+        return next(self._results, None)
+
+    def cancel(self, kernel_id):
+        self.cancelled.append(kernel_id)
+
+
+class _Extension:
+    def __init__(self, execution_stack):
+        self._Extension__execution_stack = execution_stack
+
+
+class _ExtensionManager:
+    def __init__(self, extension):
+        apps = {extension} if extension is not None else set()
+        self.extension_apps = {"jupyter_server_nbmodel": apps}
+
+
+class _ServerApp:
+    def __init__(self, execution_stack=None, kernel_manager=None):
+        extension = _Extension(execution_stack) if execution_stack is not None else None
+        self.extension_manager = _ExtensionManager(extension)
+        self.kernel_manager = kernel_manager
+
+
+@pytest.mark.asyncio
+async def test_success_fires_a_paired_after_execute(handler):
+    """Control: the path that already worked, measured with the same harness."""
+    stack = _ExecutionStack(
+        results=[
+            {
+                "pending": False,
+                "request_status": "complete",
+                "status": "ok",
+                "execution_count": 1,
+                "outputs": json.dumps(
+                    [{"output_type": "stream", "name": "stdout", "text": "hi\n"}]
+                ),
+            }
+        ]
+    )
+
+    await execute_via_execution_stack(
+        serverapp=_ServerApp(stack), kernel_id="kernel-1", code="print('hi')", poll_interval=0
+    )
+
+    assert assert_paired(handler)["error"] is None
+
+
+@pytest.mark.asyncio
+async def test_unexpected_input_request_fires_after_execute(handler):
+    stack = _ExecutionStack(results=[{"pending": False, "input_request": {"prompt": "?"}}])
+
+    outputs = await execute_via_execution_stack(
+        serverapp=_ServerApp(stack), kernel_id="kernel-1", code="input()", poll_interval=0
+    )
+
+    assert outputs == ["[ERROR: Unexpected input request]"]
+    assert assert_paired(handler)["error"] is not None
+
+
+@pytest.mark.asyncio
+async def test_unparseable_outputs_fire_after_execute(handler):
+    stack = _ExecutionStack(
+        results=[{"pending": False, "request_status": "complete", "outputs": "{not json"}]
+    )
+
+    outputs = await execute_via_execution_stack(
+        serverapp=_ServerApp(stack), kernel_id="kernel-1", code="print(1)", poll_interval=0
+    )
+
+    assert outputs == ["[ERROR: Invalid output format]"]
+    after = assert_paired(handler)
+    assert isinstance(after["error"], json.JSONDecodeError)
+
+
+@pytest.mark.asyncio
+async def test_timeout_fires_after_execute(handler):
+    """The path observability most needs: a cell that never finishes."""
+    stack = _ExecutionStack(results=[])  # always pending
+
+    outputs = await execute_via_execution_stack(
+        serverapp=_ServerApp(stack),
+        kernel_id="kernel-1",
+        code="while True: pass",
+        timeout=0,
+        poll_interval=0,
+    )
+
+    assert any("timed out" in str(output) for output in outputs)
+    after = assert_paired(handler)
+    assert isinstance(after["error"], TimeoutError)
+    assert stack.cancelled == ["kernel-1"]
+
+
+@pytest.mark.asyncio
+async def test_user_cancellation_fires_after_execute(handler):
+    """An MCP user-cancel unwinds through the same cleanup block."""
+    stack = _ExecutionStack(results=[])
+
+    task = asyncio.create_task(
+        execute_via_execution_stack(
+            serverapp=_ServerApp(stack),
+            kernel_id="kernel-1",
+            code="while True: pass",
+            timeout=300,
+            poll_interval=0.01,
+        )
+    )
+    await asyncio.sleep(0.05)
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+    after = assert_paired(handler)
+    assert isinstance(after["error"], asyncio.CancelledError)
+    assert stack.cancelled == ["kernel-1"]
+
+
+@pytest.mark.asyncio
+async def test_unexpected_error_after_submission_fires_after_execute(handler):
+    stack = _ExecutionStack(get_error=ValueError("stack blew up"))
+
+    outputs = await execute_via_execution_stack(
+        serverapp=_ServerApp(stack), kernel_id="kernel-1", code="print(1)", poll_interval=0
+    )
+
+    assert outputs == ["[ERROR: stack blew up]"]
+    after = assert_paired(handler)
+    assert isinstance(after["error"], ValueError)
+
+
+@pytest.mark.asyncio
+async def test_failure_before_the_hook_fires_nothing(handler):
+    """No extension, so BEFORE_EXECUTE never fires and no AFTER is owed."""
+    outputs = await execute_via_execution_stack(
+        serverapp=_ServerApp(execution_stack=None), kernel_id="kernel-1", code="print(1)"
+    )
+
+    assert outputs == ["[ERROR: jupyter_server_nbmodel extension not found. Please install it.]"]
+    assert handler.events == []
+
+
+# --------------------------------------------------------------------------
+# execute_code_local (no jupyter-server-nbmodel; raw kernel client)
+# --------------------------------------------------------------------------
+
+
+class _Channel:
+    """Channel over a real, never written to, zmq socket, so the poller
+    registration and polling under test run for real."""
+
+    def __init__(self, socket, send_error=None):
+        self.socket = socket
+        self._send_error = send_error
+
+    def send(self, msg):
+        if self._send_error is not None:
+            raise self._send_error
+
+    def get_msg(self, timeout=0):
+        return None
+
+
+class _Session:
+    def msg(self, msg_type, content):
+        return {"header": {"msg_id": "msg-1"}, "content": content}
+
+
+class _KernelClient:
+    def __init__(self, context, send_error=None):
+        self.channels_running = True
+        self.shell_channel = _Channel(context.socket(zmq.PULL), send_error=send_error)
+        self.iopub_channel = _Channel(context.socket(zmq.PULL))
+
+    def start_channels(self):
+        self.channels_running = True
+
+    def stop_channels(self):
+        self.channels_running = False
+
+    def close(self):
+        self.shell_channel.socket.close()
+        self.iopub_channel.socket.close()
+
+
+class _Kernel:
+    def __init__(self, client):
+        self.session = _Session()
+        self._client = client
+
+    def client(self):
+        return self._client
+
+
+class _PinnedSuperclass:
+    def __init__(self, kernel):
+        self._kernel = kernel
+
+    def get_kernel(self, kernel_manager, kernel_id):
+        return self._kernel
+
+
+class _KernelManager:
+    def __init__(self, kernel):
+        self.pinned_superclass = _PinnedSuperclass(kernel)
+
+
+@pytest.mark.asyncio
+async def test_local_timeout_fires_after_execute(handler):
+    context = zmq.asyncio.Context()
+    client = _KernelClient(context)
+    try:
+        outputs = await execute_code_local(
+            serverapp=_ServerApp(kernel_manager=_KernelManager(_Kernel(client))),
+            notebook_path="notebook.ipynb",
+            code="while True: pass",
+            kernel_id="kernel-1",
+            timeout=1,
+        )
+
+        assert outputs == ["[TIMEOUT ERROR: Code execution exceeded 1 seconds]"]
+        after = assert_paired(handler)
+        assert isinstance(after["error"], asyncio.TimeoutError)
+    finally:
+        client.close()
+        context.term()
+
+
+@pytest.mark.asyncio
+async def test_local_unexpected_error_fires_after_execute(handler):
+    context = zmq.asyncio.Context()
+    client = _KernelClient(context, send_error=RuntimeError("shell channel is dead"))
+    try:
+        outputs = await execute_code_local(
+            serverapp=_ServerApp(kernel_manager=_KernelManager(_Kernel(client))),
+            notebook_path="notebook.ipynb",
+            code="print(1)",
+            kernel_id="kernel-1",
+            timeout=5,
+        )
+
+        assert outputs == ["[ERROR: shell channel is dead]"]
+        after = assert_paired(handler)
+        assert isinstance(after["error"], RuntimeError)
+    finally:
+        client.close()
+        context.term()
+
+
+# --------------------------------------------------------------------------
+# What an unpaired BEFORE_EXECUTE costs a real handler
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_timed_out_execution_exports_an_otel_span(tmp_path):
+    """An unpaired execution is missing from the span file entirely."""
+    spans_file = tmp_path / "spans.jsonl"
+    HookRegistry.get_instance().register(create_otel_handler(file_path=spans_file))
+
+    await execute_via_execution_stack(
+        serverapp=_ServerApp(_ExecutionStack(results=[])),
+        kernel_id="kernel-1",
+        code="while True: pass",
+        timeout=0,
+        poll_interval=0,
+    )
+
+    spans = [json.loads(line) for line in spans_file.read_text().splitlines() if line.strip()]
+    assert len(spans) == 1, f"expected the timed-out execution to be exported, got {spans}"
+    assert spans[0]["name"] == "execute"
+    assert spans[0]["attributes"]["error"] is True
+    assert spans[0]["end_time"] is not None


### PR DESCRIPTION
`execute_via_execution_stack` and `execute_code_local` fire `BEFORE_EXECUTE` and then return or re-raise on their timeout, cancellation, input-request, unparseable-output and unexpected-error exits without firing `AFTER_EXECUTE`, so a handler that stashes per-execution state in the context never gets it back. `OTelHookHandler` ends its span only in the AFTER branch and `SimpleSpanProcessor` exports on end, so a timed-out execution is absent from the span file rather than recorded as an error. Full exit enumeration and a standalone reproduction are in #360.

## Fix

Fire `AFTER_EXECUTE` on every exit past the BEFORE fire, using the payload shape `execute_code_tool._execute_on_kernel` already uses for the same tool in MCP_SERVER mode: `outputs=` what the caller gets back, `error=` the exception.

Two details worth a second look:

- `hook_ctx` starts as `None`, so the outer `except Exception` can distinguish a failure before the BEFORE fire (a missing `jupyter_server_nbmodel` extension, for instance) from one after it, and stays silent for the first.
- The `except (asyncio.CancelledError, TimeoutError)` handler fires and then re-raises. `TimeoutError` reaches the outer handler and `CancelledError` does not, since it is not an `Exception`, so the fire has to live in the inner handler and `after_execute_fired` keeps the outer one from firing a second time on the timeout path.

## Verification

Clean `python:3.13-slim` container, `pip install -e '.[test]'`, base `cf707a1`, provenance `/w/jupyter_mcp_server/utils.py`.

`tests/test_execute_hook_pairing.py` is new, one test per exit plus two controls:

- at `cf707a1`: **8 failed, 2 passed**. The two that pass are the success path and the pre-BEFORE failure, which owes no AFTER.
- on this branch: **10 passed**.

The standalone reproduction from #360, same container:

```
cf707a1      hook events: ['BEFORE_EXECUTE']                    otel spans exported: 0
this branch  hook events: ['BEFORE_EXECUTE', 'AFTER_EXECUTE']   otel spans exported: 1
```

Regression: `tests/test_otel_integration.py` 7 passed on both transports against a real Jupyter server, and `test_hooks.py` / `test_otel_hooks.py` / `test_execute_via_execution_stack.py` / the `test_execute_*` timeout files 38 passed. The whole suite in that container ends 387 passed / 9 failed / 5 errors, and re-running those five failing files against unmodified `main` in the same container gives the same set (`test_mcpb_version_sync`, `test_tools`, `test_use_notebook_ui_open`, `test_use_notebook_split_servers`, and `test_move_cell`, which varies run to run), so they look environmental rather than caused by this change. CI here is the real check.

`ruff format --check` clean, and `ruff check jupyter_mcp_server/utils.py` reports the same 23 pre-existing errors as `main`.

Fixes #360
