### PR TITLE
fix(execute): keep the reason when ExecutionStack reports an error as a string

### DIFF
--- a/jupyter_mcp_server/utils.py
+++ b/jupyter_mcp_server/utils.py
@@ -1026,6 +1026,20 @@ async def execute_via_execution_stack(
                     # Check for errors
                     if "error" in result:
                         error_info = result["error"]
+                        if not isinstance(error_info, dict):
+                            # ExecutionStack reports a request-level failure as a
+                            # plain string: the kernel it could not connect to, a
+                            # request superseded by a newer one for the same cell,
+                            # a request cancelled after an earlier one failed. Only
+                            # an exception raised inside the kernel arrives as a
+                            # mapping with ename/evalue/traceback. Wrap the string
+                            # so the reason reaches the caller instead of being
+                            # lost to an attribute error on the lines below.
+                            error_info = {
+                                "ename": "ExecutionError",
+                                "evalue": str(error_info),
+                                "traceback": [],
+                            }
                         logger.error(f"Execution error: {error_info}")
                         error_output = [
                             f"[ERROR: {error_info.get('ename', 'Unknown')}: {error_info.get('evalue', '')}]"

--- a/tests/test_execute_via_execution_stack.py
+++ b/tests/test_execute_via_execution_stack.py
@@ -44,6 +44,22 @@ class _ExecutionStack:
         return next(self._results)
 
 
+class _SingleResultExecutionStack:
+    """Return one terminal result, whatever it is, on the first poll."""
+
+    def __init__(self, result):
+        self._result = result
+
+    def put(self, kernel_id, code, metadata):
+        return "request-id"
+
+    def get(self, kernel_id, request_id):
+        return self._result
+
+    def cancel(self, kernel_id):
+        pass
+
+
 class _Extension:
     def __init__(self, execution_stack):
         self._Extension__execution_stack = execution_stack
@@ -77,3 +93,74 @@ async def test_rich_pending_snapshots_are_not_treated_as_completion():
     assert all("partial" not in str(output) for output in outputs)
     assert raw_outputs == [{"output_type": "stream", "name": "stdout", "text": "complete\n"}]
     assert execution_counts == [1]
+
+
+@pytest.mark.asyncio
+async def test_string_shaped_error_keeps_its_message():
+    # jupyter-server-nbmodel writes a request-level failure as a plain string,
+    # which is the only shape it ever writes for the "error" key: a kernel it
+    # could not connect to, a superseded request, a cancelled request.
+    raw_outputs = []
+
+    outputs = await execute_via_execution_stack(
+        serverapp=_ServerApp(
+            _SingleResultExecutionStack(
+                {
+                    "error": "HTTP 404: Not Found (Kernel does not exist: kernel-id)",
+                    "pending": False,
+                    "request_status": "complete",
+                }
+            )
+        ),
+        kernel_id="kernel-id",
+        code="print('hi')",
+        poll_interval=0,
+        raw_outputs=raw_outputs,
+    )
+
+    assert outputs == [
+        "[ERROR: ExecutionError: HTTP 404: Not Found (Kernel does not exist: kernel-id)]"
+    ]
+    assert raw_outputs == [
+        {
+            "output_type": "error",
+            "ename": "ExecutionError",
+            "evalue": "HTTP 404: Not Found (Kernel does not exist: kernel-id)",
+            "traceback": [],
+        }
+    ]
+
+
+@pytest.mark.asyncio
+async def test_mapping_shaped_error_still_reports_ename_and_evalue():
+    raw_outputs = []
+
+    outputs = await execute_via_execution_stack(
+        serverapp=_ServerApp(
+            _SingleResultExecutionStack(
+                {
+                    "error": {
+                        "ename": "ZeroDivisionError",
+                        "evalue": "division by zero",
+                        "traceback": ["Traceback line"],
+                    },
+                    "pending": False,
+                    "request_status": "complete",
+                }
+            )
+        ),
+        kernel_id="kernel-id",
+        code="1/0",
+        poll_interval=0,
+        raw_outputs=raw_outputs,
+    )
+
+    assert outputs == ["[ERROR: ZeroDivisionError: division by zero]"]
+    assert raw_outputs == [
+        {
+            "output_type": "error",
+            "ename": "ZeroDivisionError",
+            "evalue": "division by zero",
+            "traceback": ["Traceback line"],
+        }
+    ]


### PR DESCRIPTION
Fixes #394

`execute_via_execution_stack` reads a completed request's `error` field as a mapping, and
jupyter-server-nbmodel never writes one there. Every producer of that key writes a plain
string: `execution_stack.py:150` (`str(error)`, the worker could not connect to the kernel)
and five sites in `actions.py` (585, 615, 620, 627, 633: superseded, cancelled after an
earlier failure, cancelled, and `str(e)` twice). An exception raised inside the kernel does
not use the key at all, it arrives under `outputs` with `status: "error"`, which is why the
traceback path works.

`error_info.get` therefore raises `AttributeError`, the outer `except Exception` in the same
function turns it into a cell output, and the reason the execution failed is replaced by
`[ERROR: 'str' object has no attribute 'get']`. In JUPYTER_SERVER file mode
`_write_outputs_to_cell` then persists that string into the notebook.

This wraps a non-mapping `error` in `ename`/`evalue`/`traceback` before the existing lines
read it, so the reported reason survives. Nothing else on the path changes.

## Scenarios pinned by the tests

Two, one test each, both in `tests/test_execute_via_execution_stack.py`:

1. **A string-shaped `error` keeps its message.** The formatted output becomes
   `[ERROR: ExecutionError: HTTP 404: Not Found (Kernel does not exist: kernel-id)]` and
   the `raw_outputs` entry carries the same `evalue`. Verified as a differential: this test
   FAILS on `0fe1eae` with `AssertionError` against
   `["[ERROR: 'str' object has no attribute 'get']"]` and passes with the change.
2. **A mapping-shaped `error` still reports `ename` and `evalue`.** A guard on the branch
   this change does not alter. Passes both with and without the change.

## Verification

Clean `python:3.12-slim` container on `0fe1eaecf9d54b655f65eaf4a971b4a4d4e76784`,
`pip install -e ".[test]"`, `jupyter_mcp_server.__file__` reported as
`/build/app/jupyter_mcp_server/__init__.py`, version 1.5.2.

Live differential against a real `ExecutionStack` and a real `AsyncMappingKernelManager`,
before the change (the repro in the issue):

```
stack : {"error": "HTTP 404: Not Found (Kernel does not exist: 1111...5555)", ..., "request_status": "complete"}
type  : str
server: ["[ERROR: 'str' object has no attribute 'get']"]
```

Controls on the same run, both unaffected: a live kernel running `print('alive')` returns
`['alive\n']`, and a live kernel running `1/0` returns the real `ZeroDivisionError`
traceback.

Targeted:

```
tests/test_execute_via_execution_stack.py                          3 passed
tests/test_execute_code_kernel_id.py                               4 passed
```

Whole suite, same container both sides, `pytest tests/` with the two optional
`ext/` packages installed:

```
0fe1eae             3 failed, 440 passed, 1 skipped, 57 errors   (17:59)
0fe1eae + this PR   4 failed, 440 passed, 1 skipped, 58 errors   (19:58)
```

Those errors and failures are the live-server tests (`test_tools.py`, `test_auth.py`,
`test_use_notebook_split_servers.py`), and they are order and timing dependent in this
container rather than caused by the change. The one failure present on the right and
absent on the left is
`test_execute_code_kernel_id.py::test_execute_code_runs_in_the_requested_kernel`, which
passes on the patched tree when run on its own (above), and which exercises
`execute_code`, a tool that does not call the changed function at all. The branch this PR
touches runs only when a completed request carries an `error` key, which no live-server
test produces. I could not get a clean local baseline, so the CI matrix is the real check.
