### PR TITLE
docs: clarify read_cell output format

### DIFF
--- a/docs/sourcey/index.md
+++ b/docs/sourcey/index.md
@@ -32,7 +32,7 @@ This reference documents the server's complete MCP surface — **22 tools** and 
 | Tool | Summary |
 | --- | --- |
 | [`insert_cell`](/mcp/tools/insert-cell/) | Insert a cell to specified position from the currently activated notebook. |
-| [`read_cell`](/mcp/tools/read-cell/) | Read a specific cell from the currently activated notebook and return it's metadata (index, type, execution count), source and outputs (for code cells) |
+| [`read_cell`](/mcp/tools/read-cell/) | Read a cell as readable text entries. |
 | [`edit_cell_source`](/mcp/tools/edit-cell-source/) | Perform a surgical find-and-replace within a cell's source (like an editor's Edit tool). |
 | [`overwrite_cell_source`](/mcp/tools/overwrite-cell-source/) | Replace the entire source of a cell in the currently activated notebook. |
 | [`move_cell`](/mcp/tools/move-cell/) | Move a cell from source_index to target_index within the currently activated notebook. |

--- a/docs/sourcey/mcp.json
+++ b/docs/sourcey/mcp.json
@@ -615,7 +615,7 @@
     },
     {
       "name": "read_cell",
-      "description": "Read a specific cell from the currently activated notebook and return it's metadata (index, type, execution count), source and outputs (for code cells)",
+      "description": "Read a cell as readable text entries.\n\nIncludes metadata and source, plus optional formatted output text rather\nthan raw nbformat objects.\n",
       "inputSchema": {
         "properties": {
           "cell_index": {

--- a/docs/sourcey/tools/read_cell.md
+++ b/docs/sourcey/tools/read_cell.md
@@ -1,11 +1,14 @@
 ---
 title: "read_cell"
-description: "Read a specific cell from the currently activated notebook and return it's metadata (index, type, execution count), source and outputs (for code cells)"
+description: "Read a cell as readable text entries."
 ---
 
 # read_cell
 
-Read a specific cell from the currently activated notebook and return it's metadata (index, type, execution count), source and outputs (for code cells)
+Read a cell as readable text entries.
+
+Includes metadata and source, plus optional formatted output text rather
+than raw nbformat objects.
 
 > read-only: **yes**
 

--- a/jupyter_mcp_server/server.py
+++ b/jupyter_mcp_server/server.py
@@ -911,10 +911,17 @@ async def read_cell(
 ) -> Annotated[
     list[str | ImageContent],
     Field(
-        description="Cell information including index, type, source, and outputs (for code cells)"
+        description=(
+            "Readable text entries containing cell metadata, source, and optional "
+            "code-cell outputs"
+        )
     ),
 ]:
-    """Read a specific cell from the currently activated notebook and return it's metadata (index, type, execution count), source and outputs (for code cells)"""
+    """Read a cell as readable text entries.
+
+    Includes metadata and source, plus optional formatted output text rather
+    than raw nbformat objects.
+    """
     return await safe_notebook_operation(
         lambda: ReadCellTool().execute(
             mode=server_context.mode,


### PR DESCRIPTION
## Summary

Clarifies the MCP contract for `read_cell`: it returns readable text entries, including formatted output text when requested, rather than raw nbformat output objects. This documents the behavior maintained in response to https://github.com/datalayer/jupyter-mcp-server/issues/78.

## Validation

- `python -m pytest tests/test_extract_output_fidelity.py tests/test_execute_cell_output_fidelity.py -q` - 18 passed
- `npm run build` in `docs/`
- `git diff --check`
- independent scope, quality, and security review - approved

The generated Sourcey reference was regenerated for the changed tool description. No runtime behavior changed.