### PR TITLE
fix(sandbox): rebuild a code sandbox whose kernel the server no longer has

### DIFF
--- a/jupyter_mcp_server/notebook_manager.py
+++ b/jupyter_mcp_server/notebook_manager.py
@@ -44,6 +44,11 @@ logger = logging.getLogger(__name__)
 DISCONNECT_TIMEOUT = 20
 
 
+def _code_sandbox_reports_alive(code_sandbox: Any) -> bool:
+    """Ask the sandbox object itself whether it is alive."""
+    return hasattr(code_sandbox, "is_alive") and bool(code_sandbox.is_alive())
+
+
 class NotebookConnection:
     """
     Context manager for Notebook connections that handles the lifecycle
@@ -370,7 +375,10 @@ class NotebookManager:
         return len(self._notebooks) == 0
 
     def ensure_code_sandbox_alive(
-        self, name: str, code_sandbox_factory: Callable[[], CodeSandboxClient]
+        self,
+        name: str,
+        code_sandbox_factory: Callable[[], CodeSandboxClient],
+        is_alive_fn: Callable[[Any], bool] | None = None,
     ) -> CodeSandboxClient:
         """
         Ensure a code sandbox is alive, create if necessary.
@@ -378,16 +386,17 @@ class NotebookManager:
         Args:
             name: Notebook identifier
             code_sandbox_factory: Function to create a new code sandbox
+            is_alive_fn: Liveness test for the tracked sandbox. Defaults to the
+                sandbox's own `is_alive()`, which reports whether this process
+                started it and not whether it still exists where it runs.
 
         Returns:
             The alive code sandbox instance
         """
         code_sandbox = self.get_code_sandbox(name)
-        if (
-            code_sandbox is None
-            or not hasattr(code_sandbox, "is_alive")
-            or not code_sandbox.is_alive()
-        ):
+        if is_alive_fn is None:
+            is_alive_fn = _code_sandbox_reports_alive
+        if code_sandbox is None or not is_alive_fn(code_sandbox):
             new_code_sandbox = code_sandbox_factory()
             if name in self._notebooks:
                 # Swap only the sandbox: a restart replaces the sandbox, never the

--- a/jupyter_mcp_server/utils.py
+++ b/jupyter_mcp_server/utils.py
@@ -651,13 +651,44 @@ def start_code_sandbox(notebook_manager, config, logger):
         raise
 
 
+def code_sandbox_is_alive(code_sandbox: Any) -> bool:
+    """Whether `code_sandbox` can still run code.
+
+    `CodeSandboxClient.is_alive()` returns `is_started`, a flag set when this
+    process called `start()`, so it stays True after the kernel goes away on the
+    server side. For a Jupyter-backed sandbox the server's kernel list is the
+    authority, the same check `use_notebook` and `execute_code` already make
+    before they accept a caller-supplied kernel id.
+    """
+    if not hasattr(code_sandbox, "is_alive") or not code_sandbox.is_alive():
+        return False
+    if getattr(code_sandbox, "variant", None) != "jupyter-server":
+        return True
+
+    from jupyter_mcp_server.server_context import ServerContext
+
+    kernel_id = getattr(code_sandbox, "id", None)
+    sandbox_server_client = ServerContext.get_instance().sandbox_server_client
+    if not kernel_id or sandbox_server_client is None:
+        return True
+    try:
+        kernels = sandbox_server_client.kernels.list_kernels()
+    except Exception:
+        # A failed lookup says nothing about the kernel, so keep the sandbox
+        # rather than discarding a working one on a transient error.
+        return True
+    return any(kernel.id == kernel_id for kernel in kernels)
+
+
 def ensure_code_sandbox_alive(
     notebook_manager, current_notebook, create_code_sandbox_fn: Callable[[], CodeSandboxClient]
 ) -> CodeSandboxClient:
     """Ensure the notebook's code sandbox is running, restart if needed."""
     return cast(
         CodeSandboxClient,
-        notebook_manager.ensure_code_sandbox_alive(current_notebook, create_code_sandbox_fn),
+        notebook_manager.ensure_code_sandbox_alive(
+            current_notebook, create_code_sandbox_fn, is_alive_fn=code_sandbox_is_alive
+        ),
     )
 
 

--- a/tests/test_ensure_code_sandbox_alive_server_liveness.py
+++ b/tests/test_ensure_code_sandbox_alive_server_liveness.py
@@ -1,0 +1,117 @@
+# Copyright (c) 2024- Datalayer, Inc.
+#
+# BSD 3-Clause License
+
+"""Unit tests for the server-side liveness check in ensure_code_sandbox_alive.
+
+A Jupyter-backed sandbox keeps reporting `is_alive()` True after the server has
+dropped its kernel, so the guard is driven from the server's kernel list. These
+tests use a stand-in sandbox and a stubbed server client, so no running Jupyter
+server is required.
+"""
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+from jupyter_mcp_server.notebook_manager import NotebookManager
+from jupyter_mcp_server.server_context import ServerContext
+from jupyter_mcp_server.tools import ServerMode
+from jupyter_mcp_server.utils import code_sandbox_is_alive, ensure_code_sandbox_alive
+
+
+class FakeSandbox:
+    """Stand-in for CodeSandboxClient exposing only what the guard reads."""
+
+    def __init__(self, sandbox_id, variant="jupyter-server"):
+        self.id = sandbox_id
+        self.variant = variant
+
+    def is_alive(self):
+        return True
+
+
+def _server_client_listing(*kernel_ids):
+    client = MagicMock()
+    client.kernels.list_kernels.return_value = [SimpleNamespace(id=k) for k in kernel_ids]
+    return client
+
+
+def _install_server_client(client):
+    context = ServerContext.get_instance()
+    context._mode = ServerMode.MCP_SERVER
+    context._sandbox_server_client = client
+    context._initialized = True
+    return context
+
+
+def setup_function():
+    ServerContext.reset()
+    ServerContext._instance = None
+
+
+def teardown_function():
+    ServerContext.reset()
+    ServerContext._instance = None
+
+
+def test_ensure_replaces_sandbox_whose_kernel_the_server_dropped():
+    """The kernel is gone from the server, so the guard provisions a new sandbox."""
+    _install_server_client(_server_client_listing())
+    nm = NotebookManager()
+    stale = FakeSandbox("culled-kernel")
+    nm.add_notebook("nb", stale)
+
+    result = ensure_code_sandbox_alive(nm, "nb", lambda: FakeSandbox("fresh-kernel"))
+
+    assert result.id == "fresh-kernel"
+    assert nm.get_code_sandbox_id("nb") == "fresh-kernel"
+
+
+def test_ensure_keeps_sandbox_the_server_still_lists():
+    """The kernel is still on the server, so nothing is provisioned."""
+    _install_server_client(_server_client_listing("live-kernel", "someone-elses-kernel"))
+    nm = NotebookManager()
+    live = FakeSandbox("live-kernel")
+    nm.add_notebook("nb", live)
+
+    result = ensure_code_sandbox_alive(nm, "nb", lambda: FakeSandbox("should-not-be-used"))
+
+    assert result is live
+
+
+def test_lookup_failure_keeps_the_sandbox():
+    """A failed kernel listing is not evidence that the kernel is gone."""
+    client = MagicMock()
+    client.kernels.list_kernels.side_effect = ConnectionError("server unreachable")
+    _install_server_client(client)
+    live = FakeSandbox("live-kernel")
+
+    assert code_sandbox_is_alive(live) is True
+
+
+def test_sandbox_that_reports_itself_dead_is_not_looked_up():
+    """The sandbox's own answer is still enough to condemn it."""
+    client = _server_client_listing("live-kernel")
+    _install_server_client(client)
+    stopped = FakeSandbox("live-kernel")
+    stopped.is_alive = lambda: False
+
+    assert code_sandbox_is_alive(stopped) is False
+    client.kernels.list_kernels.assert_not_called()
+
+
+def test_sandbox_is_kept_when_no_server_client_is_configured():
+    """With nothing to ask, the previous behaviour stands."""
+    context = _install_server_client(None)
+    context._sandbox_server_client = None
+
+    assert code_sandbox_is_alive(FakeSandbox("live-kernel")) is True
+
+
+def test_non_jupyter_sandbox_is_not_checked_against_the_kernel_list():
+    """Another variant does not run on this server, so its kernel list says nothing."""
+    client = _server_client_listing()
+    _install_server_client(client)
+
+    assert code_sandbox_is_alive(FakeSandbox("sandbox-1", variant="e2b")) is True
+    client.kernels.list_kernels.assert_not_called()


### PR DESCRIPTION
`CodeSandboxClient.is_alive()` returns `is_started`, a flag set when this process called `start()`. It never asks the server, so it stays `True` after the kernel goes away: an idle cull, a `DELETE /api/kernels/<id>`, or a server restart. `ensure_code_sandbox_alive` is the guard meant to replace a dead sandbox, and it reads exactly that flag, so it finds nothing wrong and hands the caller a sandbox that can no longer execute.

Measured on `9908001` in a clean container, driving the real guard against a real Jupyter server, with `/api/kernels` empty in both rows:

```
kernel deleted server-side   new sandbox: no   execute -> stdout '' after 25.0s, "Timeout waiting for output"
jupyter server restarted     new sandbox: no   execute -> stdout '' at once,     "Connection is already closed."
```

In the first row the outcome still comes back with `success=True` and no output, which is the shape that worries me most: nothing upstream of the sandbox has been told the cell did not run.

## The fix

Ask the server. For a Jupyter-backed sandbox its kernel list is the authority, and it is the check `use_notebook` and `execute_code` already make before they accept a caller-supplied kernel id. `NotebookManager.ensure_code_sandbox_alive` takes an optional liveness callable, defaulting to today's `is_alive()` so no other caller changes, and `utils.ensure_code_sandbox_alive` supplies one that looks the sandbox id up in `/api/kernels`.

Two cases deliberately keep the current sandbox: a non-`jupyter-server` variant, whose kernel does not live on this server at all, and a failed lookup, which is not evidence about the kernel and should not cost a working one.

With the change, both rows above provision a replacement in about 1.1s and the next execution prints normally.

## Verification

- The new test fails on `main`, where the guard returns the culled sandbox, and passes here. The existing `ensure_kernel_alive` tests are untouched and still pass.
- Full suite in both server modes on Python 3.10 and 3.13, in a clean container: identical failures to `main` run in the same container, plus the 6 new tests. Several server-backed tests error there on `main` as well, so that set is not from this change.
- `ruff` and `mypy` over the two changed files report the same as `main`.
- Not checked: a connection that drops while the kernel is still running. The server keeps listing it, so the guard leaves that case exactly as it is today.

Refs #21. This covers the half where the kernel is gone from the server. The report also describes a websocket dropping under a kernel that is still alive, and that is untouched here.
