### PR TITLE
test: cover cell mutation file fallback

### DIFF
--- a/tests/test_read_tools_ydoc.py
+++ b/tests/test_read_tools_ydoc.py
@@ -187,9 +187,10 @@ class TestCellMutationFileFallback:
         result = await self.tool.execute(
             mode=ServerMode.JUPYTER_SERVER,
             contents_manager=_FileContentsManager(tmp_path),
-            notebook_manager=None,
+            notebook_manager=_FakeNotebookManager("nb", "nb.ipynb"),
             cell_index=0,
             cell_source="UPDATED_SOURCE",
+            notebook_name="nb",
         )
 
         assert "UPDATED_SOURCE" in result
@@ -211,6 +212,9 @@ class _FakeNotebookManager:
 
     def get_notebook_path(self, name):
         return self._path
+
+    def get_code_sandbox_id(self, name):
+        return None
 
 
 class TestReadNotebookToolYDocFirst:

--- a/tests/test_read_tools_ydoc.py
+++ b/tests/test_read_tools_ydoc.py
@@ -26,14 +26,14 @@ import pytest
 
 import jupyter_mcp_server.tools.read_cell_tool as read_cell_tool_module
 import jupyter_mcp_server.tools.read_notebook_tool as read_notebook_tool_module
+from jupyter_mcp_server.jupyter_extension.context import get_server_context
 from jupyter_mcp_server.tools import (
     overwrite_cell_source_tool as overwrite_cell_source_tool_module,
 )
-from jupyter_mcp_server.jupyter_extension.context import get_server_context
 from jupyter_mcp_server.tools._base import ServerMode
+from jupyter_mcp_server.tools.overwrite_cell_source_tool import OverwriteCellSourceTool
 from jupyter_mcp_server.tools.read_cell_tool import ReadCellTool
 from jupyter_mcp_server.tools.read_notebook_tool import ReadNotebookTool
-from jupyter_mcp_server.tools.overwrite_cell_source_tool import OverwriteCellSourceTool
 
 
 def _write_notebook(path, sources):

--- a/tests/test_read_tools_ydoc.py
+++ b/tests/test_read_tools_ydoc.py
@@ -3,7 +3,7 @@
 # BSD 3-Clause License
 
 """
-Tests for read_cell and read_notebook tools' YDoc-first read path.
+Tests for YDoc-first reads and the non-collaborative file fallback path.
 
 Regression tests for #297: in JUPYTER_SERVER mode, read_cell/read_notebook
 unconditionally read the notebook file from disk, so a write that already
@@ -26,10 +26,14 @@ import pytest
 
 import jupyter_mcp_server.tools.read_cell_tool as read_cell_tool_module
 import jupyter_mcp_server.tools.read_notebook_tool as read_notebook_tool_module
+from jupyter_mcp_server.tools import (
+    overwrite_cell_source_tool as overwrite_cell_source_tool_module,
+)
 from jupyter_mcp_server.jupyter_extension.context import get_server_context
 from jupyter_mcp_server.tools._base import ServerMode
 from jupyter_mcp_server.tools.read_cell_tool import ReadCellTool
 from jupyter_mcp_server.tools.read_notebook_tool import ReadNotebookTool
+from jupyter_mcp_server.tools.overwrite_cell_source_tool import OverwriteCellSourceTool
 
 
 def _write_notebook(path, sources):
@@ -159,6 +163,39 @@ class TestReadCellToolYDocFirst:
         )
 
         assert "FILE_SOURCE" in "\n".join(result)
+
+
+class TestCellMutationFileFallback:
+    """Exercise cell mutation against a notebook with no collaborative room."""
+
+    def setup_method(self):
+        self.tool = OverwriteCellSourceTool()
+
+    @pytest.mark.asyncio
+    async def test_overwrite_cell_updates_file_without_ydoc(self, tmp_path, monkeypatch):
+        notebook_path = tmp_path / "nb.ipynb"
+        _write_notebook(str(notebook_path), ["FILE_SOURCE"])
+        get_server_context().update(
+            context_type="JUPYTER_SERVER", serverapp=_FakeServerApp(str(tmp_path))
+        )
+        monkeypatch.setattr(
+            overwrite_cell_source_tool_module,
+            "get_notebook_model",
+            _fake_get_notebook_model(None),
+        )
+
+        result = await self.tool.execute(
+            mode=ServerMode.JUPYTER_SERVER,
+            contents_manager=_FileContentsManager(tmp_path),
+            notebook_manager=None,
+            cell_index=0,
+            cell_source="UPDATED_SOURCE",
+        )
+
+        assert "UPDATED_SOURCE" in result
+        with open(notebook_path, encoding="utf-8") as f:
+            notebook = nbformat.read(f, as_version=4)
+        assert notebook.cells[0].source == "UPDATED_SOURCE"
 
 
 class _FakeNotebookManager:


### PR DESCRIPTION
## Summary

Closes #224.

Adds deterministic coverage for overwriting a cell through the non-collaborative, file-based fallback path. The test disables the YDoc lookup, calls `OverwriteCellSourceTool.execute()` with a connected notebook context, and verifies the updated notebook contents on disk.

## Compatibility and scope

- Test-only change; production behavior and public APIs are unchanged.
- YDoc and WebSocket paths are unchanged.
- The test uses the same notebook name/path resolution contract as a connected notebook.

## Verification

- `python -m pytest -q tests/test_read_tools_ydoc.py::TestCellMutationFileFallback::test_overwrite_cell_updates_file_without_ydoc` — 1 passed.
- `python -m pytest -q tests/test_read_tools_ydoc.py` — 5 passed.
- `ruff check tests/test_read_tools_ydoc.py --select I001` — passed.
- `git diff --check` — passed.
- Full-file `ruff check tests/test_read_tools_ydoc.py` still reports the pre-existing `A002` finding on `_FileContentsManager.get(..., type=...)`; this PR does not modify that helper signature.

## Evidence review

- **Issue meaningful and reproducible:** Yes. #224 requests coverage of the file fallback path. The initial fixture failed in CI because it supplied neither a notebook manager nor a notebook name, so `resolve_notebook_path()` returned `None`.
- **Requirements satisfied:** Yes. The test now reaches the real file mutation path through the public `execute()` entry point and asserts the notebook content on disk.
- **Additional problems assessed:** Yes. The change is test-only and preserves all production APIs and behavior.
- **Atomicity/consistency/races assessed:** Not applicable to the current diff. The earlier production locking/atomic-write experiment was removed; this PR changes no persistence or concurrency code.
- **Tests sufficient:** Yes for the requested fixture. The test fails when the connected notebook context is omitted and passes with the required context; the surrounding YDoc-first and file-fallback tests also pass.