### PR TITLE
fix(tool_cache): serve stale tools on a failed refresh and coalesce concurrent misses

### DIFF
--- a/jupyter_mcp_server/tool_cache.py
+++ b/jupyter_mcp_server/tool_cache.py
@@ -45,12 +45,40 @@ class ToolCache:
         self._cache: dict[str, CacheEntry] = {}
         self._default_ttl = default_ttl
         self._lock = asyncio.Lock()
+        # In-flight fetches, keyed the same way as _cache, so concurrent callers
+        # that miss on the same key share one call instead of each making their own.
+        self._inflight: dict[str, asyncio.Task] = {}
 
-    def _make_cache_key(self, base_url: str, query: str) -> str:
+    def _make_cache_key(self, base_url: str, query: str, enabled_only: bool = False) -> str:
         """Create a cache key from the request parameters."""
-        # Use a simplified key based on base_url and query
+        # Use a simplified key based on base_url, query and enabled_only.
+        # enabled_only changes which tools come back, so entries for the two
+        # values must not be shared.
         # Don't include token for security reasons
-        return f"{base_url}:{query}"
+        return f"{base_url}:{query}:{enabled_only}"
+
+    async def _fetch_and_store(
+        self,
+        cache_key: str,
+        fetch_func: Any,
+        base_url: str,
+        token: str,
+        query: str,
+        enabled_only: bool,
+    ) -> list[dict[str, Any]]:
+        """Fetch fresh data and store it. Only replaces the entry on success."""
+        try:
+            logger.info(f"Fetching fresh tools from jupyter-mcp-tools (query: '{query}')")
+            fresh_data = await fetch_func(
+                base_url=base_url, token=token, query=query, enabled_only=enabled_only
+            )
+            async with self._lock:
+                self._cache[cache_key] = CacheEntry(data=fresh_data, timestamp=time.time())
+            logger.info(f"Cached {len(fresh_data)} tools for key {cache_key}")
+            return fresh_data
+        finally:
+            async with self._lock:
+                self._inflight.pop(cache_key, None)
 
     async def get_tools(
         self,
@@ -75,47 +103,55 @@ class ToolCache:
         Returns:
             List of tool dictionaries
         """
-        cache_key = self._make_cache_key(base_url, query)
+        cache_key = self._make_cache_key(base_url, query, enabled_only)
         ttl = ttl_seconds or self._default_ttl
 
         async with self._lock:
-            # Check if we have a valid cache entry
-            if cache_key in self._cache:
-                entry = self._cache[cache_key]
-                if not entry.is_expired(ttl):
-                    logger.debug(
-                        f"Cache HIT for {cache_key} (age: {time.time() - entry.timestamp:.1f}s)"
-                    )
-                    return entry.data
-                else:
-                    logger.debug(
-                        f"Cache EXPIRED for {cache_key} (age: {time.time() - entry.timestamp:.1f}s)"
-                    )
-                    del self._cache[cache_key]
-            else:
-                logger.debug(f"Cache MISS for {cache_key}")
+            entry = self._cache.get(cache_key)
+            if entry is not None and not entry.is_expired(ttl):
+                logger.debug(
+                    f"Cache HIT for {cache_key} (age: {time.time() - entry.timestamp:.1f}s)"
+                )
+                return entry.data
 
-        # Cache miss or expired - fetch fresh data
-        if fetch_func is None:
-            logger.warning("No fetch function provided for cache miss - returning empty list")
-            return []
+            if entry is None:
+                logger.debug(f"Cache MISS for {cache_key}")
+            else:
+                logger.debug(
+                    f"Cache EXPIRED for {cache_key} (age: {time.time() - entry.timestamp:.1f}s)"
+                )
+
+            if fetch_func is None:
+                logger.warning("No fetch function provided for cache miss")
+                # An expired entry still beats nothing when we cannot refresh.
+                return entry.data if entry is not None else []
+
+            # Join an in-flight fetch for this key rather than starting another.
+            task = self._inflight.get(cache_key)
+            if task is None:
+                task = asyncio.create_task(
+                    self._fetch_and_store(
+                        cache_key, fetch_func, base_url, token, query, enabled_only
+                    )
+                )
+                self._inflight[cache_key] = task
 
         try:
-            logger.info(f"Fetching fresh tools from jupyter-mcp-tools (query: '{query}')")
-            fresh_data = await fetch_func(
-                base_url=base_url, token=token, query=query, enabled_only=enabled_only
-            )
-
-            # Store in cache
-            async with self._lock:
-                self._cache[cache_key] = CacheEntry(data=fresh_data, timestamp=time.time())
-
-            logger.info(f"Cached {len(fresh_data)} tools for key {cache_key}")
-            return fresh_data
-
+            return await task
         except Exception as e:
             logger.error(f"Failed to fetch tools from jupyter-mcp-tools: {e}")
-            # Return empty list on error to prevent cascading failures
+            # Serve the stale entry rather than dropping every tool because one
+            # refresh failed. A failed fetch is expected when the JupyterLab
+            # frontend is not loaded, and it should not empty the tool list.
+            async with self._lock:
+                stale = self._cache.get(cache_key)
+            if stale is not None:
+                logger.warning(
+                    f"Serving stale tools for {cache_key} "
+                    f"(age: {time.time() - stale.timestamp:.1f}s) after a failed refresh"
+                )
+                return stale.data
+            # Nothing cached yet, so there is nothing better to return.
             return []
 
     async def invalidate(self, base_url: str, query: str = None):
@@ -137,10 +173,12 @@ class ToolCache:
                 logger.info(f"Invalidated {len(keys_to_remove)} cache entries for {base_url}")
             else:
                 # Invalidate specific entry
-                cache_key = self._make_cache_key(base_url, query)
-                if cache_key in self._cache:
-                    del self._cache[cache_key]
-                    logger.info(f"Invalidated cache entry for {cache_key}")
+                prefix = f"{base_url}:{query}:"
+                keys_to_remove = [key for key in self._cache if key.startswith(prefix)]
+                for key in keys_to_remove:
+                    del self._cache[key]
+                if keys_to_remove:
+                    logger.info(f"Invalidated cache entry for {base_url}:{query}")
 
     async def clear(self):
         """Clear all cache entries."""

--- a/tests/test_tool_cache.py
+++ b/tests/test_tool_cache.py
@@ -1,0 +1,173 @@
+# Copyright (c) 2024- Datalayer, Inc.
+#
+# BSD 3-Clause License
+
+"""
+Tests for ToolCache.
+
+The cache exists to absorb an expensive and routinely-failing call: the
+handlers themselves note that a failed fetch is "normal if JupyterLab frontend
+is not loaded". These tests cover the two paths where it does not.
+
+Launch the tests:
+```
+$ pytest tests/test_tool_cache.py -v
+```
+"""
+
+import asyncio
+
+import pytest
+
+from jupyter_mcp_server.tool_cache import ToolCache
+
+BASE_URL = "http://localhost:8888"
+TOOLS = [{"id": "tool-a"}, {"id": "tool-b"}]
+
+
+class TestServeStaleOnFetchFailure:
+    """An expired entry must not be dropped until a refetch succeeds."""
+
+    @pytest.mark.asyncio
+    async def test_failed_refresh_keeps_serving_the_cached_tools(self):
+        calls = {"n": 0}
+
+        async def flaky_fetch(**kwargs):
+            calls["n"] += 1
+            if calls["n"] == 1:
+                return TOOLS
+            raise RuntimeError("frontend not loaded")
+
+        cache = ToolCache(default_ttl=1)
+
+        first = await cache.get_tools(
+            base_url=BASE_URL, token="t", query="q", fetch_func=flaky_fetch
+        )
+        assert len(first) == 2
+
+        await asyncio.sleep(1.1)  # let the entry expire
+
+        # The refresh fails. The previously cached tools are still the best
+        # answer available, and dropping them makes every tool disappear.
+        after = await cache.get_tools(
+            base_url=BASE_URL, token="t", query="q", fetch_func=flaky_fetch
+        )
+        assert len(after) == 2, "a failed refresh must not empty the tool list"
+
+    @pytest.mark.asyncio
+    async def test_failed_refresh_does_not_discard_the_entry(self):
+        calls = {"n": 0}
+
+        async def flaky_fetch(**kwargs):
+            calls["n"] += 1
+            if calls["n"] == 1:
+                return TOOLS
+            raise RuntimeError("frontend not loaded")
+
+        cache = ToolCache(default_ttl=1)
+        await cache.get_tools(base_url=BASE_URL, token="t", query="q", fetch_func=flaky_fetch)
+
+        await asyncio.sleep(1.1)
+        await cache.get_tools(base_url=BASE_URL, token="t", query="q", fetch_func=flaky_fetch)
+
+        assert cache.get_cache_stats()["total_entries"] == 1, (
+            "the entry was discarded before the refetch was known to work"
+        )
+
+    @pytest.mark.asyncio
+    async def test_successful_refresh_still_replaces_the_entry(self):
+        """Regression guard: a working refresh must return the new data."""
+        versions = [[{"id": "old"}], [{"id": "new"}]]
+
+        async def fetch(**kwargs):
+            return versions.pop(0)
+
+        cache = ToolCache(default_ttl=1)
+        first = await cache.get_tools(base_url=BASE_URL, token="t", query="q", fetch_func=fetch)
+        assert first == [{"id": "old"}]
+
+        await asyncio.sleep(1.1)
+        second = await cache.get_tools(base_url=BASE_URL, token="t", query="q", fetch_func=fetch)
+        assert second == [{"id": "new"}]
+
+    @pytest.mark.asyncio
+    async def test_first_ever_fetch_failure_still_returns_empty(self):
+        """With nothing cached there is nothing to fall back to."""
+
+        async def always_fails(**kwargs):
+            raise RuntimeError("frontend not loaded")
+
+        cache = ToolCache(default_ttl=300)
+        result = await cache.get_tools(
+            base_url=BASE_URL, token="t", query="q", fetch_func=always_fails
+        )
+        assert result == []
+
+
+class TestConcurrentMissCoalescing:
+    """Concurrent callers on a cold cache should share one fetch."""
+
+    @pytest.mark.asyncio
+    async def test_concurrent_cold_callers_share_one_fetch(self):
+        calls = {"n": 0}
+
+        async def slow_fetch(**kwargs):
+            calls["n"] += 1
+            await asyncio.sleep(0.05)
+            return TOOLS
+
+        cache = ToolCache(default_ttl=300)
+
+        results = await asyncio.gather(
+            *[
+                cache.get_tools(base_url=BASE_URL, token="t", query="q", fetch_func=slow_fetch)
+                for _ in range(10)
+            ]
+        )
+
+        assert all(len(r) == 2 for r in results)
+        assert calls["n"] == 1, (
+            f"the cache exists to avoid repeated expensive calls, but made {calls['n']}"
+        )
+
+    @pytest.mark.asyncio
+    async def test_distinct_queries_are_not_serialised_into_one_fetch(self):
+        """Regression guard: coalescing must be per key, not global."""
+        calls = {"n": 0}
+
+        async def fetch(**kwargs):
+            calls["n"] += 1
+            await asyncio.sleep(0.01)
+            return TOOLS
+
+        cache = ToolCache(default_ttl=300)
+        await asyncio.gather(
+            cache.get_tools(base_url=BASE_URL, token="t", query="a", fetch_func=fetch),
+            cache.get_tools(base_url=BASE_URL, token="t", query="b", fetch_func=fetch),
+        )
+        assert calls["n"] == 2
+
+
+class TestCacheKey:
+    """enabled_only changes the result, so it has to be part of the key."""
+
+    @pytest.mark.asyncio
+    async def test_enabled_only_is_not_shared_across_entries(self):
+        async def fetch(**kwargs):
+            if kwargs.get("enabled_only"):
+                return [{"id": "enabled-only"}]
+            return TOOLS
+
+        cache = ToolCache(default_ttl=300)
+
+        unfiltered = await cache.get_tools(
+            base_url=BASE_URL, token="t", query="q", enabled_only=False, fetch_func=fetch
+        )
+        filtered = await cache.get_tools(
+            base_url=BASE_URL, token="t", query="q", enabled_only=True, fetch_func=fetch
+        )
+
+        assert len(unfiltered) == 2
+        assert filtered == [{"id": "enabled-only"}], (
+            "an enabled_only request was served the unfiltered entry"
+        )


### PR DESCRIPTION
Fixes #370

`ToolCache` deleted an expired entry before knowing the refetch would work, so one failed fetch left nothing cached and returned `[]`. Both call sites then iterate an empty list, and every jupyter-mcp-tools entry drops out of the MCP tool list until a fetch succeeds. That path is not rare: `handlers.py` notes a failed fetch is "normal if JupyterLab frontend is not loaded" and gives it a 5 second timeout.

Three changes:

- **Serve stale on a failed refresh.** The entry is only replaced once `fetch_func` returns. If the refresh raises and something is still cached, that is returned instead of `[]`. With nothing cached yet the behaviour is unchanged and `[]` is still returned.
- **Coalesce concurrent misses.** In-flight fetches are tracked per cache key, so callers that miss on the same key await the same task rather than each starting a fetch. Distinct keys still fetch independently.
- **Put `enabled_only` in the cache key.** It changes which tools come back, so a filtered and an unfiltered request no longer share an entry. `invalidate()` was updated to match the new key shape and still clears both variants for a given query.

### Tests

New `tests/test_tool_cache.py`, no server needed.

On `main`, without the source change:

```
FAILED  test_failed_refresh_keeps_serving_the_cached_tools
FAILED  test_failed_refresh_does_not_discard_the_entry
FAILED  test_concurrent_cold_callers_share_one_fetch
FAILED  test_enabled_only_is_not_shared_across_entries
PASSED  test_successful_refresh_still_replaces_the_entry
PASSED  test_first_ever_fetch_failure_still_returns_empty
PASSED  test_distinct_queries_are_not_serialised_into_one_fetch
```

The three that pass are the regression guards: a working refresh must still replace the entry, a first-ever failure with nothing cached must still return `[]`, and coalescing must be per key rather than global.

With the change, all 7 pass.

`ruff check` and `ruff format --check` are clean on both files. There is one pre-existing `RUF013` on `invalidate(query: str = None)` that I left alone to keep the diff to the reported bug.
