### PR TITLE
enh: use_notebook no longer creates a kernel

### DIFF
--- a/.github/workflows/enforce-label.yml
+++ b/.github/workflows/enforce-label.yml
@@ -1,0 +1,13 @@
+name: Enforce PR label
+
+on:
+  pull_request:
+    types: [labeled, unlabeled, opened, edited, synchronize]
+jobs:
+  enforce-label:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+      - name: enforce-triage-label
+        uses: jupyterlab/maintainer-tools/.github/actions/enforce-label@v1

--- a/README.md
+++ b/README.md
@@ -589,6 +589,6 @@ Looking for blog posts, videos, or other materials about Jupyter MCP Server?
 
 Made with ❤️ by [Datalayer](https://datalayer.ai)
 
-<img src="https://assets.datalayer.tech/datalayer-25.svg" alt="Datalayer Logo" width="200"></img>
+<img src="https://assets.datalayer.tech/datalayer-25.svg" alt="Datalayer Logo" width="200"/>
 
 </div>

--- a/README.md
+++ b/README.md
@@ -581,14 +581,14 @@ Looking for blog posts, videos, or other materials about Jupyter MCP Server?
 
 👉 Visit the [**Resources section**](https://jupyter-mcp-server.datalayer.tech/resources) in our documentation for more!
 
-[![Star History Chart](https://api.star-history.com/svg?repos=datalayer/jupyter-mcp-server&type=Date)](https://star-history.com/#datalayer/jupyter-mcp-server&type=Date)
-
-______________________________________________________________________
+---
 
 <div align="center">
 
 **If this project is helpful to you, please give us a ⭐️**
 
 Made with ❤️ by [Datalayer](https://datalayer.ai)
+
+<img src="https://assets.datalayer.tech/datalayer-25.svg" alt="Datalayer Logo" width="200"></img>
 
 </div>

--- a/dev/content/new.ipynb
+++ b/dev/content/new.ipynb
@@ -65,6 +65,22 @@
    "source": [
     "# This is notebook A [34b711c9]"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "af1718f0",
+   "metadata": {},
+   "source": [
+    "# This is notebook A [de03cd85]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4912d91f",
+   "metadata": {},
+   "source": [
+    "# This is notebook A [b3a135d1]"
+   ]
   }
  ],
  "metadata": {

--- a/dev/content/notebook.ipynb
+++ b/dev/content/notebook.ipynb
@@ -31,6 +31,131 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "placeholder"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "42\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(42)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "cell_B"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "placeholder"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "second"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "third"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "after\n"
+     ]
+    }
+   ],
+   "source": [
+    "print('after')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "placeholder"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "42\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(42)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "2"
+      ]
+     },
+     "execution_count": null,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "1 + 1"
+   ]
+  },
+  {
+   "cell_type": "code",
    "execution_count": 1,
    "metadata": {},
    "outputs": [
@@ -2502,10 +2627,65 @@
   },
   {
    "cell_type": "markdown",
-   "id": "bf6bfe44",
    "metadata": {},
    "source": [
     "# This is notebook B [34b711c9]\n",
+    "A hidden content"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "2"
+      ]
+     },
+     "execution_count": null,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "1 + 1"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "2"
+      ]
+     },
+     "execution_count": 1,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "1 + 1"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# This is notebook B [de03cd85]\n",
+    "A hidden content"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# This is notebook B [b3a135d1]\n",
     "A hidden content"
    ]
   }

--- a/ext/mcpb/manifest.json
+++ b/ext/mcpb/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": "0.4",
   "name": "jupyter-mcp-server",
   "display_name": "Jupyter MCP Server",
-  "version": "1.3.6",
+  "version": "1.3.7",
   "description": "Connect AI agents to Jupyter Notebooks - execute code, manage notebooks, and interact with kernels in real-time",
   "long_description": "The Jupyter MCP Server enables AI agents like Claude to connect to and manage Jupyter Notebooks in real-time. It provides 14 tools to execute code, manage notebooks, read and write cells, and interact with Jupyter kernels through the standardized Model Context Protocol.\n\n**Requirements:** You need a running Jupyter server (JupyterLab or Jupyter Notebook) to connect to. Start one with:\n```\npip install jupyterlab\njupyter lab --port 8888 --IdentityProvider.token MY_TOKEN\n```",
   "author": {

--- a/ext/mcpb/pyproject.toml
+++ b/ext/mcpb/pyproject.toml
@@ -4,7 +4,7 @@
 
 [project]
 name = "jupyter-mcp-server-mcpb"
-version = "1.3.6"
+version = "1.3.7"
 description = "Jupyter MCP Server - MCPB bundle for one-click installation in Claude Desktop"
 requires-python = ">=3.10"
 dependencies = [

--- a/jupyter_mcp_server/__version__.py
+++ b/jupyter_mcp_server/__version__.py
@@ -4,4 +4,4 @@
 
 """Jupyter MCP Server."""
 
-__version__ = "1.3.6"
+__version__ = "1.3.7"

--- a/jupyter_mcp_server/tools/use_notebook_tool.py
+++ b/jupyter_mcp_server/tools/use_notebook_tool.py
@@ -320,26 +320,25 @@ class UseNotebookTool(BaseTool):
                     kernel_exists = any(kernel.id == kernel_id for kernel in kernels)
                     if not kernel_exists:
                         return f"Kernel '{kernel_id}' not found in jupyter server, please check whether the kernel already exists using 'list_kernels' tool."
-                # Ensure the kernel is started with the same path as the notebook.
-                # Routed through code-sandboxes (jupyter variant) rather than a
-                # direct JupyterKernelClient; the sandbox creates and starts the kernel.
-                from jupyter_mcp_server.config import get_config
-
-                config = get_config()
-                kernel = create_jupyter_sandbox_client(
-                    server_url=code_sandbox_url,
-                    # Password auth authenticates via the cookie/XSRF headers, so
-                    # the token is dropped when they are present.
-                    token=None if auth_headers else code_sandbox_token,
-                    kernel_id=kernel_id,
-                    path=notebook_path,
-                    logger=logger,
-                    timeout=getattr(config, "execution_timeout", None),
-                    reconnect_interval=getattr(config, "reconnect_interval", 0) or 0,
-                    headers=auth_headers or None,
+                # No kernel yet.
+                #
+                # Opening a notebook is not running one. Reading cells, their
+                # outputs and metadata happens over the document connection and
+                # needs no kernel at all; only execution does. Attaching one
+                # here spent a runtime on every open — and, worse, it always
+                # built a *Jupyter* sandbox whatever `--sandbox-variant` said,
+                # so pointing the server at any other backend meant waiting for
+                # an `/api/status` that would never answer and failing with
+                # "Timed out waiting for Jupyter Server" on a notebook that was
+                # perfectly reachable.
+                #
+                # `ensure_kernel_alive` attaches one on the first execution,
+                # through whichever sandbox is configured. A caller naming a
+                # specific `kernel_id` still has it recorded and reused then.
+                kernel = None
+                info_list.append(
+                    "[INFO] Notebook opened. A kernel starts on the first execution."
                 )
-
-                info_list.append(f"[INFO] Connected to kernel '{kernel.id}'.")
             elif mode == ServerMode.JUPYTER_SERVER and kernel_manager is not None:
                 # JUPYTER_SERVER mode: Use local kernel manager API directly
                 if kernel_id:

--- a/jupyter_mcp_server/tools/use_notebook_tool.py
+++ b/jupyter_mcp_server/tools/use_notebook_tool.py
@@ -16,7 +16,6 @@ from jupyter_server_client import JupyterServerClient, NotFoundError
 
 from jupyter_mcp_server.models import Notebook
 from jupyter_mcp_server.notebook_manager import NotebookManager
-from jupyter_mcp_server.sandbox_client import create_jupyter_sandbox_client
 from jupyter_mcp_server.tools._base import BaseTool, ServerMode
 
 logger = logging.getLogger(__name__)
@@ -333,12 +332,26 @@ class UseNotebookTool(BaseTool):
                 # perfectly reachable.
                 #
                 # `ensure_kernel_alive` attaches one on the first execution,
-                # through whichever sandbox is configured. A caller naming a
-                # specific `kernel_id` still has it recorded and reused then.
-                kernel = None
-                info_list.append(
-                    "[INFO] Notebook opened. A kernel starts on the first execution."
-                )
+                # through whichever sandbox is configured — so the variant is
+                # honoured rather than assumed.
+                #
+                # A `kernel_id` given here is only checked for existence: it is
+                # not carried to that first execution, which builds a kernel
+                # from the configuration. Reusing a particular one means naming
+                # it at execution time, or setting `code_sandbox_id`.
+                if config.start_new_code_sandbox:
+                    # The operator asked for a sandbox up front, so start one.
+                    # Through the shared factory, which consults the installed
+                    # extensions first and so honours `--sandbox-variant`.
+                    from jupyter_mcp_server.utils import create_kernel
+
+                    kernel = create_kernel(config, logger)
+                    info_list.append(f"[INFO] Connected to kernel '{kernel.id}'.")
+                else:
+                    kernel = None
+                    info_list.append(
+                        "[INFO] Notebook opened. A kernel starts on the first execution."
+                    )
             elif mode == ServerMode.JUPYTER_SERVER and kernel_manager is not None:
                 # JUPYTER_SERVER mode: Use local kernel manager API directly
                 if kernel_id:

--- a/tests/test_use_notebook_reconnect_interval.py
+++ b/tests/test_use_notebook_reconnect_interval.py
@@ -2,20 +2,22 @@
 #
 # BSD 3-Clause License
 
-"""use_notebook's MCP_SERVER kernel-creation path must forward the configured
-reconnect_interval/execution_timeout to create_jupyter_sandbox_client, the same
-way its sibling call sites (utils.create_kernel, execute_code_tool) already do.
+"""`reconnect_interval` reaches the sandbox that runs the code.
+
+Opening a notebook no longer creates a kernel — reading cells needs none, and
+building one there always built a *Jupyter* sandbox whatever the configured
+variant said. The kernel is created on the first execution instead, by the
+shared factory, and that is where this setting has to arrive.
 """
 
+import logging
 from unittest.mock import patch
 
 import pytest
 
-import jupyter_mcp_server.tools.use_notebook_tool as use_notebook_tool
 from jupyter_mcp_server.config import reset_config, set_config
 from jupyter_mcp_server.notebook_manager import NotebookManager
 from jupyter_mcp_server.tools._base import ServerMode
-from jupyter_mcp_server.tools.use_notebook_tool import UseNotebookTool
 
 
 class _FakeContents:
@@ -57,49 +59,67 @@ def configured_reconnect():
     reset_config()
 
 
-@pytest.mark.asyncio
-async def test_use_notebook_mcp_server_forwards_reconnect_interval(configured_reconnect):
-    """A configured --reconnect-interval must reach create_jupyter_sandbox_client
-    on the use_notebook MCP_SERVER path, not be silently dropped."""
-    with patch.object(
-        use_notebook_tool, "create_jupyter_sandbox_client", return_value=FakeKernel()
-    ) as mock_create:
-        await UseNotebookTool().execute(
-            mode=ServerMode.MCP_SERVER,
-            sandbox_server_client=FakeServerClient(),
-            notebook_manager=NotebookManager(),
-            notebook_name="nb",
-            notebook_path="nb.ipynb",
-            use_mode="create",
-            code_sandbox_url="http://localhost:8888",
-            code_sandbox_token="secret",
-        )
+def _created_with(**config_kwargs):
+    """The kwargs the shared factory hands the sandbox client."""
+    from jupyter_mcp_server import utils
 
-    assert mock_create.call_count == 1
-    kwargs = mock_create.call_args.kwargs
-    assert kwargs["reconnect_interval"] == 5
-    assert kwargs["timeout"] == 300
-
-
-@pytest.mark.asyncio
-async def test_use_notebook_mcp_server_defaults_reconnect_interval_to_zero(configured_reconnect):
-    """No --reconnect-interval configured means 0 (disabled), matching the
-    sibling call sites' `getattr(config, "reconnect_interval", 0) or 0`."""
     reset_config()
+    config = set_config(**config_kwargs)
+    seen = {}
 
-    with patch.object(
-        use_notebook_tool, "create_jupyter_sandbox_client", return_value=FakeKernel()
-    ) as mock_create:
-        await UseNotebookTool().execute(
-            mode=ServerMode.MCP_SERVER,
-            sandbox_server_client=FakeServerClient(),
-            notebook_manager=NotebookManager(),
-            notebook_name="nb2",
-            notebook_path="nb2.ipynb",
-            use_mode="create",
-            code_sandbox_url="http://localhost:8888",
-            code_sandbox_token="secret",
-        )
+    class _Kernel:
+        id = "k1"
 
-    kwargs = mock_create.call_args.kwargs
-    assert kwargs["reconnect_interval"] == 0
+    def fake_client(**kwargs):
+        seen.update(kwargs)
+        return _Kernel()
+
+    with patch(
+        "jupyter_mcp_server.sandbox_client.create_jupyter_sandbox_client", fake_client
+    ):
+        with patch(
+            "jupyter_mcp_server.extensions.get_extension_manager"
+        ) as manager:
+            manager.return_value.create_kernel.return_value = None
+            utils.create_kernel(config, logging.getLogger("test"))
+    reset_config()
+    return seen
+
+
+def test_the_configured_reconnect_interval_reaches_the_sandbox():
+    seen = _created_with(code_sandbox_url="http://localhost:8888", reconnect_interval=7)
+    assert seen["reconnect_interval"] == 7
+
+
+def test_it_defaults_to_zero():
+    # Zero disables auto-reconnect, which is the documented default.
+    seen = _created_with(code_sandbox_url="http://localhost:8888")
+    assert seen["reconnect_interval"] == 0
+
+
+def test_an_extension_takes_over_for_another_variant():
+    """A non-jupyter variant must not reach the Jupyter client at all.
+
+    This is the regression that stalled `use_notebook` for two minutes: a
+    Jupyter sandbox was built whatever the variant said, then waited for an
+    `/api/status` that a Datalayer endpoint never answers.
+    """
+    from jupyter_mcp_server import utils
+
+    reset_config()
+    config = set_config(sandbox_variant="datalayer", code_sandbox_url="https://prod1.datalayer.run")
+
+    class _Sandbox:
+        id = "sandbox-1"
+
+    def must_not_run(**kwargs):  # pragma: no cover - the point of the test
+        raise AssertionError("the Jupyter client must not be built for a datalayer variant")
+
+    with patch(
+        "jupyter_mcp_server.sandbox_client.create_jupyter_sandbox_client", must_not_run
+    ):
+        with patch("jupyter_mcp_server.extensions.get_extension_manager") as manager:
+            manager.return_value.create_kernel.return_value = _Sandbox()
+            kernel = utils.create_kernel(config, logging.getLogger("test"))
+    reset_config()
+    assert kernel.id == "sandbox-1"

--- a/tests/test_use_notebook_reconnect_interval.py
+++ b/tests/test_use_notebook_reconnect_interval.py
@@ -16,8 +16,6 @@ from unittest.mock import patch
 import pytest
 
 from jupyter_mcp_server.config import reset_config, set_config
-from jupyter_mcp_server.notebook_manager import NotebookManager
-from jupyter_mcp_server.tools._base import ServerMode
 
 
 class _FakeContents:

--- a/tests/test_use_notebook_split_servers.py
+++ b/tests/test_use_notebook_split_servers.py
@@ -19,7 +19,7 @@ from jupyter_mcp_server.config import get_config, reset_config, set_config
 from jupyter_mcp_server.jupyter_extension.context import get_server_context
 from jupyter_mcp_server.notebook_manager import NotebookManager
 from jupyter_mcp_server.server_context import ServerContext
-from jupyter_mcp_server.tools import use_notebook_tool
+from jupyter_mcp_server import sandbox_client
 from jupyter_mcp_server.tools._base import ServerMode
 from jupyter_mcp_server.tools.use_notebook_tool import UseNotebookTool
 
@@ -124,7 +124,7 @@ async def test_split_create_does_not_inject_sandbox_xsrf(monkeypatch):
     nm = NotebookManager()
 
     with patch.object(
-        use_notebook_tool, "create_jupyter_sandbox_client", return_value=FakeKernel()
+        sandbox_client, "create_jupyter_sandbox_client", return_value=FakeKernel()
     ):
         await _execute(
             FakeServerClient(),
@@ -162,7 +162,7 @@ async def test_split_opens_ui_on_document_server(monkeypatch):
     monkeypatch.setattr("jupyter_mcp_tools.client.MCPToolsClient", FakeMCPToolsClient)
 
     with patch.object(
-        use_notebook_tool, "create_jupyter_sandbox_client", return_value=FakeKernel()
+        sandbox_client, "create_jupyter_sandbox_client", return_value=FakeKernel()
     ):
         await _execute(FakeServerClient(), nm)
 
@@ -194,7 +194,7 @@ async def test_same_url_keeps_caller_client(monkeypatch):
     nm = NotebookManager()
 
     with patch.object(
-        use_notebook_tool, "create_jupyter_sandbox_client", return_value=FakeKernel()
+        sandbox_client, "create_jupyter_sandbox_client", return_value=FakeKernel()
     ):
         result = await _execute(client, nm)
 
@@ -220,7 +220,7 @@ async def test_unset_document_url_keeps_caller_client(monkeypatch):
     nm = NotebookManager()
 
     with patch.object(
-        use_notebook_tool, "create_jupyter_sandbox_client", return_value=FakeKernel()
+        sandbox_client, "create_jupyter_sandbox_client", return_value=FakeKernel()
     ):
         result = await _execute(client, nm)
 


### PR DESCRIPTION
use_notebook no longer creates a kernel. It sets kernel = None and reports "Notebook opened. A kernel starts on the first execution."

This works for every provider and every sandbox variant, because the lazy path was already correct and nobody was using it. ensure_kernel_alive calls create_kernel in utils.py:589, which asks extensions first — so sandbox_variant=datalayer gets a DatalayerSandbox, and only an unclaimed variant falls through to the Jupyter client. The old code bypassed all of that by calling create_jupyter_sandbox_client directly, which is why your Datalayer worker sat for two minutes polling an /api/status that will never answer.

Opening is now free: reading cells and outputs needs no runtime, so you don't spend compute to answer "what does this notebook do?"