### PR TITLE
fix(execute_code): don't inherit the kernel's ZMQ identity

### DIFF
--- a/jupyter_mcp_server/jupyter_extension/backends/local_backend.py
+++ b/jupyter_mcp_server/jupyter_extension/backends/local_backend.py
@@ -16,7 +16,7 @@ from jupyter_core.utils import ensure_async
 from mcp.types import ImageContent
 
 from jupyter_mcp_server.jupyter_extension.backends.base import Backend
-from jupyter_mcp_server.utils import safe_extract_outputs
+from jupyter_mcp_server.utils import create_isolated_kernel_client, safe_extract_outputs
 
 if TYPE_CHECKING:
     from jupyter_server.serverapp import ServerApp
@@ -330,9 +330,10 @@ class LocalBackend(Backend):
         cell = cells[cell_index]
         source = "".join(cell["source"]) if isinstance(cell["source"], list) else cell["source"]
 
-        # Get kernel client
+        # Get kernel client. Its ZMQ identity must not collide with any
+        # long-lived client on the same kernel (see create_isolated_kernel_client).
         kernel = self.kernel_manager.get_kernel(kernel_id)
-        client = kernel.client()
+        client = create_isolated_kernel_client(kernel)
 
         # Execute code
         msg_id = client.execute(source)

--- a/jupyter_mcp_server/utils.py
+++ b/jupyter_mcp_server/utils.py
@@ -7,6 +7,7 @@ import json
 import os
 import re
 import time
+import uuid
 from collections.abc import Callable
 from typing import Any, cast
 
@@ -1159,6 +1160,33 @@ async def execute_via_execution_stack(
         return [f"[ERROR: {e!s}]"]
 
 
+def create_isolated_kernel_client(kernel: Any) -> Any:
+    """Create a kernel client that does not inherit the kernel's ZMQ identity.
+
+    ``KernelManager.client()`` hands the new client a *clone* of the manager's
+    ``Session``, and the clone keeps the session id. jupyter_client uses that id
+    as the ZMQ socket identity on shell, stdin and control
+    (``connect_shell(identity=self.session.bsession)``), and ipykernel sets
+    ``ROUTER_HANDOVER``, so a client connecting with an identity that is already
+    in use takes it over — the previous owner keeps its sockets but stops
+    reaching the kernel, silently and permanently.
+
+    Anything holding a long-lived client on the same kernel is orphaned that way
+    by a single short-lived client created here. jupyter-server-nbmodel keeps one
+    per kernel to serve ``execute_cell``, so without this every ``execute_cell``
+    after an ``execute_code`` on that kernel hangs until its timeout.
+
+    Giving each client its own session id keeps the identities distinct. The
+    signing key is shared, so the kernel still accepts the messages. Clients that
+    expose no ``Session`` (remote/websocket backed) are returned unchanged.
+    """
+    client = kernel.client()
+    session = getattr(client, "session", None)
+    if session is not None and hasattr(session, "session"):
+        session.session = str(uuid.uuid4())
+    return client
+
+
 async def execute_code_local(
     serverapp, notebook_path: str, code: str, kernel_id: str, timeout: int = 300, logger=None
 ) -> list[str | ImageContent]:
@@ -1204,7 +1232,7 @@ async def execute_code_local(
         # Get the kernel using pinned_superclass pattern (like KernelUsageHandler)
         lkm = kernel_manager.pinned_superclass.get_kernel(kernel_manager, kernel_id)
         session = lkm.session
-        client = lkm.client()
+        client = create_isolated_kernel_client(lkm)
 
         # Ensure channels are started (critical for receiving IOPub messages!)
         if not client.channels_running:

--- a/tests/test_kernel_client_zmq_identity.py
+++ b/tests/test_kernel_client_zmq_identity.py
@@ -1,0 +1,109 @@
+# Copyright (c) 2024- Datalayer, Inc.
+#
+# BSD 3-Clause License
+
+"""Regression tests for kernel clients inheriting the manager's ZMQ identity.
+
+``KernelManager.client()`` clones the manager's ``Session``, and the clone keeps
+the session id — which jupyter_client passes as the ZMQ socket identity. ipykernel
+sets ``ROUTER_HANDOVER``, so a second client claiming an identity that is already
+in use takes it over and the first client silently stops reaching the kernel.
+
+The live test below fails without ``create_isolated_kernel_client``: the
+long-lived client's second execute never reaches the kernel and times out.
+"""
+
+import asyncio
+import inspect
+
+import pytest
+
+from jupyter_mcp_server.utils import create_isolated_kernel_client
+
+pytest.importorskip("ipykernel", reason="the live test needs a real kernel to connect to")
+
+from jupyter_client.manager import AsyncKernelManager  # noqa: E402
+
+EXECUTE_TIMEOUT = 15.0
+
+
+class _FakeSession:
+    def __init__(self, session_id):
+        self.session = session_id
+
+
+class _FakeClient:
+    def __init__(self, session=None):
+        if session is not None:
+            self.session = session
+
+
+class _FakeKernel:
+    """Mimics KernelManager.client(): a fresh client carrying a Session clone."""
+
+    def __init__(self, session_id="shared-identity", with_session=True):
+        self.session_id = session_id
+        self.with_session = with_session
+
+    def client(self):
+        if not self.with_session:
+            return _FakeClient()
+        return _FakeClient(_FakeSession(self.session_id))
+
+
+def test_client_does_not_inherit_the_kernel_session_id():
+    kernel = _FakeKernel(session_id="shared-identity")
+
+    first = create_isolated_kernel_client(kernel)
+    second = create_isolated_kernel_client(kernel)
+
+    assert first.session.session != "shared-identity"
+    assert second.session.session != "shared-identity"
+    assert first.session.session != second.session.session
+
+
+def test_client_without_a_session_is_returned_unchanged():
+    """Remote/websocket-backed clients expose no Session; they must still work."""
+    client = create_isolated_kernel_client(_FakeKernel(with_session=False))
+
+    assert client is not None
+    assert not hasattr(client, "session")
+
+
+async def _execute(client, code):
+    """Return the execution status, or 'TIMEOUT' when the request never lands."""
+    result = client.execute_interactive(code, output_hook=lambda msg: None, stdin_hook=None)
+    if inspect.isawaitable(result):
+        result = asyncio.ensure_future(result)
+    try:
+        reply = await asyncio.wait_for(result, timeout=EXECUTE_TIMEOUT)
+    except asyncio.TimeoutError:
+        return "TIMEOUT"
+    return reply["content"]["status"]
+
+
+@pytest.mark.asyncio
+async def test_second_client_does_not_orphan_a_long_lived_one():
+    """A short-lived client must not evict a long-lived client's ZMQ identity."""
+    manager = AsyncKernelManager(kernel_name="python3")
+    await manager.start_kernel()
+    long_lived = None
+    short_lived = None
+    try:
+        long_lived = manager.client()
+        long_lived.start_channels()
+        await long_lived.wait_for_ready(timeout=EXECUTE_TIMEOUT)
+        assert await _execute(long_lived, "x = 1") == "ok"
+
+        short_lived = create_isolated_kernel_client(manager)
+        short_lived.start_channels()
+        await short_lived.wait_for_ready(timeout=EXECUTE_TIMEOUT)
+        assert await _execute(short_lived, "y = 2") == "ok"
+
+        # Without the fix this times out: the kernel never receives the request.
+        assert await _execute(long_lived, "z = 3") == "ok"
+    finally:
+        for client in (short_lived, long_lived):
+            if client is not None and client.channels_running:
+                client.stop_channels()
+        await manager.shutdown_kernel(now=True)


### PR DESCRIPTION
## The problem

In `JUPYTER_SERVER` mode, one `execute_code` call permanently breaks `execute_cell` for that kernel.

`execute_code` builds its own client with `lkm.client()`. `KernelManager.client()` hands back a *clone* of the manager's `Session`, and `clone()` keeps the session id — which jupyter_client passes straight through as the ZMQ socket identity:

```python
socket = self.connect_shell(identity=self.session.bsession)   # jupyter_client/client.py:359
```

ipykernel sets `ROUTER_HANDOVER` (#300 upstream, working around zeromq/libzmq#2892 so a client can reconnect while the kernel is busy). With handover, a second peer presenting an identity that is already in use **takes it over**, and the first client keeps its sockets but stops reaching the kernel.

`jupyter-server-nbmodel` keeps one long-lived client per kernel to serve `execute_cell`, so `execute_code` orphans it. What the user sees:

- `execute_cell` hangs until its timeout and returns `[ERROR: Execution timed out after N seconds]`, and the file-mode path writes that string into the notebook cell as if it were the cell's output, with an `execution_count` derived by scanning the file.
- `POST /api/kernels/<id>/execute` returns `202 Accepted` / `"queued"` and never completes; `/api/kernels` shows the kernel `idle` with frozen `last_activity` — it never receives the code.
- Restarting the kernel with the same id does **not** help. Only a new kernel id or a server restart does.
- `execute_code` keeps working throughout, which makes this look like an `execute_cell` bug.

Two individually reasonable upstream decisions collide here: jupyter/jupyter_client#252 added `Session.clone()` *specifically* so that "multiple Clients … instantiated against the same kernel" don't share `digest_history`, but it keeps the session id; ipython/ipykernel#300 made same-identity reconnects take over. Multi-client support plus same-identity handover means the newest client silently evicts the others.

## The fix

`create_isolated_kernel_client()` in `utils.py` gives each short-lived client its own session id before its channels are started. The signing key is shared, so the kernel still accepts the messages; clients that expose no `Session` (remote/websocket-backed) pass through unchanged.

Applied at both sites that build a client from a kernel:

- `utils.py` — `execute_code_local()`
- `jupyter_extension/backends/local_backend.py` — `execute_cell()`

## Tests

`tests/test_kernel_client_zmq_identity.py`:

- two unit tests — distinct session ids per client; a client with no `Session` is returned unchanged;
- one live test against a real kernel: a long-lived client executes, a short-lived client connects and executes, and the long-lived client must still be able to execute.

The live test earns its keep — swapping `create_isolated_kernel_client(manager)` back to `manager.client()` fails it:

```
E       AssertionError: assert 'TIMEOUT' == 'ok'
E         - ok
E         + TIMEOUT
```

With the fix: `3 passed in 4.59s`.

Also run, all passing: `test_execute_code_local_channel_cleanup.py`, `test_execute_hook_pairing.py`, `test_local_backend_contents_manager.py`, `test_execute_code_borrowed_kernel_stop_race.py`, `test_execute_code_orphaned_timeout.py` — 26 passed.

`test_execute_code_kernel_id.py` has fixture errors ("kernel … was not ready within 60s"), but they reproduce on an unmodified checkout of the same commit and vary run to run, so they look like pre-existing flakiness in that fixture rather than fallout from this change.

## Notes

Verified on `jupyter-mcp-server` 1.3.8 as a server extension, with `jupyter-server-nbmodel` 0.2.4, `jupyter-client` 8.9.1, `jupyter-collaboration` 5.0.0, Python 3.13, macOS.
