### PR TITLE
docs: restore star history chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -596,6 +596,8 @@ Looking for blog posts, videos, or other materials about Jupyter MCP Server?
 
 👉 Visit the [**Resources section**](https://jupyter-mcp-server.datalayer.tech/resources) in our documentation for more!
 
+[![Star History Chart](https://star-history.dera.page/svg?repos=datalayer/jupyter-mcp-server&type=Date)](https://star-history.dera.page/#datalayer/jupyter-mcp-server&type=Date)
+
 ---
 
 <div align="center">


### PR DESCRIPTION
The star history chart in the README footer was removed in f9caa8c (#372) because it was broken. The GitHub stargazer API restrictions broke the old chart, so a working fix is needed to bring it back.

This PR restores the chart in its original location, pointing to star-history.dera.page which provides the same star history data reliably.