### PR TITLE
fix: read serverapp from the extension context in get_registered_tools

### DIFF
--- a/jupyter_mcp_server/server.py
+++ b/jupyter_mcp_server/server.py
@@ -27,6 +27,7 @@ from jupyter_mcp_server.config import get_config, set_config
 from jupyter_mcp_server.enroll import auto_enroll_document
 from jupyter_mcp_server.extensions import get_extension_manager
 from jupyter_mcp_server.hooks import HookEvent, HookRegistry, with_hooks
+from jupyter_mcp_server.jupyter_extension.context import get_server_context
 from jupyter_mcp_server.log import logger
 from jupyter_mcp_server.models import DocumentCodeSandbox
 from jupyter_mcp_server.notebook_manager import NotebookManager
@@ -1256,12 +1257,13 @@ async def get_registered_tools():
 
                 from jupyter_mcp_server.tool_cache import get_tool_cache
 
-                # Get the base_url and token from server context
-                # In JUPYTER_SERVER mode, we should use the actual serverapp URL, not hardcoded localhost
-                if server_context.serverapp is not None:
+                # Get the base_url and token from the extension context, which is the object
+                # that carries the ServerApp (handlers.py reads it the same way).
+                extension_context = get_server_context()
+                if extension_context.serverapp is not None:
                     # Use the actual Jupyter server connection URL
-                    base_url = server_context.serverapp.connection_url
-                    token = server_context.serverapp.token
+                    base_url = extension_context.serverapp.connection_url
+                    token = extension_context.serverapp.token
                     logger.info(f"Using Jupyter ServerApp connection URL: {base_url}")
                 else:
                     # Fallback to configuration (for remote scenarios)

--- a/tests/test_allowed_jupyter_mcp_tools.py
+++ b/tests/test_allowed_jupyter_mcp_tools.py
@@ -66,9 +66,9 @@ def registered_tools(monkeypatch):
     monkeypatch.setattr(tool_cache, "_global_tool_cache", None, raising=False)
     monkeypatch.setattr(server_context.__class__, "_mode", ServerMode.JUPYTER_SERVER)
     monkeypatch.setattr(server_context.__class__, "_initialized", True)
-    # get_registered_tools reads server_context.serverapp, which this context object does
-    # not define; None selects its documented fallback to the configured sandbox URL.
-    monkeypatch.setattr(server_context, "serverapp", None, raising=False)
+    # No `serverapp` is injected onto server_context here. The real extension context is
+    # left to report the serverapp it actually holds (none, outside a running server),
+    # which selects the documented fallback to the configured sandbox URL.
 
     async def run(allowed):
         reset_config()
@@ -109,3 +109,23 @@ async def test_configured_allowlist_still_registers_its_tools(registered_tools):
 
     assert await run("notebook_run-all-cells") == {"notebook_run-all-cells"}
     assert fetch.queries == ["notebook_run-all-cells"]
+
+
+@pytest.mark.asyncio
+async def test_serverapp_is_read_from_the_extension_context(registered_tools):
+    """The connection details come from the extension context, which is the object that
+    carries the ServerApp.
+
+    get_registered_tools() used to read `serverapp` off the module-level
+    `jupyter_mcp_server.server_context.ServerContext`, which defines no such attribute.
+    The resulting AttributeError was caught by the enclosing `except Exception`, so the
+    jupyter-mcp-tools fetch was never attempted and the allowlist silently registered
+    nothing.
+    """
+    run, fetch = registered_tools
+
+    registered = await run("notebook_run-all-cells,terminal_open")
+
+    # The fetch was attempted at all, which the AttributeError used to prevent.
+    assert fetch.queries == ["notebook_run-all-cells,terminal_open"]
+    assert registered == {"notebook_run-all-cells", "terminal_open"}


### PR DESCRIPTION
Fixes #387.

`get_registered_tools()` read `serverapp` off the module-level `server_context`, which is bound at `server.py:216` to `jupyter_mcp_server.server_context.ServerContext`. That class defines no `serverapp`; the attribute belongs to the same-named class in `jupyter_extension/context.py`. The `AttributeError` was swallowed by the `except Exception` at `server.py:1348`, so the jupyter-mcp-tools fetch was never attempted and `GET /mcp/tools/list` returned the FastMCP tools only.

The fix reads the connection details from the extension context, which is what `handlers.py:145` already does for the same lookup.

## Verification

Clean `python:3.12-slim` container, editable install, `jupyter_mcp_server.__file__` = `/work/jupyter_mcp_server/__init__.py`, at `280d1c8`.

`tests/test_allowed_jupyter_mcp_tools.py`, which #381 added, injected the missing attribute in its fixture:

```python
monkeypatch.setattr(server_context, "serverapp", None, raising=False)
```

`raising=False` was needed because the attribute is absent, and setting it took the fallback branch, so the suite passed over the bug. That line is removed here and the real extension context reports the serverapp it actually holds.

With the fixture corrected and the source fix reverted, 2 of the 4 tests fail:

```
FAILED test_configured_allowlist_still_registers_its_tools
FAILED test_serverapp_is_read_from_the_extension_context
2 failed, 2 passed
```

With the fix applied, `4 passed`.

Wider suite, same container, `--ignore=tests/test_integration.py --ignore=tests/test_execute_cell_sandbox_routing.py` (the latter fails to collect on `jupyter_mcp_sandboxes`, which is not installed):

| | result |
| --- | --- |
| `280d1c8` unmodified | 2 failed, 369 passed, 1 skipped, 121 errors |
| this branch | 2 failed, 370 passed, 1 skipped, 121 errors |

The failures and errors are identical in both runs and are unrelated to this change; the difference is the one added test.

## Limitation

The added test exercises the branch where no ServerApp is present, so it covers the fallback to the configured sandbox URL and proves the fetch is now reached. It does not exercise `connection_url` / `token` against a live `ServerApp`; that path is unchanged apart from the object it is read from.

Happy to adjust the approach if you would rather the two `ServerContext` classes be reconciled instead.
