### PR TITLE
fix(tool_cache): key in-flight fetches by fetcher and shield the shared task

### DIFF
--- a/jupyter_mcp_server/jupyter_extension/handlers.py
+++ b/jupyter_mcp_server/jupyter_extension/handlers.py
@@ -30,6 +30,21 @@ from jupyter_mcp_server.utils import clean_mcp_response, clean_mcp_response_cont
 logger = logging.getLogger(__name__)
 
 
+async def _fetch_jupyter_tools(**kwargs):
+    """Fetch jupyter-mcp-tools with the shorter timeout this transport wants.
+
+    If the JupyterLab frontend is not loaded there is nothing to wait for, so
+    tools/list should not sit here for the library default of 30 seconds.
+
+    Defined at module level on purpose: ToolCache keys its in-flight fetches by
+    fetcher as well as by query, so a function rebuilt per request would stop
+    concurrent tools/list requests from sharing one call.
+    """
+    from jupyter_mcp_tools import get_tools
+
+    return await get_tools(wait_timeout=5, **kwargs)
+
+
 class MCPSSEHandler(JupyterHandler):
     """
     Handler for MCP protocol over Streamable HTTP.
@@ -137,8 +152,6 @@ class MCPSSEHandler(JupyterHandler):
                     # Get tools from jupyter_mcp_tools extension first to identify duplicates
                     jupyter_tools_data = []
                     try:
-                        from jupyter_mcp_tools import get_tools
-
                         from jupyter_mcp_server.tool_cache import get_tool_cache
 
                         # Get the server's base URL dynamically from ServerApp
@@ -187,21 +200,13 @@ class MCPSSEHandler(JupyterHandler):
                                 # Use cached get_tools to avoid expensive repeated calls
                                 tool_cache = get_tool_cache()
 
-                                # Create wrapper function that matches the expected signature
-                                async def get_tools_wrapper(**kwargs):
-                                    # Add wait_timeout for handlers.py compatibility
-                                    return await get_tools(
-                                        wait_timeout=5,  # Shorter timeout - if frontend isn't loaded, don't wait long
-                                        **kwargs,
-                                    )
-
                                 jupyter_tools_data = await tool_cache.get_tools(
                                     base_url=base_url,
                                     token=token,
                                     query=search_query,
                                     enabled_only=False,
                                     ttl_seconds=180,  # 3 minutes for handlers (shorter than server.py)
-                                    fetch_func=get_tools_wrapper,  # Use wrapper that includes wait_timeout
+                                    fetch_func=_fetch_jupyter_tools,  # module-level wrapper carrying wait_timeout=5
                                 )
                                 logger.info(
                                     f"Query returned {len(jupyter_tools_data)} tools (from cache or fresh)"

--- a/jupyter_mcp_server/tool_cache.py
+++ b/jupyter_mcp_server/tool_cache.py
@@ -45,9 +45,12 @@ class ToolCache:
         self._cache: dict[str, CacheEntry] = {}
         self._default_ttl = default_ttl
         self._lock = asyncio.Lock()
-        # In-flight fetches, keyed the same way as _cache, so concurrent callers
-        # that miss on the same key share one call instead of each making their own.
-        self._inflight: dict[str, asyncio.Task] = {}
+        # In-flight fetches, so concurrent callers that miss on the same key share
+        # one call instead of each making their own. The fetcher is part of the key:
+        # two callers can ask for the same tools through fetchers with different
+        # timeouts, and joining someone else's fetch would silently replace the
+        # bound this caller asked for.
+        self._inflight: dict[tuple[str, Any], asyncio.Task] = {}
 
     def _make_cache_key(self, base_url: str, query: str, enabled_only: bool = False) -> str:
         """Create a cache key from the request parameters."""
@@ -60,6 +63,7 @@ class ToolCache:
     async def _fetch_and_store(
         self,
         cache_key: str,
+        inflight_key: tuple[str, Any],
         fetch_func: Any,
         base_url: str,
         token: str,
@@ -93,7 +97,7 @@ class ToolCache:
             return fresh_data
         finally:
             async with self._lock:
-                self._inflight.pop(cache_key, None)
+                self._inflight.pop(inflight_key, None)
 
     async def get_tools(
         self,
@@ -142,17 +146,22 @@ class ToolCache:
                 return entry.data if entry is not None else []
 
             # Join an in-flight fetch for this key rather than starting another.
-            task = self._inflight.get(cache_key)
+            inflight_key = (cache_key, fetch_func)
+            task = self._inflight.get(inflight_key)
             if task is None:
                 task = asyncio.create_task(
                     self._fetch_and_store(
-                        cache_key, fetch_func, base_url, token, query, enabled_only
+                        cache_key, inflight_key, fetch_func, base_url, token, query, enabled_only
                     )
                 )
-                self._inflight[cache_key] = task
+                self._inflight[inflight_key] = task
 
         try:
-            return await task
+            # Shielded: the task is shared, so letting this caller's cancellation
+            # reach it would abort the fetch for everyone else waiting on it. A
+            # cancelled caller still raises CancelledError, it just no longer takes
+            # the other callers down with it.
+            return await asyncio.shield(task)
         except Exception as e:
             logger.error(f"Failed to fetch tools from jupyter-mcp-tools: {e}")
             # Serve the stale entry rather than dropping every tool because one

--- a/tests/test_tool_cache.py
+++ b/tests/test_tool_cache.py
@@ -148,6 +148,99 @@ class TestConcurrentMissCoalescing:
         assert calls["n"] == 2
 
 
+class TestInflightIsolation:
+    """Joining a shared fetch must not change what this caller asked for."""
+
+    @pytest.mark.asyncio
+    async def test_a_different_fetcher_is_not_served_by_the_in_flight_one(self):
+        """The two call sites pass fetchers with different timeouts.
+
+        handlers.py wraps get_tools with wait_timeout=5 ("if frontend isn't
+        loaded, don't wait long"); server.py passes the bare get_tools, whose
+        default is 30. Every other key component is identical between them, so
+        joining by query alone hands the short-timeout caller the long fetch.
+        """
+        used = []
+        started = asyncio.Event()
+
+        async def slow_fetcher(**kwargs):
+            used.append("slow")
+            started.set()
+            await asyncio.sleep(0.20)
+            return TOOLS
+
+        async def fast_fetcher(**kwargs):
+            used.append("fast")
+            await asyncio.sleep(0.01)
+            return TOOLS
+
+        cache = ToolCache(default_ttl=300)
+
+        creator = asyncio.create_task(
+            cache.get_tools(base_url=BASE_URL, token="t", query="q", fetch_func=slow_fetcher)
+        )
+        await started.wait()
+
+        await cache.get_tools(
+            base_url=BASE_URL, token="t", query="q", ttl_seconds=180, fetch_func=fast_fetcher
+        )
+        await creator
+
+        assert "fast" in used, "the joining caller's fetch_func was silently replaced"
+
+    @pytest.mark.asyncio
+    async def test_same_fetcher_still_coalesces(self):
+        """Regression guard: the fetcher is part of the key, not the whole key."""
+        calls = {"n": 0}
+
+        async def fetch(**kwargs):
+            calls["n"] += 1
+            await asyncio.sleep(0.05)
+            return TOOLS
+
+        cache = ToolCache(default_ttl=300)
+        await asyncio.gather(
+            *[
+                cache.get_tools(base_url=BASE_URL, token="t", query="q", fetch_func=fetch)
+                for _ in range(5)
+            ]
+        )
+        assert calls["n"] == 1
+
+    @pytest.mark.asyncio
+    async def test_one_caller_cancelling_does_not_abort_the_shared_fetch(self):
+        """A client disconnecting must not empty the tool list for everyone else.
+
+        `await task` on a shared task propagates the awaiting caller's
+        cancellation into it, and CancelledError is a BaseException, so the
+        other callers do not even reach the stale-serving fallback below.
+        """
+        started = asyncio.Event()
+
+        async def slow_fetch(**kwargs):
+            started.set()
+            await asyncio.sleep(0.20)
+            return TOOLS
+
+        cache = ToolCache(default_ttl=300)
+
+        first = asyncio.create_task(
+            cache.get_tools(base_url=BASE_URL, token="t", query="q", fetch_func=slow_fetch)
+        )
+        await started.wait()
+        second = asyncio.create_task(
+            cache.get_tools(base_url=BASE_URL, token="t", query="q", fetch_func=slow_fetch)
+        )
+        await asyncio.sleep(0.02)  # let the second caller join the in-flight task
+
+        first.cancel()
+
+        with pytest.raises(asyncio.CancelledError):
+            await first
+        assert await second == TOOLS, "an unrelated caller's cancellation emptied the tool list"
+        assert cache.get_cache_stats()["total_entries"] == 1
+
+
 class TestCacheKey:
     """enabled_only changes the result, so it has to be part of the key."""
 


### PR DESCRIPTION
Fixes #392.

## Root cause

`_inflight` was keyed by `_make_cache_key(base_url, query, enabled_only)`, the same key as `_cache`, so a caller joining an existing fetch ran the creator's `fetch_func` rather than its own. The two call sites pass different fetchers on purpose: `handlers.py` wraps `get_tools` with `wait_timeout=5` ("if frontend isn't loaded, don't wait long", #171) and `server.py` passes the bare `get_tools` at the library default of 30. In JUPYTER_SERVER mode every other key component is computed identically in both, so `POST /mcp/` and `GET /mcp/tools/list` collide on one key and the first fetch to start decides the timeout for both.

The shared task was also awaited bare. Cancelling a coroutine that awaits a task cancels that task, so one client disconnecting aborted the fetch for every caller joined on it, and because the recovery below is `except Exception` and `CancelledError` is a `BaseException`, those callers did not reach the stale-serving fallback either.

## Fix

The in-flight key becomes `(cache_key, fetch_func)`, so callers coalesce only when they asked for the same thing through the same fetcher. `handlers.py`'s wrapper moves to module level: it was rebuilt per request, and a fresh function object per request would have made that key unique every time and stopped concurrent `tools/list` requests from sharing a call at all. Its `wait_timeout=5` and its reason are unchanged.

The bare `await task` becomes `await asyncio.shield(task)`. A cancelled caller still raises `CancelledError`, it just no longer takes the shared fetch down with it, and the fetch it started still completes and populates the cache.

`_cache` keying is untouched, so a completed fetch is still shared by everyone regardless of fetcher.

## Verification

- `test_a_different_fetcher_is_not_served_by_the_in_flight_one` and `test_one_caller_cancelling_does_not_abort_the_shared_fetch` fail on `ca89f01` and pass here. `test_same_fetcher_still_coalesces` passes on both and guards the coalescing #371 added.
- `tests/test_tool_cache.py`, `tests/test_tool_cache_empty_result.py`, `tests/test_allowed_jupyter_mcp_tools.py`: 17 passed on this branch in a clean `python:3.12-slim` container. Wider run including `test_jupyter_extension.py`, `test_identity*.py` and `test_auth.py`: 103 passed. `test_auth.py`'s password-auth E2E leaves 1 failure and 2 errors, identical on `ca89f01` and on this branch, so it is not from this change.
- `ruff check` on the three files: 18 findings on `ca89f01`, 17 here, all pre-existing and none new.
- Not exercised against a live JupyterLab frontend. The two call sites' key components were read from the source, and the concurrency itself was reproduced against the real `ToolCache` with stand-in fetchers rather than against real `jupyter-mcp-tools` traffic.

One judgement call worth flagging: keying by the function object means a caller that builds its fetcher inline never coalesces. That is why the wrapper moved rather than the key growing a name-based component. If you would rather `ToolCache.get_tools` took `wait_timeout` explicitly and kept a single fetcher, say so and I will send that instead.
