### PR TITLE
fix(tool_cache): serve the cached tools when a refresh comes back empty

### DIFF
--- a/jupyter_mcp_server/tool_cache.py
+++ b/jupyter_mcp_server/tool_cache.py
@@ -72,12 +72,18 @@ class ToolCache:
             fresh_data = await fetch_func(
                 base_url=base_url, token=token, query=query, enabled_only=enabled_only
             )
-            # jupyter-mcp-tools returns [] rather than raising when the JupyterLab
-            # extension has not registered its tools yet (HTTP 503), on a timeout, or
-            # on a connection error, so an empty result is transient here. Leaving the
-            # previous entry in place also means an expired one is still available to
-            # serve, for the same reason the except branch below falls back to it.
+            # jupyter-mcp-tools returns [] rather than raising for an HTTP 503, a
+            # timeout or a connection error, so an empty result says no more than the
+            # failed refresh below does, and gets the same answer.
             if not fresh_data:
+                async with self._lock:
+                    entry = self._cache.get(cache_key)
+                if entry is not None:
+                    logger.warning(
+                        f"Serving stale tools for {cache_key} "
+                        f"(age: {time.time() - entry.timestamp:.1f}s) after an empty refresh"
+                    )
+                    return entry.data
                 logger.debug(f"Not caching empty tool list for key {cache_key}")
                 return fresh_data
 

--- a/tests/test_tool_cache_empty_result.py
+++ b/tests/test_tool_cache_empty_result.py
@@ -11,6 +11,8 @@ whole TTL. These tests use a fake fetch function, so no running Jupyter server a
 no jupyter-mcp-tools installation are required.
 """
 
+import asyncio
+
 import pytest
 
 from jupyter_mcp_server.tool_cache import ToolCache
@@ -56,6 +58,28 @@ async def test_empty_result_is_not_cached_and_next_call_refetches():
     )
     assert second == TOOLS
     assert fetch.calls == 2
+
+
+@pytest.mark.asyncio
+async def test_empty_refresh_serves_the_cached_tools():
+    """An empty refresh over a warm cache must not empty the caller's tool list, and
+    must not refresh the entry either, so the next good answer still replaces it."""
+    cache = ToolCache(default_ttl=1)
+    fetch = RecordingFetch(TOOLS, [], TOOLS)
+
+    await cache.get_tools(base_url=BASE_URL, token=TOKEN, query=QUERY, fetch_func=fetch)
+    await asyncio.sleep(1.1)
+
+    after_empty = await cache.get_tools(
+        base_url=BASE_URL, token=TOKEN, query=QUERY, fetch_func=fetch
+    )
+    assert after_empty == TOOLS, "an empty refresh must not empty the tool list"
+
+    refreshed = await cache.get_tools(
+        base_url=BASE_URL, token=TOKEN, query=QUERY, fetch_func=fetch
+    )
+    assert refreshed == TOOLS
+    assert fetch.calls == 3
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Fixes #384.

## Root cause

`jupyter_mcp_tools.client.MCPToolsClient.get_tools` returns `[]` rather than raising on an HTTP 503, on any other non-200, on an `aiohttp.ClientError` and on any other exception. The failure that `ToolCache`'s `except` branch protects against therefore almost never arrives as an exception. It arrives as an empty list, and that path handed the empty list to every caller joined on the fetch even with a good list still in the cache.

So a JupyterLab frontend that is briefly unavailable empties the MCP client's tool list, which is the outcome #367 and #371 were both written to prevent. The protection stopped at the cache and did not reach the caller.

## Fix

Give an empty result the same answer the `except` branch already gives a refresh that raises, and serve the cached entry. With nothing cached, `[]` is still returned. The entry is still neither written nor re-timestamped, so the next good fetch replaces it on schedule.

The trade is the one that branch already makes: if an allowlist's commands stop being registered for real, the previously cached list keeps being served. If you would rather bound that with a short negative-cache TTL for the empty case, say so and I will send that instead.

## Verification

- `test_empty_refresh_serves_the_cached_tools` fails on `94ad96b` and passes here.
- `tests/test_tool_cache_empty_result.py`, `tests/test_tool_cache.py` and `tests/test_allowed_jupyter_mcp_tools.py`: 13 passed on this branch, 12 on main, in a clean `python:3.13-slim` container.
- `ruff check` and `mypy` report the same findings on both changed files before and after the change (two pre-existing).
- Not exercised against a live JupyterLab. The empty-instead-of-raise behaviour was read from jupyter-mcp-tools 0.1.7 `client.py:138-158`, not reproduced end to end this time.
