### PR TITLE
fix: start local kernels in notebook directory

### DIFF
--- a/jupyter_mcp_server/tools/execute_cell_tool.py
+++ b/jupyter_mcp_server/tools/execute_cell_tool.py
@@ -84,10 +84,10 @@ class ExecuteCellTool(BaseTool):
             return True
 
     async def _start_and_bind_kernel(
-        self, kernel_manager, notebook_manager, notebook_path: str
+        self, kernel_manager, notebook_manager, notebook_path: str | None
     ) -> str:
         """Start a kernel and rebind it to the current notebook in local mode."""
-        kernel_id = await kernel_manager.start_kernel()
+        kernel_id = await kernel_manager.start_kernel(path=notebook_path)
         await asyncio.sleep(1.0)
         logger.info(f"Kernel {kernel_id} started and initialized")
 
@@ -257,8 +257,10 @@ class ExecuteCellTool(BaseTool):
             if kernel_manager is None:
                 raise ValueError("kernel_manager is required for JUPYTER_SERVER mode")
 
-            # Get notebook_path and kernel_id first
+            # Preserve the root-relative API path for kernel creation, then resolve
+            # a separate filesystem path for file and YDoc operations below.
             notebook_path, kernel_id = get_current_notebook_context(notebook_manager)
+            notebook_api_path = notebook_path
 
             # Resolve to absolute path
             if notebook_path and serverapp and not Path(notebook_path).is_absolute():
@@ -270,7 +272,7 @@ class ExecuteCellTool(BaseTool):
             if kernel_id is None:
                 logger.info("No kernel_id available, starting new kernel for execute_cell")
                 kernel_id = await self._start_and_bind_kernel(
-                    kernel_manager, notebook_manager, notebook_path
+                    kernel_manager, notebook_manager, notebook_api_path
                 )
             elif not await self._kernel_exists(kernel_manager, kernel_id):
                 logger.info(
@@ -278,7 +280,7 @@ class ExecuteCellTool(BaseTool):
                     kernel_id,
                 )
                 kernel_id = await self._start_and_bind_kernel(
-                    kernel_manager, notebook_manager, notebook_path
+                    kernel_manager, notebook_manager, notebook_api_path
                 )
 
             logger.info(
@@ -340,7 +342,7 @@ class ExecuteCellTool(BaseTool):
                             kernel_id,
                         )
                         kernel_id = await self._start_and_bind_kernel(
-                            kernel_manager, notebook_manager, notebook_path
+                            kernel_manager, notebook_manager, notebook_api_path
                         )
                         outputs = await execute_via_execution_stack(
                             serverapp=serverapp,
@@ -398,7 +400,7 @@ class ExecuteCellTool(BaseTool):
                             kernel_id,
                         )
                         kernel_id = await self._start_and_bind_kernel(
-                            kernel_manager, notebook_manager, notebook_path
+                            kernel_manager, notebook_manager, notebook_api_path
                         )
                         raw_outputs = []
                         execution_count_out = []

--- a/jupyter_mcp_server/tools/use_notebook_tool.py
+++ b/jupyter_mcp_server/tools/use_notebook_tool.py
@@ -27,7 +27,7 @@ class UseNotebookTool(BaseTool):
 
     async def _start_kernel_local(self, kernel_manager: Any, path: str | None = None):
         # Start a new kernel using local API
-        kernel_id = await kernel_manager.start_kernel()
+        kernel_id = await kernel_manager.start_kernel(path=path)
         logger.info(f"Started kernel '{kernel_id}', waiting for it to be ready...")
 
         # CRITICAL: Wait for the kernel to actually start and be ready

--- a/tests/test_execute_cell_kernel_start_path.py
+++ b/tests/test_execute_cell_kernel_start_path.py
@@ -4,6 +4,7 @@
 
 """Regression test for local kernel reprovisioning working directories."""
 
+from pathlib import Path
 from types import SimpleNamespace
 
 import nbformat
@@ -95,5 +96,8 @@ async def test_reprovisioned_kernel_uses_notebook_api_path_not_absolute_file_pat
     )
 
     assert kernel_manager.started_paths == ["projects/demo/notebook.ipynb"]
-    assert file_id_manager.paths == ["/srv/notebooks/projects/demo/notebook.ipynb"]
-    assert read_paths == ["/srv/notebooks/projects/demo/notebook.ipynb"]
+    filesystem_notebook_path = str(
+        Path("/srv/notebooks") / "projects/demo/notebook.ipynb"
+    )
+    assert file_id_manager.paths == [filesystem_notebook_path]
+    assert read_paths == [filesystem_notebook_path]

--- a/tests/test_execute_cell_kernel_start_path.py
+++ b/tests/test_execute_cell_kernel_start_path.py
@@ -1,0 +1,99 @@
+# Copyright (c) 2024- Datalayer, Inc.
+#
+# BSD 3-Clause License
+
+"""Regression test for local kernel reprovisioning working directories."""
+
+from types import SimpleNamespace
+
+import nbformat
+import pytest
+
+from jupyter_mcp_server.notebook_manager import NotebookManager
+from jupyter_mcp_server.tools._base import ServerMode
+from jupyter_mcp_server.tools.execute_cell_tool import ExecuteCellTool
+
+
+class RecordingKernelManager:
+    """Minimal local kernel manager that records the requested working directory."""
+
+    def __init__(self):
+        self.started_paths = []
+
+    async def start_kernel(self, path=None):
+        self.started_paths.append(path)
+        return "kernel-1"
+
+
+class FileIdManager:
+    def __init__(self):
+        self.paths = []
+
+    def get_id(self, path):
+        self.paths.append(path)
+        return "file-id"
+
+    def index(self, _path):
+        return "file-id"
+
+
+@pytest.mark.asyncio
+async def test_reprovisioned_kernel_uses_notebook_api_path_not_absolute_file_path(monkeypatch):
+    """A replacement kernel receives the root-relative Jupyter notebook path."""
+    async def no_sleep(_seconds):
+        return None
+
+    async def no_ydoc(_serverapp, _file_id):
+        return None
+
+    async def no_outputs(*_args, **_kwargs):
+        return None
+
+    async def empty_execution(**_kwargs):
+        return []
+
+    read_paths = []
+
+    async def read_notebook(path):
+        read_paths.append(path)
+        return nbformat.v4.new_notebook(cells=[nbformat.v4.new_code_cell("1 + 1")])
+
+    file_id_manager = FileIdManager()
+    serverapp = SimpleNamespace(
+        root_dir="/srv/notebooks",
+        web_app=SimpleNamespace(settings={"file_id_manager": file_id_manager}),
+    )
+    monkeypatch.setattr(
+        "jupyter_mcp_server.jupyter_extension.context.get_server_context",
+        lambda: SimpleNamespace(serverapp=serverapp),
+    )
+    monkeypatch.setattr(
+        "jupyter_mcp_server.tools.execute_cell_tool.get_current_notebook_context",
+        lambda _manager: ("projects/demo/notebook.ipynb", None),
+    )
+    monkeypatch.setattr("jupyter_mcp_server.tools.execute_cell_tool.asyncio.sleep", no_sleep)
+    monkeypatch.setattr("jupyter_mcp_server.tools.execute_cell_tool.get_jupyter_ydoc", no_ydoc)
+    monkeypatch.setattr(
+        "jupyter_mcp_server.tools.execute_cell_tool.execute_via_execution_stack",
+        empty_execution,
+    )
+    monkeypatch.setattr(ExecuteCellTool, "_write_outputs_to_cell", no_outputs)
+
+    tool = ExecuteCellTool()
+    monkeypatch.setattr(
+        tool,
+        "_read_notebook_file_with_retry",
+        read_notebook,
+    )
+    kernel_manager = RecordingKernelManager()
+
+    await tool.execute(
+        mode=ServerMode.JUPYTER_SERVER,
+        kernel_manager=kernel_manager,
+        notebook_manager=NotebookManager(),
+        cell_index=0,
+    )
+
+    assert kernel_manager.started_paths == ["projects/demo/notebook.ipynb"]
+    assert file_id_manager.paths == ["/srv/notebooks/projects/demo/notebook.ipynb"]
+    assert read_paths == ["/srv/notebooks/projects/demo/notebook.ipynb"]

--- a/tests/test_use_notebook_create_local.py
+++ b/tests/test_use_notebook_create_local.py
@@ -39,9 +39,11 @@ class RecordingKernelManager:
 
     def __init__(self, events):
         self.events = events
+        self.start_kernel_calls = []
 
-    async def start_kernel(self):
+    async def start_kernel(self, path=None):
         self.events.append("start_kernel")
+        self.start_kernel_calls.append(path)
         return "kernel-1"
 
     def get_kernel(self, kernel_id):
@@ -103,3 +105,24 @@ async def test_create_writes_the_notebook_before_starting_a_session_on_it():
 
     assert events.index("new") < events.index("create_session")
     assert events.index("new") < events.index("start_kernel")
+
+
+@pytest.mark.asyncio
+async def test_create_starts_the_kernel_in_the_notebook_directory():
+    """Nested notebooks need a matching kernel working directory so relative
+    paths resolve beside the notebook rather than at the server root."""
+    events = []
+    kernel_manager = RecordingKernelManager(events)
+
+    await UseNotebookTool().execute(
+        mode=ServerMode.JUPYTER_SERVER,
+        contents_manager=RecordingContentsManager(events),
+        kernel_manager=kernel_manager,
+        session_manager=RecordingSessionManager(events),
+        notebook_manager=NotebookManager(),
+        notebook_name="nested",
+        notebook_path="projects/demo/notebook.ipynb",
+        use_mode="create",
+    )
+
+    assert kernel_manager.start_kernel_calls == ["projects/demo/notebook.ipynb"]


### PR DESCRIPTION
## Summary
- forward the selected notebook path to the local kernel manager
- add a regression test for creating a nested notebook in JUPYTER_SERVER mode

Fixes #356

## Validation
- `python3 -m pytest tests/test_use_notebook_create_local.py::test_create_starts_the_kernel_in_the_notebook_directory -q`
- `python3 -m pytest tests/test_use_notebook_create_local.py -q`
- `ruff check jupyter_mcp_server/tools/use_notebook_tool.py tests/test_use_notebook_create_local.py` (the file has pre-existing violations; no changed-line violations)
- `make test` was exercised after installing the optional sandbox extension: 473 passed; 3 failures and 4 errors in pre-existing Jupyter extension/UI tests unrelated to this patch.