### PR TITLE
fix: do not query jupyter-mcp-tools for an empty allowlist

### DIFF
--- a/jupyter_mcp_server/jupyter_extension/handlers.py
+++ b/jupyter_mcp_server/jupyter_extension/handlers.py
@@ -156,23 +156,23 @@ class MCPSSEHandler(JupyterHandler):
 
                         logger.info(f"Querying jupyter_mcp_tools at {base_url}")
 
-                        # Check if JupyterLab mode is enabled before loading jupyter-mcp-tools
+                        # Check if JupyterLab mode is enabled before loading jupyter-mcp-tools.
+                        # An empty allowlist enables no command, and jupyter-mcp-tools applies
+                        # no filter to an empty query, so asking would return every command.
+                        from jupyter_mcp_server.config import get_config
+
                         context = ServerContext.get_instance()
                         jupyterlab_enabled = context.is_jupyterlab_mode()
+                        allowed_jupyter_mcp_tools = get_config().get_allowed_jupyter_mcp_tools()
                         logger.info(f"JupyterLab mode check: enabled={jupyterlab_enabled}")
 
-                        if jupyterlab_enabled:
+                        if jupyterlab_enabled and allowed_jupyter_mcp_tools:
                             # Define specific tools we want to load from jupyter-mcp-tools
                             # (https://github.com/datalayer/jupyter-mcp-tools)
                             # jupyter-mcp-tools exposes JupyterLab commands as MCP tools.
                             # Only tools listed here will be available to MCP clients.
                             # To add new tools, also update the list in server.py and
                             # see docs/docs/reference/tools-jupyterlab/index.mdx for documentation.
-                            from jupyter_mcp_server.config import get_config
-
-                            config = get_config()
-                            allowed_jupyter_mcp_tools = config.get_allowed_jupyter_mcp_tools()
-
                             logger.info(
                                 f"Looking for specific jupyter-mcp-tools: {allowed_jupyter_mcp_tools}"
                             )
@@ -220,9 +220,12 @@ class MCPSSEHandler(JupyterHandler):
                                 f"Successfully loaded {len(jupyter_tools_data)} specific jupyter-mcp-tools (requires JupyterLab frontend)"
                             )
                         else:
-                            # JupyterLab mode disabled, don't load any jupyter-mcp-tools
                             jupyter_tools_data = []
-                            logger.info("JupyterLab mode disabled, skipping jupyter-mcp-tools")
+                            logger.info(
+                                "Skipping jupyter-mcp-tools "
+                                f"(jupyterlab={jupyterlab_enabled}, "
+                                f"allowed={allowed_jupyter_mcp_tools})"
+                            )
 
                         # Build set of jupyter tool names and cache it for routing decisions
                         jupyter_tool_names = {

--- a/jupyter_mcp_server/server.py
+++ b/jupyter_mcp_server/server.py
@@ -1241,8 +1241,11 @@ async def get_registered_tools():
         all_tools = []
         jupyter_tool_names = set()
 
-        # Check if JupyterLab mode is enabled before loading jupyter-mcp-tools
-        if server_context.is_jupyterlab_mode():
+        # Check if JupyterLab mode is enabled before loading jupyter-mcp-tools.
+        # An empty allowlist enables no command, and jupyter-mcp-tools applies no filter
+        # to an empty query, so asking would return every command.
+        allowed_jupyter_mcp_tools = get_config().get_allowed_jupyter_mcp_tools()
+        if server_context.is_jupyterlab_mode() and allowed_jupyter_mcp_tools:
             logger.info("JupyterLab mode enabled, loading selected jupyter-mcp-tools")
 
             # Get tools from jupyter-mcp-tools extension with caching
@@ -1273,8 +1276,6 @@ async def get_registered_tools():
                 # Only tools listed here will be available to MCP clients.
                 # To add new tools, also update the list in handlers.py and
                 # see docs/docs/reference/tools-jupyterlab/index.mdx for documentation.
-                config = get_config()
-                allowed_jupyter_mcp_tools = config.get_allowed_jupyter_mcp_tools()
 
                 # Try querying with caching to avoid expensive repeated calls
                 try:
@@ -1346,7 +1347,11 @@ async def get_registered_tools():
                 logger.error(f"Error querying jupyter-mcp-tools extension: {e}", exc_info=True)
                 # Continue to add FastMCP tools even if jupyter-mcp-tools fails
         else:
-            logger.info("JupyterLab mode disabled, skipping jupyter-mcp-tools integration")
+            logger.info(
+                "Skipping jupyter-mcp-tools integration "
+                f"(jupyterlab={server_context.is_jupyterlab_mode()}, "
+                f"allowed={allowed_jupyter_mcp_tools})"
+            )
 
         # Second, add FastMCP tools
         try:

--- a/tests/test_allowed_jupyter_mcp_tools.py
+++ b/tests/test_allowed_jupyter_mcp_tools.py
@@ -1,0 +1,111 @@
+# Copyright (c) 2024- Datalayer, Inc.
+#
+# BSD 3-Clause License
+
+"""Unit tests for the ALLOWED_JUPYTER_MCP_TOOLS allowlist.
+
+jupyter-mcp-tools filters its response only when the query is non-empty: its request
+handler guards the filter with `if query:`. Joining an empty allowlist into a query
+string therefore asks it for every registered JupyterLab command. These tests replace
+jupyter_mcp_tools with a stand-in that reproduces that behaviour, so no running
+JupyterLab frontend is required.
+"""
+
+import sys
+import types
+
+import pytest
+
+BASE_URL = "http://localhost:8888"
+
+ALL_TOOLS = [
+    {"id": "notebook_run-all-cells", "label": "Run All Cells", "isEnabled": True},
+    {"id": "notebook_get-selected-cell", "label": "Get Selected Cell", "isEnabled": True},
+    {"id": "notebook_delete-cell", "label": "Delete Cell", "isEnabled": True},
+    {"id": "filebrowser_delete", "label": "Delete File", "isEnabled": True},
+    {"id": "terminal_open", "label": "Open Terminal", "isEnabled": True},
+]
+
+ALL_TOOL_IDS = {tool["id"] for tool in ALL_TOOLS}
+
+
+class RecordingTools:
+    """Stand-in for jupyter_mcp_tools.get_tools that records every query it receives
+    and filters the way jupyter-mcp-tools does: no filter at all for an empty query."""
+
+    def __init__(self):
+        self.queries = []
+
+    async def __call__(self, query=None, **kwargs):
+        self.queries.append(query)
+        if not query:
+            return list(ALL_TOOLS)
+        terms = [term.strip().lower() for term in query.split(",")]
+        return [
+            tool
+            for tool in ALL_TOOLS
+            if any(
+                term in tool["id"].lower() or term in tool["label"].lower() for term in terms
+            )
+        ]
+
+
+@pytest.fixture
+def registered_tools(monkeypatch):
+    """Drive get_registered_tools() in JUPYTER_SERVER mode against a stand-in
+    jupyter_mcp_tools, and yield (call the allowlist, get back the JupyterLab tool ids)."""
+    from jupyter_mcp_server import tool_cache
+    from jupyter_mcp_server.config import reset_config, set_config
+    from jupyter_mcp_server.server import get_registered_tools, server_context
+    from jupyter_mcp_server.tools import ServerMode
+
+    fetch = RecordingTools()
+    stub = types.ModuleType("jupyter_mcp_tools")
+    stub.get_tools = fetch
+    monkeypatch.setitem(sys.modules, "jupyter_mcp_tools", stub)
+    monkeypatch.setattr(tool_cache, "_global_tool_cache", None, raising=False)
+    monkeypatch.setattr(server_context.__class__, "_mode", ServerMode.JUPYTER_SERVER)
+    monkeypatch.setattr(server_context.__class__, "_initialized", True)
+    # get_registered_tools reads server_context.serverapp, which this context object does
+    # not define; None selects its documented fallback to the configured sandbox URL.
+    monkeypatch.setattr(server_context, "serverapp", None, raising=False)
+
+    async def run(allowed):
+        reset_config()
+        config = set_config(jupyterlab=True, code_sandbox_url=BASE_URL)
+        # The extension assigns this attribute directly, which is how an empty allowlist
+        # reaches the config at all: set_config() drops "" as an alias for None.
+        config.allowed_jupyter_mcp_tools = allowed
+        tools = await get_registered_tools()
+        return {tool["name"] for tool in tools} & ALL_TOOL_IDS
+
+    yield run, fetch
+    reset_config()
+
+
+@pytest.mark.asyncio
+async def test_empty_allowlist_registers_no_jupyterlab_tools(registered_tools):
+    """An empty allowlist enables no JupyterLab command, so none may be registered and
+    jupyter-mcp-tools must not be asked for a filter it would ignore."""
+    run, fetch = registered_tools
+
+    assert await run("") == set()
+    assert fetch.queries == []
+
+
+@pytest.mark.asyncio
+async def test_whitespace_only_allowlist_registers_no_jupyterlab_tools(registered_tools):
+    """get_allowed_jupyter_mcp_tools() drops blank entries, so ' , ' is also empty."""
+    run, fetch = registered_tools
+
+    assert await run(" , ") == set()
+    assert fetch.queries == []
+
+
+@pytest.mark.asyncio
+async def test_configured_allowlist_still_registers_its_tools(registered_tools):
+    """The allowlist keeps working: a configured command is queried for and registered."""
+    run, fetch = registered_tools
+
+    assert await run("notebook_run-all-cells") == {"notebook_run-all-cells"}
+    assert fetch.queries == ["notebook_run-all-cells"]


### PR DESCRIPTION
Fixes #380.

## Root cause

`Config.get_allowed_jupyter_mcp_tools()` returns `[]` for an empty `allowed_jupyter_mcp_tools`, and both consumers build their query as `",".join([])`, which is `""`. jupyter-mcp-tools guards its filter with `if query:`, so an empty query means no filter and the response carries every registered JupyterLab command. Neither call site narrows the result afterwards, and `MCPSSEHandler` caches the whole set as `_jupyter_tool_names`, the routing table used for `tools/call`.

The empty value reaches the config through `jupyter_extension/extension.py:155`, which assigns the attribute directly and so bypasses the handling of `""` in `set_config()`.

## Fix

Treat an empty allowlist the way JupyterLab mode being off is already treated, and skip the query. The existing `else` branch at each call site already produces no tools and an empty routing table, so this is one condition in each of `server.py` and `handlers.py`. A non-empty allowlist is unaffected.

## Verification

- `tests/test_allowed_jupyter_mcp_tools.py` is new: the empty and whitespace-only cases fail on `6bb9e5a` (all five commands from the stand-in register, including `filebrowser_delete` and `terminal_open`) and pass here, and the configured-allowlist case passes on both.
- Both suites in a clean `python:3.12-slim` container, this branch against a pristine worktree of main: `TEST_JUPYTER_SERVER=true` gives 436 passed against 434, `TEST_MCP_SERVER=true` gives 436 against 434, the difference being the two tests above. The one remaining failure and the error counts are identical on both sides, from integration fixtures needing a JupyterLab that container could not start.
- `ruff check` reports the same 56 findings on the two changed files before and after, and the new test file is clean.
- Not verified: no live JupyterLab frontend was involved, so the stand-in reproduces the filtering I read in the installed jupyter-mcp-tools 0.1.7 rather than exercising it. The new tests drive the `server.py` path, and the identical guard in `handlers.py` has no unit test.

One thing I left alone: with a non-empty allowlist, jupyter-mcp-tools matches each term as a substring of a tool's id or label, so the published set can still be wider than the allowlist. That is documented behaviour on its side, so narrowing it locally reads as your design call rather than a bug fix. I can add an exact-id filter at both call sites if you want one.
