### PR TITLE
fix(hooks): report the provisioned kernel id to the execute_code hooks

### DIFF
--- a/jupyter_mcp_server/tools/execute_code_tool.py
+++ b/jupyter_mcp_server/tools/execute_code_tool.py
@@ -137,7 +137,9 @@ class ExecuteCodeTool(BaseTool):
                     "[ERROR: Kernel metadata found instead of an active CodeSandboxClient in MCP_SERVER mode]"
                 ]
 
-            kid = current_kernel_id or ""
+            # Read the id back here: ensure_code_sandbox_alive_fn stores a freshly
+            # created sandbox on the notebook entry, so the id read above predates it.
+            kid = notebook_manager.get_code_sandbox_id(current_notebook) or ""
 
         try:
             return await self._execute_on_kernel(

--- a/tests/test_execute_code_hook_kernel_id.py
+++ b/tests/test_execute_code_hook_kernel_id.py
@@ -1,0 +1,104 @@
+# Copyright (c) 2024- Datalayer, Inc.
+#
+# BSD 3-Clause License
+
+"""Tests that execute_code reports the kernel it actually ran on to the hooks."""
+
+import pytest
+
+from jupyter_mcp_server.hooks import HookEvent, HookRegistry
+from jupyter_mcp_server.notebook_manager import NotebookManager
+from jupyter_mcp_server.tools.execute_code_tool import ExecuteCodeTool
+
+
+PROVISIONED_KERNEL_ID = "kernel-provisioned-during-this-call"
+
+
+class RecordingHandler:
+    """Records the kernel_id carried by every execution hook."""
+
+    def __init__(self):
+        self.propagate_errors = False
+        self.kernel_ids: list[tuple[HookEvent, str]] = []
+
+    async def on_event(self, event: HookEvent, **kwargs) -> None:
+        if event in (HookEvent.BEFORE_EXECUTE, HookEvent.AFTER_EXECUTE):
+            self.kernel_ids.append((event, kwargs.get("kernel_id")))
+
+
+class FakeCodeSandbox:
+    """Minimal stand-in for the sandbox client the factory hands back."""
+
+    def __init__(self, sandbox_id):
+        self.id = sandbox_id
+
+    def is_alive(self):
+        return True
+
+    def execute(self, code):
+        return {"outputs": []}
+
+
+@pytest.fixture(autouse=True)
+def reset_registry():
+    """Reset the singleton between tests."""
+    HookRegistry.reset()
+    yield
+    HookRegistry.reset()
+
+
+async def _noop_wait_for_idle(code_sandbox, max_wait_seconds=30):
+    return None
+
+
+@pytest.mark.asyncio
+async def test_hooks_receive_the_kernel_provisioned_during_this_call():
+    notebook_manager = NotebookManager()
+    notebook_manager.add_notebook("notebook", None)
+    notebook_manager.set_current_notebook("notebook")
+
+    handler = RecordingHandler()
+    HookRegistry.get_instance().register(handler)
+
+    await ExecuteCodeTool()._execute_via_notebook_manager(
+        notebook_manager=notebook_manager,
+        code="1 + 1",
+        timeout=5,
+        ensure_code_sandbox_alive_fn=lambda: notebook_manager.ensure_code_sandbox_alive(
+            "notebook", lambda: FakeCodeSandbox(PROVISIONED_KERNEL_ID)
+        ),
+        wait_for_code_sandbox_idle_fn=_noop_wait_for_idle,
+        safe_extract_outputs_fn=lambda outputs: [],
+    )
+
+    assert handler.kernel_ids == [
+        (HookEvent.BEFORE_EXECUTE, PROVISIONED_KERNEL_ID),
+        (HookEvent.AFTER_EXECUTE, PROVISIONED_KERNEL_ID),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_hooks_receive_the_kernel_id_when_the_sandbox_already_exists():
+    notebook_manager = NotebookManager()
+    notebook_manager.add_notebook("notebook", FakeCodeSandbox("kernel-already-running"))
+    notebook_manager.set_current_notebook("notebook")
+
+    handler = RecordingHandler()
+    HookRegistry.get_instance().register(handler)
+
+    def _fail_if_called():
+        raise AssertionError("an existing sandbox must not be re-provisioned")
+
+    await ExecuteCodeTool()._execute_via_notebook_manager(
+        notebook_manager=notebook_manager,
+        code="1 + 1",
+        timeout=5,
+        ensure_code_sandbox_alive_fn=_fail_if_called,
+        wait_for_code_sandbox_idle_fn=_noop_wait_for_idle,
+        safe_extract_outputs_fn=lambda outputs: [],
+    )
+
+    assert handler.kernel_ids == [
+        (HookEvent.BEFORE_EXECUTE, "kernel-already-running"),
+        (HookEvent.AFTER_EXECUTE, "kernel-already-running"),
+    ]


### PR DESCRIPTION
`execute_code` fires its execution hooks with `kernel_id=""` on the one call that provisions the sandbox.

`_execute_via_notebook_manager` reads the notebook's sandbox id at the top of the method, before it knows whether a sandbox exists:

```python
current_kernel_id = notebook_manager.get_code_sandbox_id(current_notebook)
```

When the notebook has none, the branch below calls `ensure_code_sandbox_alive_fn()`, which creates one and stores it on the notebook entry. `kid` was still derived from the value read before that call, so it is `""`, and that is what reaches `BEFORE_EXECUTE` and all three `AFTER_EXECUTE` exits. The execution that provisioned the kernel is therefore the only one a hook consumer cannot attribute to it; every later call on the same notebook reports the id correctly.

`execute_cell` already runs the two steps in the other order (`execute_cell_tool.py:435-438`): provision, then read the id. This makes `execute_code` match.

Reaching it needs a notebook with no live sandbox, which is the state `use_notebook` leaves it in when `start_new_code_sandbox` is false. That is the default in `config.py`, though `cli/commands/serve.py` and the Jupyter extension both set it True, so the plain CLI path provisions eagerly and does not hit this.

Only the hook payload changes. The sandbox the code runs on is the same object either way.

### Verification

- `test_hooks_receive_the_kernel_provisioned_during_this_call` fails on `main`, where the hooks receive `''`, and passes here. Run on 3.10 and 3.13.
- The second test in the file covers the already-provisioned path and passes both before and after, which pins the case this must not change.
- `TEST_MCP_SERVER=true pytest` on 3.10, run against both `main` and this branch: the only assertion failures are `test_auth.py::TestSessionExpiry::test_notebook_operations_recover_after_session_expiry` and `test_cli_typer_config.py::test_jupyter_collaboration_is_a_required_dependency`, and both fail identically on unmodified `main`.
- Not checked: no span was read out of a real OpenTelemetry exporter, so the tests assert the payload handed to `HookRegistry.fire` rather than what a span carries. The integration fixture also could not reliably bind ports on my machine, and the set of tests it errored on varied between two runs of unmodified `main`, so I could not use the rest of that suite as a signal and am relying on CI for it.
