### PR TITLE
Document Provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ working on your data when your laptop does not.
 <table>
 <tr><td>
 
-![Renamed](https://img.shields.io/badge/%F0%9F%94%84-Renamed-E67E22?style=for-the-badge&labelColor=A0522D)
+![Renamed in v1.3.2](https://img.shields.io/badge/%F0%9F%94%84%20Renamed%20in-v1.3.2-E67E22?style=for-the-badge&labelColor=A0522D)
 
 **`--provider` is now `--document-provider`** (env var `PROVIDER` → `DOCUMENT_PROVIDER`).
 
@@ -58,8 +58,9 @@ API of a Jupyter Server, `datalayer` for the Datalayer spacer — while the old 
 help text suggested it also chose where code runs. Execution is picked separately, with
 `--sandbox-variant` (`jupyter`, `datalayer`, `kaggle`, `colab`, `monty`, `modal`).
 
-The former names keep working: `--provider` is still accepted as an alias, `PROVIDER` is
-still read, and a `/connect` payload carrying `"provider"` is still understood.
+Nothing breaks in v1.3.2: `--provider` is still accepted as an alias, `PROVIDER` is still
+read, and a `/connect` payload carrying `"provider"` is still understood. Move to the new
+names when convenient — the old ones are deprecated, not removed.
 
 </td></tr>
 </table>

--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@
 > Built and maintained by [**Datalayer**](https://datalayer.ai), where the same server drives
 > always-on Notebooks with GPU Code Sandboxes and durable execution — so your agent keeps
 > working on your data when your laptop does not.
+>
 > → **[Discover Datalayer](https://datalayer.ai)**
 
 <div align="center">

--- a/README.md
+++ b/README.md
@@ -25,17 +25,44 @@
 
 </div>
 
-> [!NOTE]
-> <a href="https://datalayer.ai"><img alt="Datalayer" src="https://images.datalayer.io/brand/logos/datalayer-horizontal.svg" height="22"/></a>
->
-> **Free and open source, BSD 3-Clause** — point it at any Jupyter you already run, local or
-> JupyterHub, no account needed.
->
-> Built and maintained by [**Datalayer**](https://datalayer.ai), where the same server drives
-> always-on Notebooks with GPU Code Sandboxes and durable execution — so your agent keeps
-> working on your data when your laptop does not.
->
-> → **[Discover Datalayer](https://datalayer.ai)**
+<table>
+<tr><td>
+
+<a href="https://datalayer.ai"><img alt="Datalayer" src="https://images.datalayer.io/brand/logos/datalayer-horizontal.svg" height="22"/></a>
+
+[![Built and maintained by Datalayer](https://img.shields.io/badge/Built%20and%20maintained%20by-Datalayer%20%C2%B7%20datalayer.ai-1ABC9C?style=for-the-badge&logo=jupyter&logoColor=white&labelColor=0E7C6B)](https://datalayer.ai)
+
+📖 [Documentation](https://jupyter-mcp-server.datalayer.tech) &nbsp;·&nbsp; 🔧 [Tools](https://jupyter-mcp-server.datalayer.tech/mcp) &nbsp;·&nbsp; 💬 [Community](https://jupyter-mcp-server.datalayer.tech/community)
+
+**Free and open source, BSD 3-Clause** — point it at any Jupyter you already run, local or
+JupyterHub, no account needed.
+
+Built and maintained by [**Datalayer**](https://datalayer.ai), where the same server drives
+always-on Notebooks with GPU Code Sandboxes and durable execution — so your agent keeps
+working on your data when your laptop does not.
+
+[![Discover Datalayer](https://img.shields.io/badge/%E2%86%92%20Discover%20Datalayer-datalayer.ai-1ABC9C?style=for-the-badge&labelColor=0E7C6B)](https://datalayer.ai)
+
+</td></tr>
+</table>
+
+<table>
+<tr><td>
+
+![Renamed](https://img.shields.io/badge/%F0%9F%94%84-Renamed-E67E22?style=for-the-badge&labelColor=A0522D)
+
+**`--provider` is now `--document-provider`** (env var `PROVIDER` → `DOCUMENT_PROVIDER`).
+
+It only ever chose where the notebook **documents** live — `jupyter` for the collaboration
+API of a Jupyter Server, `datalayer` for the Datalayer spacer — while the old name and its
+help text suggested it also chose where code runs. Execution is picked separately, with
+`--sandbox-variant` (`jupyter`, `datalayer`, `kaggle`, `colab`, `monty`, `modal`).
+
+The former names keep working: `--provider` is still accepted as an alias, `PROVIDER` is
+still read, and a `/connect` payload carrying `"provider"` is still understood.
+
+</td></tr>
+</table>
 
 <div align="center">
 
@@ -157,15 +184,22 @@ For comprehensive setup instructions—including `Streamable HTTP` transport, ru
 pip install jupyterlab jupyter-collaboration jupyter-mcp-tools ipykernel
 ```
 
-> [!TIP]
-> To confirm your environment is correctly configured:
->
-> 1. Open a notebook in JupyterLab
-> 1. Type some content in any cell (code or markdown)
-> 1. Observe the tab indicator: you should see an "×" appear next to the notebook name, indicating unsaved changes
-> 1. Wait a few seconds—the "×" should automatically change to a "●" without manually saving
->
-> This automatic saving behavior confirms that the real-time collaboration features are working properly, which is essential for MCP server integration.
+<table>
+<tr><td>
+
+![Tip](https://img.shields.io/badge/%F0%9F%92%A1-Tip-1ABC9C?style=for-the-badge&labelColor=0E7C6B)
+
+To confirm your environment is correctly configured:
+
+1. Open a notebook in JupyterLab
+1. Type some content in any cell (code or markdown)
+1. Observe the tab indicator: you should see an "×" appear next to the notebook name, indicating unsaved changes
+1. Wait a few seconds—the "×" should automatically change to a "●" without manually saving
+
+This automatic saving behavior confirms that the real-time collaboration features are working properly, which is essential for MCP server integration.
+
+</td></tr>
+</table>
 
 ### 2. Start JupyterLab
 
@@ -174,8 +208,15 @@ pip install jupyterlab jupyter-collaboration jupyter-mcp-tools ipykernel
 jupyter lab --port 8888 --IdentityProvider.token MY_TOKEN --ip 0.0.0.0
 ```
 
-> [!NOTE]
-> If you are running notebooks through JupyterHub instead of JupyterLab as above, refer to our [JupyterHub setup guide](https://jupyter-mcp-server.datalayer.tech/code-sandboxes/jupyterhub).
+<table>
+<tr><td>
+
+![Note](https://img.shields.io/badge/%E2%84%B9%EF%B8%8F-Note-3498DB?style=for-the-badge&labelColor=1B5E8A)
+
+If you are running notebooks through JupyterHub instead of JupyterLab as above, refer to our [JupyterHub setup guide](https://jupyter-mcp-server.datalayer.tech/code-sandboxes/jupyterhub).
+
+</td></tr>
+</table>
 
 ### 3. Configure Your Preferred MCP Client
 
@@ -271,13 +312,19 @@ Then, configure your client:
 
 </details>
 
-> [!TIP]
->
-> 1. **Port Configuration**: Ensure the `port` in your Jupyter URLs matches the one used in the `jupyter lab` command. For simplified config, set this in `JUPYTER_URL`.
-> 1. **Server Separation**: Use `JUPYTER_URL` when both services are on the same server, or set individual variables for advanced deployments. The different URL variables exist because some deployments separate notebook storage (`DOCUMENT_URL`) from kernel execution (`CODE_SANDBOX_URL`).
-> 1. **Authentication**: In most cases, document and code sandbox services use the same authentication token. Use `JUPYTER_TOKEN` for simplified config or set `DOCUMENT_TOKEN` and `CODE_SANDBOX_TOKEN` individually for different credentials.
-> 1. **Notebook Path**: The `DOCUMENT_ID` parameter specifies the path to the notebook the MCP client default to connect. It should be relative to the directory where JupyterLab was started. If you omit `DOCUMENT_ID`, the MCP client can automatically list all available notebooks on the Jupyter server, allowing you to select one interactively via your prompts.
-> 1. **Image Output**: Set `ALLOW_IMG_OUTPUT` to `false` if your LLM does not support mutimodel understanding.
+<table>
+<tr><td>
+
+![Tip](https://img.shields.io/badge/%F0%9F%92%A1-Tip-1ABC9C?style=for-the-badge&labelColor=0E7C6B)
+
+1. **Port Configuration**: Ensure the `port` in your Jupyter URLs matches the one used in the `jupyter lab` command. For simplified config, set this in `JUPYTER_URL`.
+1. **Server Separation**: Use `JUPYTER_URL` when both services are on the same server, or set individual variables for advanced deployments. The different URL variables exist because some deployments separate notebook storage (`DOCUMENT_URL`) from kernel execution (`CODE_SANDBOX_URL`).
+1. **Authentication**: In most cases, document and code sandbox services use the same authentication token. Use `JUPYTER_TOKEN` for simplified config or set `DOCUMENT_TOKEN` and `CODE_SANDBOX_TOKEN` individually for different credentials.
+1. **Notebook Path**: The `DOCUMENT_ID` parameter specifies the path to the notebook the MCP client default to connect. It should be relative to the directory where JupyterLab was started. If you omit `DOCUMENT_ID`, the MCP client can automatically list all available notebooks on the Jupyter server, allowing you to select one interactively via your prompts.
+1. **Image Output**: Set `ALLOW_IMG_OUTPUT` to `false` if your LLM does not support mutimodel understanding.
+
+</td></tr>
+</table>
 
 For detailed instructions on configuring various MCP clients—including [Claude Desktop](https://jupyter-mcp-server.datalayer.tech/clients/claude_desktop), [VS Code](https://jupyter-mcp-server.datalayer.tech/clients/vscode), [Cursor](https://jupyter-mcp-server.datalayer.tech/clients/cursor), [Cline](https://jupyter-mcp-server.datalayer.tech/clients/cline), and [Windsurf](https://jupyter-mcp-server.datalayer.tech/clients/windsurf) — see the [Clients documentation](https://jupyter-mcp-server.datalayer.tech/clients).
 

--- a/README.md
+++ b/README.md
@@ -4,8 +4,6 @@
   ~ BSD 3-Clause License
 -->
 
-[![Datalayer](https://images.datalayer.io/brand/logos/datalayer-horizontal.svg)](https://datalayer.io)
-
 [![Become a Sponsor](https://img.shields.io/static/v1?label=Become%20a%20Sponsor&message=%E2%9D%A4&logo=GitHub&style=flat&color=1ABC9C)](https://github.com/sponsors/datalayer)
 
 <div align="center">
@@ -16,24 +14,33 @@
 
 **An [MCP](https://modelcontextprotocol.io) server developed for AI to connect and manage [Jupyter](https://jupyter.org) Notebooks in real-time**
 
-*Developed by [Datalayer](https://github.com/datalayer) - Join our [Discord](https://github.com/datalayer)*
+*Developed by [Datalayer](https://datalayer.ai) - Join our [Discord](https://discord.gg/YQFwvmSSuR)*
 
 [![PyPI - Version](https://img.shields.io/pypi/v/jupyter-mcp-server?style=for-the-badge&logo=pypi&logoColor=white)](https://pypi.org/project/jupyter-mcp-server)
 [![Total PyPI downloads](https://img.shields.io/pepy/dt/jupyter-mcp-server?style=for-the-badge&logo=python&logoColor=white)](https://pepy.tech/project/jupyter-mcp-server)
 [![Docker Pulls](https://img.shields.io/docker/pulls/datalayer/jupyter-mcp-server?style=for-the-badge&logo=docker&logoColor=white&color=2496ED)](https://hub.docker.com/r/datalayer/jupyter-mcp-server)
 [![License](https://img.shields.io/badge/License-BSD_3--Clause-blue?style=for-the-badge&logo=open-source-initiative&logoColor=white)](https://opensource.org/licenses/BSD-3-Clause)
 
-![Jupyter MCP Server Demo](https://images.datalayer.io/products/jupyter-mcp-server/mcp-demo-multimodal.gif)
+[![Discover Datalayer](https://img.shields.io/badge/Discover%20Datalayer-datalayer.ai-1ABC9C?style=for-the-badge&logo=jupyter&logoColor=white&labelColor=0E7C6B)](https://datalayer.ai)
 
 </div>
 
-> **Breaking change in v1.2.0:** "Runtime", aka name "Jupyter Kernel", is now called "Code Sandbox", see the [migration guide](https://jupyter-mcp-server.datalayer.tech/releases/#migration-guide-to-120).
+> [!NOTE]
+> <a href="https://datalayer.ai"><img alt="Datalayer" src="https://images.datalayer.io/brand/logos/datalayer-horizontal.svg" height="22"/></a>
 >
-> **New in v1.1.0:** We are not supporting external `Sandboxes` (Datalayer, Kaggle, Monty, Google Colab, Modal...).
+> **Free and open source, BSD 3-Clause** — point it at any Jupyter you already run, local or
+> JupyterHub, no account needed.
 >
-> Setup details [on this page](https://jupyter-mcp-server.datalayer.tech/mcp-transports/streamable-http/#3-configure-your-mcp-client)
->
-> Join the conversation in our [Community page](https://jupyter-mcp-server.datalayer.tech/community) - your feedback will help us prioritize features and ensure these integrations work seamlessly for your needs.
+> Built and maintained by [**Datalayer**](https://datalayer.ai), where the same server drives
+> always-on Notebooks with GPU Code Sandboxes and durable execution — so your agent keeps
+> working on your data when your laptop does not.
+> → **[Discover Datalayer](https://datalayer.ai)**
+
+<div align="center">
+
+![Jupyter MCP Server Demo](https://images.datalayer.io/products/jupyter-mcp-server/mcp-demo-multimodal.gif)
+
+</div>
 
 ## 📖 Table of Contents
 
@@ -56,7 +63,9 @@
 - 🤝 **MCP-compatible:** Works with any MCP client, such as Claude Desktop, Cursor, Windsurf, and more.
 - 🔍 **Observability:** Built-in hook system with OpenTelemetry integration for tracing tool calls and kernel executions.
 
-Compatible with any Jupyter deployment (local, JupyterHub, ...) and with [Datalayer](https://datalayer.ai) hosted Notebooks.
+Compatible with any Jupyter deployment (local, JupyterHub, ...) and with
+[**Datalayer**](https://datalayer.ai) hosted Notebooks, where the Code Sandboxes
+come with GPUs and the execution survives a disconnect.
 
 ## 🔧 MCP Overview
 

--- a/docs/docs/code-sandboxes/datalayer/index.mdx
+++ b/docs/docs/code-sandboxes/datalayer/index.mdx
@@ -1,4 +1,4 @@
-# Datalayer Provider
+# Datalayer Code Sandbox
 
 The Jupyter MCP Server can execute code on the [Datalayer](https://datalayer.ai)
 cloud code sandbox, providing fully isolated execution with GPU support, snapshots, and
@@ -22,7 +22,7 @@ Install the Datalayer extra:
 pip install "jupyter-mcp-server[datalayer]"
 ```
 
-Install the sandbox extension package used by this provider:
+Install the sandbox extension package used by this sandbox:
 
 ```bash
 pip install datalayer_mcp_sandboxes

--- a/docs/docs/code-sandboxes/google-colab/index.mdx
+++ b/docs/docs/code-sandboxes/google-colab/index.mdx
@@ -1,4 +1,4 @@
-# Google Colab Provider
+# Google Colab Code Sandbox
 
 The Jupyter MCP Server can execute code against a **Google Colab** code sandbox. Colab
 exposes a Jupyter-compatible kernel behind an authenticating proxy, so the server
@@ -21,7 +21,7 @@ Install Jupyter MCP Server:
 pip install jupyter-mcp-server
 ```
 
-Install the sandbox extension package used by this provider:
+Install the sandbox extension package used by this sandbox:
 
 ```bash
 pip install datalayer_mcp_sandboxes

--- a/docs/docs/code-sandboxes/jupyter-server/index.mdx
+++ b/docs/docs/code-sandboxes/jupyter-server/index.mdx
@@ -1,6 +1,6 @@
-# Jupyter Server Provider
+# Jupyter Server Code Sandbox
 
-The **Jupyter Server** provider is the default. Code executes through
+The **Jupyter Server** sandbox is the default. Code executes through
 the `code-sandboxes` `jupyter` variant against a local or remote Jupyter Server
 (`SANDBOX_VARIANT=jupyter`), giving you a full Jupyter kernel with process
 isolation, persistent state, and rich outputs (images, plots, HTML).

--- a/docs/docs/code-sandboxes/kaggle/index.mdx
+++ b/docs/docs/code-sandboxes/kaggle/index.mdx
@@ -1,4 +1,4 @@
-# Kaggle Provider
+# Kaggle Code Sandbox
 
 The Jupyter MCP Server can execute code against a **Kaggle** notebook code sandbox.
 Kaggle exposes a Jupyter-compatible kernel behind an authenticating proxy, so the
@@ -22,7 +22,7 @@ Install the Kaggle extra:
 pip install "jupyter-mcp-server[kaggle]"
 ```
 
-Install the sandbox extension package used by this provider:
+Install the sandbox extension package used by this sandbox:
 
 ```bash
 pip install datalayer_mcp_sandboxes

--- a/docs/docs/code-sandboxes/modal/index.mdx
+++ b/docs/docs/code-sandboxes/modal/index.mdx
@@ -1,4 +1,4 @@
-# Modal Provider
+# Modal Code Sandbox
 
 The Jupyter MCP Server can execute code in a [Modal](https://modal.com/docs/guide)
 cloud sandbox, providing fully isolated, on-demand containers with configurable

--- a/docs/docs/code-sandboxes/monty/index.mdx
+++ b/docs/docs/code-sandboxes/monty/index.mdx
@@ -1,4 +1,4 @@
-# Monty Provider
+# Monty Code Sandbox
 
 The Jupyter MCP Server can execute code in [Monty](https://github.com/pydantic/monty),
 a minimal, secure Python interpreter written in Rust (`pydantic-monty`). Monty runs
@@ -25,7 +25,7 @@ Install the Monty extra:
 pip install "jupyter-mcp-server[monty]"
 ```
 
-Install the sandbox extension package used by this provider:
+Install the sandbox extension package used by this sandbox:
 
 ```bash
 pip install datalayer_mcp_sandboxes

--- a/docs/docs/community/index.mdx
+++ b/docs/docs/community/index.mdx
@@ -14,7 +14,7 @@ We welcome everyone to join our growing community!
 
 ## Contribute
 
-We invite you to contribute by [opening issues](https://github.com/datalayer/jupyter-mcp-server/issues) and submitting [pull requests](https://github.com/datalayer/jupyter-mcp-server/pulls) for any question, problem or to discuss adding your solution as a provider.
+We invite you to contribute by [opening issues](https://github.com/datalayer/jupyter-mcp-server/issues) and submitting [pull requests](https://github.com/datalayer/jupyter-mcp-server/pulls) for any question, problem or to discuss adding your solution as a code sandbox.
 
 We welcome contributions of all kinds, including:
 

--- a/docs/docs/features/configuration/index.mdx
+++ b/docs/docs/features/configuration/index.mdx
@@ -24,7 +24,7 @@ The server automatically detects the appropriate mode based on deployment contex
 
 When enabled together with JupyterLab mode, `use_notebook` also opens the notebook in the JupyterLab UI, which activates its tab. It is off by default so that notebooks used over MCP do not pull the focus away from the tab you are working in.
 
-## Transport & Providers
+## Transport & Code Sandboxs
 
 ### Transport Options
 
@@ -33,12 +33,15 @@ When enabled together with JupyterLab mode, `use_notebook` also opens the notebo
 | **STDIO** (default) | Desktop apps, Docker | `--transport stdio` |
 | **Streamable HTTP** | Web apps, multiple clients | `--transport streamable-http --port 4040` |
 
-### Providers
+### Document backends
 
-| Provider | Description | Configuration |
+Where the notebook documents live. Execution is a separate choice, made with
+`--sandbox-variant`.
+
+| Document backend | Description | Configuration |
 |----------|-------------|---------------|
-| **jupyter** (default) | Standard JupyterLab/Hub | `--provider jupyter` |
-| **datalayer** | Enterprise hosting | `--provider datalayer` |
+| **jupyter** (default) | Standard JupyterLab/Hub | `--document-provider jupyter` |
+| **datalayer** | Enterprise hosting | `--document-provider datalayer` |
 
 ## Environment Variables
 
@@ -89,7 +92,7 @@ For deployments requiring granular control over document storage and code sandbo
 | Variable | Description | Example | Default |
 |----------|-------------|---------|---------|
 | `START_NEW_CODE_SANDBOX` | Create new code sandbox vs use existing | `true` / `false` | `false` |
-| `PROVIDER` | Provider type for document and code sandbox | `jupyter` / `datalayer` | `jupyter` |
+| `DOCUMENT_PROVIDER` | Which backend holds the notebook documents | `jupyter` / `datalayer` | `jupyter` |
 | `TRANSPORT` | Transport method for MCP | `stdio` / `streamable-http` | `stdio` |
 | `PORT` | Port for streamable HTTP transport | `4040` | `4040` |
 | `RECONNECT_INTERVAL` | Seconds before retrying a dropped kernel WebSocket connection. `0` disables auto-reconnect. | `5` | `0` |
@@ -234,7 +237,8 @@ Usage: jupyter mcp start [OPTIONS]
 
 Options:
   --transport [stdio|streamable-http]  Transport type (default: stdio)
-  --provider [jupyter|datalayer]      Provider type (default: jupyter)
+  --document-provider [jupyter|datalayer]
+                                      Document backend holding the notebooks (default: jupyter)
   --jupyterlab BOOLEAN               Enable JupyterLab mode (default: true)
   --code-sandbox-url TEXT                  Runtime URL for kernel operations (default: None)
   --code-sandbox-token TEXT                Runtime authentication token (default: None)
@@ -277,7 +281,8 @@ Usage: jupyter mcp connect [OPTIONS]
 Connect a Jupyter MCP Server to a document and a code sandbox.
 
 Options:
-  --provider [jupyter|datalayer]      Provider type (default: jupyter)
+  --document-provider [jupyter|datalayer]
+                                      Document backend holding the notebooks (default: jupyter)
   --jupyterlab BOOLEAN               Enable JupyterLab mode (default: true)
   --code-sandbox-url TEXT                  Runtime URL for kernel operations (default: None)
   --code-sandbox-token TEXT                Runtime authentication token (default: None)
@@ -335,7 +340,7 @@ jupyter mcp start \
 Then connect via endpoint:
 ```bash
 jupyter mcp connect \
-  --provider datalayer \
+  --document-provider datalayer \
   --document-url <url> \
   --document-id <document> \
   --document-token <token> \

--- a/docs/docs/features/multi-users/index.mdx
+++ b/docs/docs/features/multi-users/index.mdx
@@ -263,7 +263,7 @@ For enterprise deployments, consider [Datalayer](https://datalayer.ai) which pro
       "command": "uvx",
       "args": ["jupyter-mcp-server@latest"],
       "env": {
-        "PROVIDER": "datalayer",
+        "DOCUMENT_PROVIDER": "datalayer",
         "DATALAYER_URL": "https://app.datalayer.ai",
         "DATALAYER_TOKEN": "your-user-token"
       }
@@ -454,9 +454,9 @@ c.JupyterHub.extra_log_file = '/var/log/jupyterhub/jupyterhub.log'
 
 ## Additional Resources
 
+- [Datalayer](https://datalayer.ai)
 - [JupyterHub Documentation](https://jupyterhub.readthedocs.io/)
 - [Zero to JupyterHub (Kubernetes)](https://z2jh.jupyter.org/)
 - [JupyterHub Deployment Guide](https://jupyterhub.readthedocs.io/en/stable/features/technical-overview.html)
-- [JupyterHub Provider Documentation](/code-sandboxes/jupyterhub)
+- [JupyterHub Documentation](/code-sandboxes/jupyterhub)
 - [Issue #181: Multi-user serving](https://github.com/datalayer/jupyter-mcp-server/issues/181)
-- [Datalayer Platform](https://datalayer.ai)

--- a/docs/docs/getting_started/index.mdx
+++ b/docs/docs/getting_started/index.mdx
@@ -4,7 +4,7 @@ To use Jupyter MCP Server, you first need to decide which setup fits your needs:
 
 - **MCP Server Location** - It can be running as a [**Standalone MCP Server**](/mcp-transports/streamable-http) or inside the Jupyter Server [**as a Jupyter Server Extension**](/mcp-transports/streamable-http-extension) - The last one has for advantage to avoid running 2 separate servers (Jupyter server + MCP server) but only supports Streamable HTTP transport.
 - **MCP Transport** - It supports both [**STDIO Transport**](/mcp-transports/stdio) and **Streamable HTTP Transport**
-- **Jupyter Provider** - It can connect to [**Jupyter Server**](/code-sandboxes/jupyter-server) (local or remote), [**JupyterHub**](/code-sandboxes/jupyterhub), [**Datalayer**](/code-sandboxes/datalayer), [**Kaggle**](/code-sandboxes/kaggle), [**Monty**](/code-sandboxes/monty), [**Google Colab**](/code-sandboxes/google-colab), and [**Modal**](/code-sandboxes/modal).
+- **Jupyter Code Sandbox** - It can connect to [**Jupyter Server**](/code-sandboxes/jupyter-server) (local or remote), [**JupyterHub**](/code-sandboxes/jupyterhub), [**Datalayer**](/code-sandboxes/datalayer), [**Kaggle**](/code-sandboxes/kaggle), [**Monty**](/code-sandboxes/monty), [**Google Colab**](/code-sandboxes/google-colab), and [**Modal**](/code-sandboxes/modal).
 
 This guide will help you set up a Jupyter MCP Server to connect your preferred MCP client to a JupyterLab instance.
 
@@ -43,13 +43,13 @@ If you choose Streamable HTTP transport, you can also choose to run the MCP serv
 - [**As a Jupyter Server Extension**](/mcp-transports/streamable-http-extension) - MCP server runs inside Jupyter (recommended, simpler setup)
 - [**As a Standalone Server**](/mcp-transports/streamable-http) - MCP server runs as a separate process
 
-## Provider Options
+## Code Sandbox Options
 
 ### Jupyter Server (Local/Remote)
 
 Connect to any standard JupyterLab or Jupyter Notebook server.
 
-👉 [Jupyter Server Provider Documentation](/code-sandboxes/jupyter-server)
+👉 [Jupyter Server Documentation](/code-sandboxes/jupyter-server)
 
 👉 Choose your transport:
 - [STDIO Transport](/mcp-transports/stdio)
@@ -66,35 +66,35 @@ Multi-user deployments with authentication and resource management.
 If you're deploying for multiple users, see the [Multi-User Documentation](/features/multi-users) for architecture patterns and best practices.
 :::
 
-### Datalayer Platform
+### Datalayer
 
 Enterprise-grade hosted Jupyter with built-in collaboration and security features.
 
-👉 [Datalayer Provider Documentation](/code-sandboxes/datalayer)
+👉 [Datalayer Documentation](/code-sandboxes/datalayer)
 
 ### Kaggle
 
 Connect to Kaggle interactive notebook code sandboxes.
 
-👉 [Kaggle Provider Documentation](/code-sandboxes/kaggle)
+👉 [Kaggle Documentation](/code-sandboxes/kaggle)
 
 ### Monty
 
 Run code with Monty, a secure in-process interpreter for lightweight Python snippets.
 
-👉 [Monty Provider Documentation](/code-sandboxes/monty)
+👉 [Monty Documentation](/code-sandboxes/monty)
 
 ### Google Colab
 
 Connect to Google Colab notebooks (experimental).
 
-👉 [Google Colab Provider Documentation](/code-sandboxes/google-colab)
+👉 [Google Colab Documentation](/code-sandboxes/google-colab)
 
 ### Modal
 
 Run code in Modal cloud sandboxes for isolated, on-demand execution.
 
-👉 [Modal Provider Documentation](/code-sandboxes/modal)
+👉 [Modal Documentation](/code-sandboxes/modal)
 
 ## MCP Client Configuration
 

--- a/docs/docs/index.mdx
+++ b/docs/docs/index.mdx
@@ -5,10 +5,14 @@ hide_table_of_contents: false
 slug: /
 ---
 
-# About Jupyter MCP Server
+# Jupyter MCP Server
 
 **Jupyter MCP Server** is a [Model Context Protocol](https://modelcontextprotocol.io) (MCP) server implementation that enables **real-time** interaction with 📓 Jupyter Notebooks, allowing AI to edit, document and execute code for data analysis, visualization etc.
-It is compatible with any [Jupyter](https://jupyter.org) deployment (local, JupyterHub, ...) and with [Datalayer](https://datalayer.ai) hosted Notebooks. Key features include:
+
+It is compatible with any [Jupyter](https://jupyter.org) deployment (local, JupyterHub, ...) and with [Datalayer](https://datalayer.ai) hosted Notebooks.
+:::info
+
+Key features include:
 
 - ⚡ **Real-time control:** Instantly view notebook changes as they happen.
 - 🔁 **Smart execution:** Automatically adjusts when a cell run fails thanks to cell output feedback.
@@ -18,6 +22,15 @@ It is compatible with any [Jupyter](https://jupyter.org) deployment (local, Jupy
 - 🎛️ **JupyterLab integration:** Enhanced UI integration like automatic notebook opening.
 - 🤝 **MCP-compatible:** Works with any MCP client, such as [Claude Desktop](/mcp-clients/claude_desktop), [Cursor](/mcp-clients/cursor), [Cline](/mcp-clients/cline), [Windsurf](/mcp-clients/windsurf) and more.
 
+**Free and open source, BSD 3-Clause** — install it in your own Jupyter, no
+account needed. Built and maintained by [**Datalayer**](https://datalayer.ai),
+where the same durable execution powers always-on Notebooks that humans and AI
+agents work in together.
+
+[![Discover Datalayer](https://img.shields.io/badge/Discover%20Datalayer-datalayer.ai-1ABC9C?style=for-the-badge&logo=jupyter&logoColor=white&labelColor=0E7C6B)](https://datalayer.ai)
+
+:::
+
 <div style={{textAlign: 'center', margin: '2rem 0'}}>
   <a href="./getting_started" className="button button--primary button--lg">
     Getting Started
@@ -25,3 +38,5 @@ It is compatible with any [Jupyter](https://jupyter.org) deployment (local, Jupy
 </div>
 
 ![Jupyter MCP Server Demo](https://images.datalayer.io/products/jupyter-mcp-server/mcp-demo-multimodal.gif)
+
+[![Install from PyPI](https://img.shields.io/badge/pip%20install-jupyter__mcp__server-306998?style=for-the-badge&logo=python&logoColor=white&labelColor=1E4064)](https://pypi.org/project/jupyter-mcp-server)

--- a/docs/docs/releases/index.mdx
+++ b/docs/docs/releases/index.mdx
@@ -1,5 +1,127 @@
 # Releases
 
+## Migration Guide to 1.3.2
+
+Version 1.3.2 renames `provider` to `document_provider`, so that the name says what the
+option actually selects.
+
+It only ever chose **where the notebook documents live** — `jupyter` for the collaboration
+API of a Jupyter Server, `datalayer` for the Datalayer spacer. Where the *code runs* is a
+separate choice, made with `--sandbox-variant`. The old name, and its help text, suggested
+one option governed both.
+
+:::tip[Nothing breaks in 1.3.2]
+
+The former names are deprecated, not removed. `--provider` is still accepted as an alias,
+`PROVIDER` is still read, and a `/connect` payload carrying `"provider"` is still
+understood. Migrate when convenient.
+
+:::
+
+### Who Should Migrate
+
+- End users passing `--provider` or setting `PROVIDER`, which in practice means anyone
+  pointing the server at Datalayer-hosted documents.
+- Operators whose manifests, wrapper scripts or MCP client configurations carry `PROVIDER`.
+- Anyone calling the `/connect` endpoint or the `connect_to_jupyter` tool with a
+  `provider` field.
+
+### Change Summary
+
+- Use `document_provider` names everywhere instead of `provider` names.
+- The accepted values are unchanged: `jupyter` (default) and `datalayer`.
+- Execution backends keep their own option, `--sandbox-variant` / `SANDBOX_VARIANT`.
+- Nothing has to change immediately: the old names still work in this version.
+
+### Rename Matrix
+
+| Old (pre-1.3.2) | New (1.3.2+) |
+|---|---|
+| `provider` | `document_provider` |
+| `PROVIDER` | `DOCUMENT_PROVIDER` |
+| `--provider` | `--document-provider` |
+| `"provider"` in the `/connect` payload | `"document_provider"` |
+| `provider` argument of `connect_to_jupyter` | `document_provider` |
+
+### End User Migration
+
+#### 1. Update environment variables
+
+Before:
+
+```bash
+export PROVIDER=datalayer
+```
+
+After:
+
+```bash
+export DOCUMENT_PROVIDER=datalayer
+```
+
+#### 2. Update CLI commands
+
+Before:
+
+```bash
+jupyter mcp start \
+	--provider datalayer \
+	--document-url <url> \
+	--document-token <token>
+```
+
+After:
+
+```bash
+jupyter mcp start \
+	--document-provider datalayer \
+	--document-url <url> \
+	--document-token <token>
+```
+
+#### 3. Update MCP client configurations
+
+An MCP client passing the variable through its `env` block needs the new key:
+
+```json
+{
+  "env": {
+    "DOCUMENT_PROVIDER": "datalayer",
+    "DOCUMENT_URL": "<url>",
+    "DOCUMENT_TOKEN": "<token>"
+  }
+}
+```
+
+#### 4. Check that document and execution are configured separately
+
+The two axes are independent, and a Datalayer document store does not imply a Datalayer
+sandbox. State each one:
+
+```bash
+jupyter mcp start \
+	--document-provider datalayer \
+	--sandbox-variant datalayer
+```
+
+### Known Migration Pitfalls
+
+- Assuming `--provider datalayer` also moved execution to Datalayer; it never did, and
+  `--sandbox-variant` is what does.
+- Both `PROVIDER` and `DOCUMENT_PROVIDER` set to different values in the same environment.
+  The new name wins, which may not be what the older one intended.
+- Wrapper scripts updated while CI secrets still carry the old key name.
+
+### Recommended Migration Checklist
+
+1. Replace `PROVIDER` with `DOCUMENT_PROVIDER` in environments, manifests and CI secrets.
+2. Replace `--provider` with `--document-provider` in commands and wrappers.
+3. Rename `provider` to `document_provider` in `/connect` payloads and tool calls.
+4. State `--sandbox-variant` explicitly wherever execution is not the default Jupyter one.
+5. Validate a notebook opens and a cell executes before removing the old names.
+
+For full reference values, see [Configuration](/features/configuration).
+
 ## Migration Guide to 1.2.0
 
 Version 1.2.0 completes the terminology migration from runtime to code sandbox.

--- a/docs/sourcey/config-fields.json
+++ b/docs/sourcey/config-fields.json
@@ -9,10 +9,10 @@
    "description": "The transport to use for the MCP server"
   },
   {
-   "name": "provider",
+   "name": "document_provider",
    "type": "<class 'str'>",
    "default": "jupyter",
-   "description": "The provider to use for the document and code sandbox"
+   "description": "Which backend holds the notebook documents: 'jupyter' or 'datalayer'"
   },
   {
    "name": "code_sandbox_url",

--- a/docs/sourcey/configuration.md
+++ b/docs/sourcey/configuration.md
@@ -10,7 +10,7 @@ All runtime settings live on the `JupyterMCPConfig` pydantic model ([`jupyter_mc
 | Setting | Type | Default | Description |
 | --- | --- | --- | --- |
 | `transport` | str | `"stdio"` | The transport to use for the MCP server |
-| `provider` | str | `"jupyter"` | The provider to use for the document and code sandbox |
+| `document_provider` | str | `"jupyter"` | Which backend holds the notebook documents |
 | `code_sandbox_url` | str | `"http://localhost:8888"` | The code sandbox URL to use, or 'local' for direct serverapp access |
 | `start_new_code_sandbox` | bool | `false` | Start a new code sandbox or use an existing one |
 | `code_sandbox_id` | str \| None | `None` | The kernel ID to use |

--- a/docs/sourcey/configuration.md
+++ b/docs/sourcey/configuration.md
@@ -10,7 +10,7 @@ All runtime settings live on the `JupyterMCPConfig` pydantic model ([`jupyter_mc
 | Setting | Type | Default | Description |
 | --- | --- | --- | --- |
 | `transport` | str | `"stdio"` | The transport to use for the MCP server |
-| `document_provider` | str | `"jupyter"` | Which backend holds the notebook documents |
+| `document_provider` | str | `"jupyter"` | Which backend holds the notebook documents: 'jupyter' or 'datalayer' |
 | `code_sandbox_url` | str | `"http://localhost:8888"` | The code sandbox URL to use, or 'local' for direct serverapp access |
 | `start_new_code_sandbox` | bool | `false` | Start a new code sandbox or use an existing one |
 | `code_sandbox_id` | str \| None | `None` | The kernel ID to use |

--- a/docs/sourcey/mcp.json
+++ b/docs/sourcey/mcp.json
@@ -891,7 +891,7 @@
             "description": "Jupyter server authentication token",
             "title": "Jupyter Token"
           },
-          "provider": {
+          "document_provider": {
             "default": "jupyter",
             "description": "Provider type",
             "title": "Provider",

--- a/docs/sourcey/mcp.json
+++ b/docs/sourcey/mcp.json
@@ -893,8 +893,8 @@
           },
           "document_provider": {
             "default": "jupyter",
-            "description": "Provider type",
-            "title": "Provider",
+            "description": "Which backend holds the notebook documents",
+            "title": "Document Provider",
             "type": "string"
           }
         },

--- a/docs/sourcey/tools/connect_to_jupyter.md
+++ b/docs/sourcey/tools/connect_to_jupyter.md
@@ -25,7 +25,7 @@ Example usage:
 | --- | --- | --- | --- | --- |
 | `jupyter_url` | string | yes | — | Jupyter server URL to connect to (e.g., 'http://localhost:8888') |
 | `jupyter_token` | string \| null | no | `null` | Jupyter server authentication token |
-| `provider` | string | no | `"jupyter"` | Provider type |
+| `document_provider` | string | no | `"jupyter"` | Which backend holds the notebook documents |
 
 ## Output
 
@@ -58,14 +58,14 @@ Example usage:
     "arguments": {
       "jupyter_url": "<jupyter_url>",
       "jupyter_token": null,
-      "provider": "jupyter"
+      "document_provider": "jupyter"
     }
   }
 }
 ```
 
 ```python
-result = await session.call_tool("connect_to_jupyter", arguments={"jupyter_url": "<jupyter_url>", "jupyter_token": None, "provider": "jupyter"})
+result = await session.call_tool("connect_to_jupyter", arguments={"jupyter_url": "<jupyter_url>", "jupyter_token": None, "document_provider": "jupyter"})
 ```
 
 ## Source

--- a/jupyter_mcp_server/__version__.py
+++ b/jupyter_mcp_server/__version__.py
@@ -4,4 +4,4 @@
 
 """Jupyter MCP Server."""
 
-__version__ = "1.3.1"
+__version__ = "1.3.2"

--- a/jupyter_mcp_server/cli/cli.py
+++ b/jupyter_mcp_server/cli/cli.py
@@ -6,7 +6,7 @@
 
 import typer
 
-from jupyter_mcp_server.cli.commands.connect import Provider, connect_command
+from jupyter_mcp_server.cli.commands.connect import DocumentProvider, connect_command
 from jupyter_mcp_server.cli.commands.serve import server_callback, start_command
 from jupyter_mcp_server.cli.commands.stop import stop_command
 
@@ -27,7 +27,7 @@ def serve() -> None:
 
 
 __all__ = [
-    "Provider",
+    "DocumentProvider",
     "app",
     "connect_command",
     "serve",

--- a/jupyter_mcp_server/cli/commands/__init__.py
+++ b/jupyter_mcp_server/cli/commands/__init__.py
@@ -4,12 +4,12 @@
 
 """Typer CLI command modules."""
 
-from jupyter_mcp_server.cli.commands.connect import Provider, connect_command
+from jupyter_mcp_server.cli.commands.connect import DocumentProvider, connect_command
 from jupyter_mcp_server.cli.commands.serve import server_callback, start_command
 from jupyter_mcp_server.cli.commands.stop import stop_command
 
 __all__ = [
-    "Provider",
+    "DocumentProvider",
     "connect_command",
     "server_callback",
     "start_command",

--- a/jupyter_mcp_server/cli/commands/connect.py
+++ b/jupyter_mcp_server/cli/commands/connect.py
@@ -55,7 +55,7 @@ def connect_command(
         DocumentProvider,
         typer.Option(
             "--document-provider",
-            # `--provider` / PROVIDER stay accepted: they named this before 1.3.
+            # `--provider` / PROVIDER stay accepted: they named this before v1.3.2.
             "--provider",
             envvar=["DOCUMENT_PROVIDER", "PROVIDER"],
         ),

--- a/jupyter_mcp_server/cli/commands/connect.py
+++ b/jupyter_mcp_server/cli/commands/connect.py
@@ -20,7 +20,7 @@ from jupyter_mcp_server.utils import (
 )
 
 
-class Provider(str, Enum):
+class DocumentProvider(str, Enum):
     jupyter = "jupyter"
     datalayer = "datalayer"
 
@@ -51,10 +51,15 @@ def connect_command(
             help="The URL of the Jupyter MCP Server to connect to. Defaults to 'http://localhost:4040'.",
         ),
     ] = "http://localhost:4040",
-    provider: Annotated[
-        Provider,
-        typer.Option("--provider", envvar="PROVIDER"),
-    ] = Provider.jupyter,
+    document_provider: Annotated[
+        DocumentProvider,
+        typer.Option(
+            "--document-provider",
+            # `--provider` / PROVIDER stay accepted: they named this before 1.3.
+            "--provider",
+            envvar=["DOCUMENT_PROVIDER", "PROVIDER"],
+        ),
+    ] = DocumentProvider.jupyter,
     jupyterlab: Annotated[
         str,
         typer.Option("--jupyterlab", envvar="JUPYTERLAB"),
@@ -148,7 +153,7 @@ def connect_command(
     )
 
     config = set_config(
-        provider=provider.value,
+        document_provider=document_provider.value,
         code_sandbox_url=resolved_code_sandbox_url,
         code_sandbox_id=code_sandbox_id,
         code_sandbox_token=resolved_code_sandbox_token,
@@ -163,7 +168,7 @@ def connect_command(
 
     config = get_config()
     document_code_sandbox = DocumentCodeSandbox(
-        provider=config.provider,
+        document_provider=config.document_provider,
         code_sandbox_url=config.code_sandbox_url,
         code_sandbox_id=config.code_sandbox_id,
         code_sandbox_token=config.code_sandbox_token,

--- a/jupyter_mcp_server/cli/commands/serve.py
+++ b/jupyter_mcp_server/cli/commands/serve.py
@@ -9,7 +9,7 @@ from typing import Annotated
 
 import typer
 
-from jupyter_mcp_server.cli.commands.connect import Provider
+from jupyter_mcp_server.cli.commands.connect import DocumentProvider
 from jupyter_mcp_server.utils import (
     do_start,
     parse_bool_option,
@@ -41,7 +41,7 @@ def _resolve_and_start(
     jupyter_token: str | None,
     jupyter_password: str | None,
     port: int,
-    provider: str,
+    document_provider: str,
     jupyterlab: str,
     open_notebook_in_ui: str,
     allowed_jupyter_mcp_tools: str,
@@ -87,7 +87,7 @@ def _resolve_and_start(
         document_token=resolved_document_token,
         document_password=resolved_document_password,
         port=port,
-        provider=provider,
+        document_provider=document_provider,
         jupyterlab=parse_bool_option(jupyterlab, "--jupyterlab"),
         open_notebook_in_ui=parse_bool_option(open_notebook_in_ui, "--open-notebook-in-ui"),
         allowed_jupyter_mcp_tools=allowed_jupyter_mcp_tools,
@@ -139,14 +139,21 @@ def server_callback(
             help="Path to JSONL file for OpenTelemetry span export.",
         ),
     ] = "",
-    provider: Annotated[
-        Provider,
+    document_provider: Annotated[
+        DocumentProvider,
         typer.Option(
+            "--document-provider",
+            # `--provider` / PROVIDER stay accepted: they named this before 1.3.
             "--provider",
-            envvar="PROVIDER",
-            help="The provider to use for the document and code sandbox. Defaults to 'jupyter'.",
+            envvar=["DOCUMENT_PROVIDER", "PROVIDER"],
+            help=(
+                "Which backend holds the notebook documents. `jupyter` talks to "
+                "the collaboration API of a Jupyter Server, `datalayer` to the "
+                "Datalayer spacer. Execution is chosen separately with "
+                "--sandbox-variant. Defaults to 'jupyter'."
+            ),
         ),
-    ] = Provider.jupyter,
+    ] = DocumentProvider.jupyter,
     jupyterlab: Annotated[
         str,
         typer.Option(
@@ -168,7 +175,7 @@ def server_callback(
         typer.Option(
             "--code-sandbox-url",
             envvar="CODE_SANDBOX_URL",
-            help="The code sandbox URL to use. For the jupyter provider, this is the Jupyter server URL. For the datalayer provider, this is the Datalayer code sandbox URL.",
+            help="The code sandbox URL to use. With the jupyter document backend, this is the Jupyter server URL. With the datalayer one, this is the Datalayer code sandbox URL.",
         ),
     ] = None,
     code_sandbox_id: Annotated[
@@ -184,7 +191,7 @@ def server_callback(
         typer.Option(
             "--code-sandbox-token",
             envvar="CODE_SANDBOX_TOKEN",
-            help="The code sandbox token to use for authentication with the provider. If not provided, the provider should accept anonymous requests.",
+            help="The code sandbox token to use for authentication with the backend. If not provided, the backend should accept anonymous requests.",
         ),
     ] = None,
     code_sandbox_password: Annotated[
@@ -216,7 +223,7 @@ def server_callback(
         typer.Option(
             "--document-url",
             envvar="DOCUMENT_URL",
-            help="The document URL to use. For the jupyter provider, this is the Jupyter server URL. For the datalayer provider, this is the Datalayer document URL.",
+            help="The document URL to use. With the jupyter document backend, this is the Jupyter server URL. With the datalayer one, this is the Datalayer document URL.",
         ),
     ] = None,
     document_id: Annotated[
@@ -224,7 +231,7 @@ def server_callback(
         typer.Option(
             "--document-id",
             envvar="DOCUMENT_ID",
-            help="The document id to use. For the jupyter provider, this is the notebook path. For the datalayer provider, this is the notebook path. Optional - if omitted, you can list and select notebooks interactively.",
+            help="The document id to use. With the jupyter document backend, this is the notebook path. With the datalayer one, this is the notebook path. Optional - if omitted, you can list and select notebooks interactively.",
         ),
     ] = None,
     document_token: Annotated[
@@ -232,7 +239,7 @@ def server_callback(
         typer.Option(
             "--document-token",
             envvar="DOCUMENT_TOKEN",
-            help="The document token to use for authentication with the provider. If not provided, the provider should accept anonymous requests.",
+            help="The document token to use for authentication with the backend. If not provided, the backend should accept anonymous requests.",
         ),
     ] = None,
     document_password: Annotated[
@@ -368,7 +375,7 @@ def server_callback(
         jupyter_token=jupyter_token,
         jupyter_password=jupyter_password,
         port=port,
-        provider=provider.value,
+        document_provider=document_provider.value,
         jupyterlab=jupyterlab,
         open_notebook_in_ui=open_notebook_in_ui,
         allowed_jupyter_mcp_tools=allowed_jupyter_mcp_tools,
@@ -417,14 +424,21 @@ def start_command(
             help="Path to JSONL file for OpenTelemetry span export.",
         ),
     ] = "",
-    provider: Annotated[
-        Provider,
+    document_provider: Annotated[
+        DocumentProvider,
         typer.Option(
+            "--document-provider",
+            # `--provider` / PROVIDER stay accepted: they named this before 1.3.
             "--provider",
-            envvar="PROVIDER",
-            help="The provider to use for the document and code sandbox. Defaults to 'jupyter'.",
+            envvar=["DOCUMENT_PROVIDER", "PROVIDER"],
+            help=(
+                "Which backend holds the notebook documents. `jupyter` talks to "
+                "the collaboration API of a Jupyter Server, `datalayer` to the "
+                "Datalayer spacer. Execution is chosen separately with "
+                "--sandbox-variant. Defaults to 'jupyter'."
+            ),
         ),
-    ] = Provider.jupyter,
+    ] = DocumentProvider.jupyter,
     jupyterlab: Annotated[
         str,
         typer.Option(
@@ -446,7 +460,7 @@ def start_command(
         typer.Option(
             "--code-sandbox-url",
             envvar="CODE_SANDBOX_URL",
-            help="The code sandbox URL to use. For the jupyter provider, this is the Jupyter server URL. For the datalayer provider, this is the Datalayer code sandbox URL.",
+            help="The code sandbox URL to use. With the jupyter document backend, this is the Jupyter server URL. With the datalayer one, this is the Datalayer code sandbox URL.",
         ),
     ] = None,
     code_sandbox_id: Annotated[
@@ -462,7 +476,7 @@ def start_command(
         typer.Option(
             "--code-sandbox-token",
             envvar="CODE_SANDBOX_TOKEN",
-            help="The code sandbox token to use for authentication with the provider. If not provided, the provider should accept anonymous requests.",
+            help="The code sandbox token to use for authentication with the backend. If not provided, the backend should accept anonymous requests.",
         ),
     ] = None,
     code_sandbox_password: Annotated[
@@ -494,7 +508,7 @@ def start_command(
         typer.Option(
             "--document-url",
             envvar="DOCUMENT_URL",
-            help="The document URL to use. For the jupyter provider, this is the Jupyter server URL. For the datalayer provider, this is the Datalayer document URL.",
+            help="The document URL to use. With the jupyter document backend, this is the Jupyter server URL. With the datalayer one, this is the Datalayer document URL.",
         ),
     ] = None,
     document_id: Annotated[
@@ -502,7 +516,7 @@ def start_command(
         typer.Option(
             "--document-id",
             envvar="DOCUMENT_ID",
-            help="The document id to use. For the jupyter provider, this is the notebook path. For the datalayer provider, this is the notebook path. Optional - if omitted, you can list and select notebooks interactively.",
+            help="The document id to use. With the jupyter document backend, this is the notebook path. With the datalayer one, this is the notebook path. Optional - if omitted, you can list and select notebooks interactively.",
         ),
     ] = None,
     document_token: Annotated[
@@ -510,7 +524,7 @@ def start_command(
         typer.Option(
             "--document-token",
             envvar="DOCUMENT_TOKEN",
-            help="The document token to use for authentication with the provider. If not provided, the provider should accept anonymous requests.",
+            help="The document token to use for authentication with the backend. If not provided, the backend should accept anonymous requests.",
         ),
     ] = None,
     document_password: Annotated[
@@ -643,7 +657,7 @@ def start_command(
         jupyter_token=jupyter_token,
         jupyter_password=jupyter_password,
         port=port,
-        provider=provider.value,
+        document_provider=document_provider.value,
         jupyterlab=jupyterlab,
         open_notebook_in_ui=open_notebook_in_ui,
         allowed_jupyter_mcp_tools=allowed_jupyter_mcp_tools,

--- a/jupyter_mcp_server/cli/commands/serve.py
+++ b/jupyter_mcp_server/cli/commands/serve.py
@@ -143,7 +143,7 @@ def server_callback(
         DocumentProvider,
         typer.Option(
             "--document-provider",
-            # `--provider` / PROVIDER stay accepted: they named this before 1.3.
+            # `--provider` / PROVIDER stay accepted: they named this before v1.3.2.
             "--provider",
             envvar=["DOCUMENT_PROVIDER", "PROVIDER"],
             help=(
@@ -428,7 +428,7 @@ def start_command(
         DocumentProvider,
         typer.Option(
             "--document-provider",
-            # `--provider` / PROVIDER stay accepted: they named this before 1.3.
+            # `--provider` / PROVIDER stay accepted: they named this before v1.3.2.
             "--provider",
             envvar=["DOCUMENT_PROVIDER", "PROVIDER"],
             help=(

--- a/jupyter_mcp_server/config.py
+++ b/jupyter_mcp_server/config.py
@@ -13,9 +13,10 @@ class JupyterMCPConfig(BaseModel):
     # Transport configuration
     transport: str = Field(default="stdio", description="The transport to use for the MCP server")
 
-    # Provider configuration
-    provider: str = Field(
-        default="jupyter", description="The provider to use for the document and code sandbox"
+    # Document backend configuration
+    document_provider: str = Field(
+        default="jupyter",
+        description="Which backend holds the notebook documents: 'jupyter' or 'datalayer'",
     )
 
     # Code Sandbox configuration

--- a/jupyter_mcp_server/jupyter_extension/extension.py
+++ b/jupyter_mcp_server/jupyter_extension/extension.py
@@ -76,7 +76,11 @@ class JupyterMCPServerExtensionApp(ExtensionAppJinjaMixin, ExtensionApp):
         "", config=True, help="Authentication token for code sandbox server (if remote)"
     )
 
-    provider = Unicode("jupyter", config=True, help="Provider type for document/code sandbox")
+    document_provider = Unicode(
+        "jupyter",
+        config=True,
+        help="Which backend holds the notebook documents: 'jupyter' or 'datalayer'",
+    )
 
     jupyterlab = Bool(True, config=True, help="Enable JupyterLab mode (defaults to True)")
 
@@ -145,7 +149,7 @@ class JupyterMCPServerExtensionApp(ExtensionAppJinjaMixin, ExtensionApp):
         config.code_sandbox_token = self.code_sandbox_token if self.code_sandbox_token else None
         config.start_new_code_sandbox = self.start_new_code_sandbox
         config.code_sandbox_id = self.code_sandbox_id if self.code_sandbox_id else None
-        config.provider = self.provider
+        config.document_provider = self.document_provider
         config.jupyterlab = self.jupyterlab
         config.open_notebook_in_ui = self.open_notebook_in_ui
         config.allowed_jupyter_mcp_tools = self.allowed_jupyter_mcp_tools
@@ -160,7 +164,7 @@ class JupyterMCPServerExtensionApp(ExtensionAppJinjaMixin, ExtensionApp):
                 "mcp_code_sandbox_token": self.code_sandbox_token,
                 "mcp_start_new_code_sandbox": self.start_new_code_sandbox,
                 "mcp_code_sandbox_id": self.code_sandbox_id,
-                "mcp_provider": self.provider,
+                "mcp_provider": self.document_provider,
                 "mcp_jupyterlab": self.jupyterlab,
                 "mcp_open_notebook_in_ui": self.open_notebook_in_ui,
                 "mcp_allowed_jupyter_mcp_tools": self.allowed_jupyter_mcp_tools,

--- a/jupyter_mcp_server/models.py
+++ b/jupyter_mcp_server/models.py
@@ -12,7 +12,7 @@ from jupyter_mcp_server.utils import normalize_cell_source, safe_extract_outputs
 class DocumentCodeSandbox(BaseModel):
     model_config = ConfigDict(populate_by_name=True)
 
-    # `provider` is what this field was called before 1.3; the /connect payload
+    # `provider` is what this field was called before v1.3.2; the /connect payload
     # of an older client still names it that way.
     document_provider: str = Field(validation_alias=AliasChoices("document_provider", "provider"))
     document_url: str | None = None

--- a/jupyter_mcp_server/models.py
+++ b/jupyter_mcp_server/models.py
@@ -4,13 +4,17 @@
 
 from typing import Annotated, Any, Literal
 
-from pydantic import BaseModel, Field
+from pydantic import AliasChoices, BaseModel, ConfigDict, Field
 
 from jupyter_mcp_server.utils import normalize_cell_source, safe_extract_outputs
 
 
 class DocumentCodeSandbox(BaseModel):
-    provider: str
+    model_config = ConfigDict(populate_by_name=True)
+
+    # `provider` is what this field was called before 1.3; the /connect payload
+    # of an older client still names it that way.
+    document_provider: str = Field(validation_alias=AliasChoices("document_provider", "provider"))
     document_url: str | None = None
     document_id: str
     document_token: str

--- a/jupyter_mcp_server/notebook_manager.py
+++ b/jupyter_mcp_server/notebook_manager.py
@@ -92,7 +92,7 @@ class NotebookConnection:
                 server_url=server_url,
                 token=token,
                 path=path,
-                provider=config.provider,
+                provider=config.document_provider,
                 headers=auth_headers or None,
             )
         except requests.HTTPError as error:
@@ -109,7 +109,7 @@ class NotebookConnection:
                 server_url=server_url,
                 token=token,
                 path=path,
-                provider=config.provider,
+                provider=config.document_provider,
                 headers=fresh_headers or None,
             )
 

--- a/jupyter_mcp_server/server.py
+++ b/jupyter_mcp_server/server.py
@@ -274,7 +274,7 @@ async def connect(request: Request):
     logger.info(
         f"Connect endpoint received - code_sandbox_url: {data.get('code_sandbox_url')!r}, "
         f"document_url: {data.get('document_url')!r}, "
-        f"provider: {data.get('provider')}"
+        f"document_provider: {data.get('document_provider')}"
     )
 
     document_code_sandbox = DocumentCodeSandbox(**data)
@@ -289,7 +289,7 @@ async def connect(request: Request):
     # Update configuration with new values
     # String "None" values will be automatically normalized by set_config()
     set_config(
-        provider=document_code_sandbox.provider,
+        document_provider=document_code_sandbox.document_provider,
         code_sandbox_url=document_code_sandbox.code_sandbox_url,
         code_sandbox_id=document_code_sandbox.code_sandbox_id,
         code_sandbox_token=document_code_sandbox.code_sandbox_token,
@@ -1124,7 +1124,9 @@ async def connect_to_jupyter(
     jupyter_token: Annotated[
         str | None, Field(description="Jupyter server authentication token")
     ] = None,
-    provider: Annotated[str, Field(description="Provider type")] = "jupyter",
+    document_provider: Annotated[
+        str, Field(description="Which backend holds the notebook documents")
+    ] = "jupyter",
 ) -> Annotated[str, Field(description="Connection status message")]:
     """Connect to a Jupyter server dynamically with URL and token.
 
@@ -1143,7 +1145,7 @@ async def connect_to_jupyter(
             mode=server_context.mode,
             jupyter_url=jupyter_url,
             jupyter_token=jupyter_token,
-            provider=provider,
+            document_provider=document_provider,
         )
     )
 

--- a/jupyter_mcp_server/tools/connect_jupyter_tool.py
+++ b/jupyter_mcp_server/tools/connect_jupyter_tool.py
@@ -20,7 +20,7 @@ class ConnectJupyterTool(BaseTool):
         mode: ServerMode,
         jupyter_url: str,
         jupyter_token: str | None = None,
-        provider: str = "jupyter",
+        document_provider: str = "jupyter",
         **kwargs,
     ) -> str:
         """Execute the connect to Jupyter server operation.
@@ -29,7 +29,7 @@ class ConnectJupyterTool(BaseTool):
             mode: ServerMode indicating MCP_SERVER or JUPYTER_SERVER
             jupyter_url: The Jupyter server URL to connect to
             jupyter_token: The Jupyter server token for authentication
-            provider: Provider type (default: "jupyter")
+            document_provider: DocumentProvider type (default: "jupyter")
             **kwargs: Additional keyword arguments
 
         Returns:
@@ -44,7 +44,7 @@ class ConnectJupyterTool(BaseTool):
         try:
             # Update configuration with new connection parameters
             set_config(
-                provider=provider,
+                document_provider=document_provider,
                 code_sandbox_url=jupyter_url,
                 code_sandbox_token=jupyter_token,
                 document_url=jupyter_url,
@@ -60,7 +60,7 @@ class ConnectJupyterTool(BaseTool):
             # Build connection info message
             connection_info = [
                 f"Successfully connected to Jupyter server: {jupyter_url}",
-                f"Provider: {provider}",
+                f"DocumentProvider: {document_provider}",
             ]
 
             if jupyter_token:

--- a/jupyter_mcp_server/utils.py
+++ b/jupyter_mcp_server/utils.py
@@ -226,7 +226,7 @@ def do_start(
     document_id: str,
     document_token: str,
     port: int,
-    provider: str,
+    document_provider: str,
     jupyterlab: bool,
     open_notebook_in_ui: bool,
     allowed_jupyter_mcp_tools: str,
@@ -264,13 +264,13 @@ def do_start(
 
     logger.info(
         f"Start command received - code_sandbox_url: {code_sandbox_url!r}, "
-        f"document_url: {document_url!r}, provider: {provider}, "
+        f"document_url: {document_url!r}, document_provider: {document_provider}, "
         f"transport: {transport}"
     )
 
     config = set_config(
         transport=transport,
-        provider=provider,
+        document_provider=document_provider,
         code_sandbox_url=code_sandbox_url,
         start_new_code_sandbox=start_new_code_sandbox,
         code_sandbox_id=code_sandbox_id,

--- a/mcpb/manifest.json
+++ b/mcpb/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": "0.4",
   "name": "jupyter-mcp-server",
   "display_name": "Jupyter MCP Server",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "description": "Connect AI agents to Jupyter Notebooks - execute code, manage notebooks, and interact with kernels in real-time",
   "long_description": "The Jupyter MCP Server enables AI agents like Claude to connect to and manage Jupyter Notebooks in real-time. It provides 14 tools to execute code, manage notebooks, read and write cells, and interact with Jupyter kernels through the standardized Model Context Protocol.\n\n**Requirements:** You need a running Jupyter server (JupyterLab or Jupyter Notebook) to connect to. Start one with:\n```\npip install jupyterlab\njupyter lab --port 8888 --IdentityProvider.token MY_TOKEN\n```",
   "author": {

--- a/mcpb/pyproject.toml
+++ b/mcpb/pyproject.toml
@@ -4,7 +4,7 @@
 
 [project]
 name = "jupyter-mcp-server-mcpb"
-version = "1.3.1"
+version = "1.3.2"
 description = "Jupyter MCP Server - MCPB bundle for one-click installation in Claude Desktop"
 requires-python = ">=3.10"
 dependencies = [

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -860,7 +860,7 @@ class TestNotebookConnectionAuth:
             code_sandbox_url="http://localhost:8888",
             document_url="http://localhost:8888",
             code_sandbox_password="secret",
-            provider="jupyter",
+            document_provider="jupyter",
         )
 
         from jupyter_mcp_server.tools import ServerMode

--- a/tests/test_cli_typer.py
+++ b/tests/test_cli_typer.py
@@ -8,7 +8,7 @@ from unittest.mock import patch
 
 from typer.testing import CliRunner
 
-from jupyter_mcp_server.cli.cli import Provider, app, connect_command, stop_command
+from jupyter_mcp_server.cli.cli import DocumentProvider, app, connect_command, stop_command
 
 
 class _Response:
@@ -32,7 +32,7 @@ def test_typer_connect_command_sends_mcp_token():
     with patch("jupyter_mcp_server.cli.commands.connect.httpx.put", fake_put):
         connect_command(
             jupyter_mcp_server_url="http://localhost:4040",
-            provider=Provider.jupyter,
+            document_provider=DocumentProvider.jupyter,
             jupyterlab=True,
             open_notebook_in_ui=False,
             code_sandbox_url=None,

--- a/tests/test_cli_typer_config.py
+++ b/tests/test_cli_typer_config.py
@@ -12,7 +12,7 @@ import pytest
 from pydantic import ValidationError
 from typer.testing import CliRunner
 
-from jupyter_mcp_server.cli.cli import Provider, app, connect_command, stop_command
+from jupyter_mcp_server.cli.cli import DocumentProvider, app, connect_command, stop_command
 from jupyter_mcp_server.config import JupyterMCPConfig, get_config, reset_config, set_config
 from jupyter_mcp_server.utils import mcp_auth_headers, resolve_url_and_token_variables
 
@@ -68,7 +68,7 @@ def test_connect_command_sends_mcp_token():
     with patch("jupyter_mcp_server.cli.commands.connect.httpx.put", fake_put):
         connect_command(
             jupyter_mcp_server_url="http://localhost:4040",
-            provider=Provider.jupyter,
+            document_provider=DocumentProvider.jupyter,
             jupyterlab=True,
             open_notebook_in_ui=False,
             code_sandbox_url=None,
@@ -97,7 +97,7 @@ def test_connect_command_accepts_unset_document_url():
     with patch("jupyter_mcp_server.cli.commands.connect.httpx.put", fake_put):
         connect_command(
             jupyter_mcp_server_url="http://localhost:4040",
-            provider=Provider.jupyter,
+            document_provider=DocumentProvider.jupyter,
             jupyterlab=True,
             open_notebook_in_ui=False,
             code_sandbox_url="http://localhost:8888",
@@ -138,18 +138,18 @@ def test_config():
     config = get_config()
     assert config.code_sandbox_url == "http://localhost:8888"
     assert config.document_id is None
-    assert config.provider == "jupyter"
+    assert config.document_provider == "jupyter"
 
     new_config = set_config(
         code_sandbox_url="http://localhost:9999",
         document_id="test_notebooks.ipynb",
-        provider="datalayer",
+        document_provider="datalayer",
         code_sandbox_token="test_token",
     )
 
     assert new_config.code_sandbox_url == "http://localhost:9999"
     assert new_config.document_id == "test_notebooks.ipynb"
-    assert new_config.provider == "datalayer"
+    assert new_config.document_provider == "datalayer"
 
     config2 = get_config()
     assert config2.code_sandbox_url == "http://localhost:9999"
@@ -159,7 +159,7 @@ def test_config():
     config3 = get_config()
     assert config3.code_sandbox_url == "http://localhost:8888"
     assert config3.document_id is None
-    assert config3.provider == "jupyter"
+    assert config3.document_provider == "jupyter"
 
 
 def test_allowed_jupyter_mcp_tools_config():


### PR DESCRIPTION
Renames provider to document_provider, so that the name says what the option actually selects.

It only ever chose where the notebook documents live — jupyter for the collaboration API of a Jupyter Server, datalayer for the Datalayer spacer. Where the code runs is a separate choice, made with --sandbox-variant. The old name, and its help text, suggested one option governed both.

Nothing breaks in 1.3.2
The former names are deprecated, not removed. --provider is still accepted as an alias, PROVIDER is still read, and a /connect payload carrying "provider" is still understood. Migrate when convenient.

Who Should Migrate
End users passing --provider or setting PROVIDER, which in practice means anyone pointing the server at Datalayer-hosted documents.
Operators whose manifests, wrapper scripts or MCP client configurations carry PROVIDER.
Anyone calling the /connect endpoint or the connect_to_jupyter tool with a provider field.
Change Summary
Use document_provider names everywhere instead of provider names.
The accepted values are unchanged: jupyter (default) and datalayer.
Execution backends keep their own option, --sandbox-variant / SANDBOX_VARIANT.
Nothing has to change immediately: the old names still work in this version.
