### PR TITLE
fix: start MCP_SERVER-mode kernels in the notebook's directory

### DIFF
--- a/jupyter_mcp_server/server.py
+++ b/jupyter_mcp_server/server.py
@@ -239,7 +239,9 @@ def __ensure_code_sandbox_alive() -> CodeSandboxClient:
     def __create_code_sandbox() -> CodeSandboxClient:
         """Create a new kernel instance using current configuration."""
         config = get_config()
-        return create_code_sandbox(config, logger)
+        return create_code_sandbox(
+            config, logger, path=notebook_manager.get_current_notebook_path()
+        )
 
     current_notebook = notebook_manager.get_current_notebook() or "default"
     return ensure_code_sandbox_alive(notebook_manager, current_notebook, __create_code_sandbox)

--- a/jupyter_mcp_server/tools/use_notebook_tool.py
+++ b/jupyter_mcp_server/tools/use_notebook_tool.py
@@ -367,7 +367,7 @@ class UseNotebookTool(BaseTool):
                     # extensions first and so honours `--sandbox-variant`.
                     from jupyter_mcp_server.utils import create_code_sandbox
 
-                    kernel = create_code_sandbox(config, logger)
+                    kernel = create_code_sandbox(config, logger, path=notebook_path)
                     info_list.append(f"[INFO] Connected to kernel '{kernel.id}'.")
                 else:
                     kernel = None

--- a/jupyter_mcp_server/utils.py
+++ b/jupyter_mcp_server/utils.py
@@ -587,7 +587,7 @@ def format_TSV(headers: list[str], rows: list[list[str]]) -> str:
 ###############################################################################
 
 
-def create_code_sandbox(config, logger) -> CodeSandboxClient:
+def create_code_sandbox(config, logger, path: str | None = None) -> CodeSandboxClient:
     """Create a new code sandbox using current configuration.
 
     Creation is resolved in this order:
@@ -600,6 +600,10 @@ def create_code_sandbox(config, logger) -> CodeSandboxClient:
 
     This routes all execution through ``code_sandboxes`` instead of calling a
     legacy direct kernel client package.
+
+    ``path`` is the root-relative path of the notebook the sandbox belongs to.
+    Jupyter Server derives the kernel's working directory from it, so relative
+    file access inside a notebook resolves against the notebook's own directory.
     """
     from jupyter_mcp_server.extensions import get_extension_manager
     from jupyter_mcp_server.sandbox_client import create_jupyter_sandbox_client
@@ -619,6 +623,7 @@ def create_code_sandbox(config, logger) -> CodeSandboxClient:
             server_url=config.code_sandbox_url,
             token=None if auth_headers else config.code_sandbox_token,
             kernel_id=config.code_sandbox_id,
+            path=path,
             timeout=getattr(config, "execution_timeout", None),
             reconnect_interval=getattr(config, "reconnect_interval", 0) or 0,
             headers=auth_headers or None,

--- a/tests/test_code_sandbox_notebook_cwd.py
+++ b/tests/test_code_sandbox_notebook_cwd.py
@@ -1,0 +1,148 @@
+# Copyright (c) 2024- Datalayer, Inc.
+#
+# BSD 3-Clause License
+
+"""MCP_SERVER-mode kernels start in the notebook's own directory.
+
+Jupyter Server derives a kernel's working directory from the ``path`` sent to
+``POST /api/kernels``, so a sandbox built without one runs in the server root
+and every relative path inside the notebook resolves against the wrong place.
+"""
+
+import logging
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+
+from jupyter_mcp_server.config import reset_config, set_config
+from jupyter_mcp_server.notebook_manager import NotebookManager
+from jupyter_mcp_server.tools._base import ServerMode
+from jupyter_mcp_server.tools.use_notebook_tool import UseNotebookTool
+
+SANDBOX_URL = "http://sandbox.example"
+NB_PATH = "projects/demo/notebook.ipynb"
+
+
+class FakeKernel:
+    id = "kernel-1"
+
+    def __init__(self, alive=True):
+        self._alive = alive
+
+    def is_alive(self):
+        return self._alive
+
+
+class _FakeContents:
+    @staticmethod
+    def create_notebook(path, content=None):
+        return None
+
+    @staticmethod
+    def list_directory(path):
+        return [SimpleNamespace(name="notebook.ipynb")]
+
+    @staticmethod
+    def get(path):
+        return {"content": {"cells": []}}
+
+
+class _FakeKernels:
+    @staticmethod
+    def list_kernels():
+        return []
+
+
+class FakeServerClient:
+    contents = _FakeContents
+    kernels = _FakeKernels
+
+    def get_status(self):
+        return {}
+
+
+@pytest.fixture
+def recorded_sandbox_kwargs(monkeypatch):
+    """Capture what the shared factory hands the Jupyter sandbox client."""
+    seen = {}
+
+    def fake_client(**kwargs):
+        seen.update(kwargs)
+        return FakeKernel()
+
+    monkeypatch.setattr(
+        "jupyter_mcp_server.sandbox_client.create_jupyter_sandbox_client", fake_client
+    )
+    with patch("jupyter_mcp_server.extensions.get_extension_manager") as manager:
+        manager.return_value.create_code_sandbox.return_value = None
+        yield seen
+
+
+@pytest.fixture(autouse=True)
+def clean_config():
+    reset_config()
+    yield
+    reset_config()
+
+
+def test_the_factory_forwards_the_notebook_path(recorded_sandbox_kwargs):
+    from jupyter_mcp_server import utils
+
+    config = set_config(code_sandbox_url=SANDBOX_URL)
+    utils.create_code_sandbox(config, logging.getLogger("test"), path=NB_PATH)
+
+    assert recorded_sandbox_kwargs["path"] == NB_PATH
+
+
+@pytest.mark.asyncio
+async def test_use_notebook_starts_the_kernel_in_the_notebook_directory(
+    monkeypatch, recorded_sandbox_kwargs
+):
+    """The eager path, taken whenever --start-new-code-sandbox is on (the default)."""
+    set_config(code_sandbox_url=SANDBOX_URL, start_new_code_sandbox=True)
+    monkeypatch.setattr(
+        "jupyter_mcp_server.server_context.ServerContext.get_instance",
+        staticmethod(
+            lambda: SimpleNamespace(
+                document_server_client=FakeServerClient(),
+                document_auth_headers={},
+                code_sandbox_auth_headers={},
+            )
+        ),
+    )
+
+    await UseNotebookTool().execute(
+        mode=ServerMode.MCP_SERVER,
+        sandbox_server_client=FakeServerClient(),
+        notebook_manager=NotebookManager(),
+        notebook_name="demo",
+        notebook_path=NB_PATH,
+        use_mode="connect",
+        code_sandbox_url=SANDBOX_URL,
+    )
+
+    assert recorded_sandbox_kwargs["path"] == NB_PATH
+
+
+def test_a_replacement_kernel_starts_in_the_current_notebooks_directory(
+    monkeypatch, recorded_sandbox_kwargs
+):
+    """The deferred path: the first execution, and every culled-kernel replacement."""
+    from jupyter_mcp_server import server
+
+    set_config(code_sandbox_url=SANDBOX_URL)
+    monkeypatch.setattr(
+        "jupyter_mcp_server.server_context.ServerContext.get_instance",
+        staticmethod(lambda: SimpleNamespace(code_sandbox_auth_headers={})),
+    )
+    notebook_manager = NotebookManager()
+    notebook_manager.add_notebook(
+        "demo", FakeKernel(alive=False), server_url=SANDBOX_URL, token=None, path=NB_PATH
+    )
+    notebook_manager.set_current_notebook("demo")
+    monkeypatch.setattr(server, "notebook_manager", notebook_manager)
+
+    getattr(server, "__ensure_code_sandbox_alive")()
+
+    assert recorded_sandbox_kwargs["path"] == NB_PATH


### PR DESCRIPTION
Fixes #382

Jupyter Server sets a kernel's working directory from the `path` field of `POST /api/kernels`. `create_code_sandbox` never sends one, so in MCP_SERVER mode every kernel starts in the server root and relative file access inside a notebook silently resolves against the wrong directory.

`use_notebook` used to send it. f9caa8c (#372) replaced its direct `create_jupyter_sandbox_client(..., path=notebook_path)` call with the shared factory so that `--sandbox-variant` is honoured, and the path went with it. The deferred path never sent one at all.

## Fix

`create_code_sandbox` takes an optional `path` and forwards it, which reaches `CodeSandboxClient.create(kernel_path=...)` and then `start(path=...)`. Two callers supply it:

- `use_notebook` passes `notebook_path`. This is the eager path, taken whenever `--start-new-code-sandbox` is on, which is the CLI default.
- `__ensure_code_sandbox_alive` passes the current notebook's path. This is the deferred path, taken on the first execution and on every culled-kernel replacement.

The extension hand-off (`get_extension_manager().create_code_sandbox(config, logger)`) is left alone: a non-Jupyter sandbox variant need not have a notion of a server-relative path, and widening that contract belongs in its own change. `start_code_sandbox` is unchanged too, since it only runs at startup when there is no `document_id` or when auto-enrollment has already failed.

## Verification

- `tests/test_code_sandbox_notebook_cwd.py` covers the factory and both callers. All three fail on `main` and pass here.
- End to end in a clean container against a real Jupyter Server with `root_dir=/srv/nb` and a notebook at `projects/demo/notebook.ipynb`: `os.getcwd()` in the kernel reads `/srv/nb` on `main` and `/srv/nb/projects/demo` on this branch.
- Full `tests/` run in that container: identical results on `main` and on the branch apart from the three new passes (the container has no live server, so the same suites error on both).
- Not checked: any non-Jupyter sandbox variant, since the extension path is untouched.

#292 also edits `create_code_sandbox`, for kernel spec names rather than the working directory, so the two changes will need a rebase against each other.
