### PR TITLE
fix(tool_cache): do not cache an empty tool list from a transient fetch failure

### DIFF
--- a/jupyter_mcp_server/tool_cache.py
+++ b/jupyter_mcp_server/tool_cache.py
@@ -106,6 +106,13 @@ class ToolCache:
                 base_url=base_url, token=token, query=query, enabled_only=enabled_only
             )
 
+            # jupyter-mcp-tools returns [] rather than raising when the JupyterLab
+            # extension has not registered its tools yet (HTTP 503), on a timeout, or
+            # on a connection error, so an empty result is transient here.
+            if not fresh_data:
+                logger.debug(f"Not caching empty tool list for key {cache_key}")
+                return fresh_data
+
             # Store in cache
             async with self._lock:
                 self._cache[cache_key] = CacheEntry(data=fresh_data, timestamp=time.time())

--- a/tests/test_tool_cache_empty_result.py
+++ b/tests/test_tool_cache_empty_result.py
@@ -1,0 +1,78 @@
+# Copyright (c) 2024- Datalayer, Inc.
+#
+# BSD 3-Clause License
+
+"""Unit tests for ToolCache's handling of an empty tool list.
+
+jupyter-mcp-tools returns [] rather than raising when the JupyterLab extension has
+not registered its tools yet (HTTP 503), when the request times out, or on a
+connection error. Caching that empty list would pin a transient failure for the
+whole TTL. These tests use a fake fetch function, so no running Jupyter server and
+no jupyter-mcp-tools installation are required.
+"""
+
+import pytest
+
+from jupyter_mcp_server.tool_cache import ToolCache
+
+BASE_URL = "http://localhost:8888"
+TOKEN = "test-token"
+QUERY = "notebook_run-cell"
+
+TOOLS = [
+    {"id": "notebook_run-cell", "label": "Run Cell", "enabled": True},
+    {"id": "notebook_insert-cell", "label": "Insert Cell", "enabled": True},
+]
+
+
+class RecordingFetch:
+    """A jupyter_mcp_tools.get_tools stand-in that returns a scripted result per call
+    and counts how many times the backend was actually asked."""
+
+    def __init__(self, *results):
+        self._results = list(results)
+        self.calls = 0
+
+    async def __call__(self, **kwargs):
+        self.calls += 1
+        return self._results.pop(0) if self._results else []
+
+
+@pytest.mark.asyncio
+async def test_empty_result_is_not_cached_and_next_call_refetches():
+    """A transient failure returns [], and the next call must reach the backend
+    again rather than serving the empty list from cache."""
+    cache = ToolCache(default_ttl=300)
+    fetch = RecordingFetch([], TOOLS)
+
+    first = await cache.get_tools(
+        base_url=BASE_URL, token=TOKEN, query=QUERY, fetch_func=fetch
+    )
+    assert first == []
+    assert cache.get_cache_stats()["total_entries"] == 0
+
+    second = await cache.get_tools(
+        base_url=BASE_URL, token=TOKEN, query=QUERY, fetch_func=fetch
+    )
+    assert second == TOOLS
+    assert fetch.calls == 2
+
+
+@pytest.mark.asyncio
+async def test_non_empty_result_is_still_cached():
+    """The caching behaviour itself is unchanged: a real answer is stored and the
+    second call is served without asking the backend again."""
+    cache = ToolCache(default_ttl=300)
+    fetch = RecordingFetch(TOOLS, TOOLS)
+
+    first = await cache.get_tools(
+        base_url=BASE_URL, token=TOKEN, query=QUERY, fetch_func=fetch
+    )
+    second = await cache.get_tools(
+        base_url=BASE_URL, token=TOKEN, query=QUERY, fetch_func=fetch
+    )
+
+    assert first == TOOLS
+    assert second == TOOLS
+    assert fetch.calls == 1
+    assert cache.get_cache_stats()["total_entries"] == 1


### PR DESCRIPTION
Fixes #366.

`ToolCache.get_tools` stored whatever `fetch_func` returned, including an empty list.
`jupyter_mcp_tools.get_tools` returns `[]` rather than raising when the JupyterLab extension has
not registered its tools yet (HTTP 503), when the request times out, or on a connection error,
so a transient failure was cached as if it were an answer and the server reported zero Jupyter
tools until the entry expired. The `except Exception` branch already declines to cache a
failure; these three simply do not raise.

The fix skips the cache write when the result is empty. The trade-off is that a persistent
outage now refetches on every call rather than once per TTL. The handler path already bounds
that with `wait_timeout=5`. If you would rather have negative caching with a short TTL, say so
and I will rework it.

### Verification

Run on `e80b8c84` in a clean container.

Differential on the new tests, with the fix and with `tool_cache.py` reverted to HEAD:

```
WITH the fix     2 passed
WITHOUT the fix  1 failed, 1 passed
                 FAILED test_empty_result_is_not_cached_and_next_call_refetches
                 (log: "Cached 0 tools for key http://localhost:8888:notebook_run-cell")
```

End to end, with a stub HTTP backend answering 503 until the frontend registers and 200
afterwards, driven through `ToolCache` with the real `jupyter_mcp_tools.get_tools`:

```
t=0  extension has not registered its tools yet (-> 503)
     tools returned: [] ; cached with data=[]
t+2s frontend registers its tools (-> 200)
     control, calling jupyter_mcp_tools directly: 2 tools
     through ToolCache: []  (backend requests made by that call: 0)
```

Suite, excluding the three files that need a live `jupyter lab`
(`test_tools.py`, `test_jupyter_extension.py`, `test_execute_code_kernel_id.py`):

```
at HEAD        2 failed, 311 passed, 1 skipped, 73 errors
with this PR   2 failed, 313 passed, 1 skipped, 73 errors
```

The same 2 failures and 73 errors are present at HEAD without this change, so they are
pre-existing in that environment and not from this PR. The two added passes are the new tests.
I have not run the three excluded files, so the paths they cover are unverified here.

### Scenarios covered by tests

- an empty result is not cached, and the next call reaches the backend again
- a non-empty result is still cached, and the second call is served without a refetch
