### PR TITLE
fix(execute): let a missing kernel reach execute_cell's retry instead of becoming an output

### DIFF
--- a/jupyter_mcp_server/utils.py
+++ b/jupyter_mcp_server/utils.py
@@ -897,6 +897,25 @@ async def safe_notebook_operation(operation_func, max_retries=3):
 ###############################################################################
 
 
+class MissingKernelError(RuntimeError):
+    """The kernel an execution request targeted no longer exists on the server.
+
+    Callers that can start a replacement kernel and retry need this failure as an
+    exception; every other request-level failure stays a formatted output.
+    """
+
+
+def is_missing_kernel_message(message: Any) -> bool:
+    """Whether *message* reads as the server reporting an unknown kernel.
+
+    ExecutionStack reports this as free text rather than a code, so this matches
+    the same two words ``execute_cell`` already looks for before it starts a
+    replacement kernel.
+    """
+    text = str(message).lower()
+    return "kernel" in text and "not found" in text
+
+
 async def execute_via_execution_stack(
     serverapp: Any,
     kernel_id: str,
@@ -944,6 +963,7 @@ async def execute_via_execution_stack(
     Raises:
         RuntimeError: If jupyter-server-nbmodel extension is not installed
         TimeoutError: If execution exceeds timeout
+        MissingKernelError: If the request failed because ``kernel_id`` is gone
     """
     import logging as default_logging
 
@@ -1041,6 +1061,13 @@ async def execute_via_execution_stack(
                                 "traceback": [],
                             }
                         logger.error(f"Execution error: {error_info}")
+                        if is_missing_kernel_message(error_info.get("evalue", "")):
+                            # execute_cell starts a replacement kernel and retries
+                            # once when this happens, and it looks for the failure
+                            # in an exception. Leave as one so that path can run;
+                            # the handler at the end of this function fires the
+                            # single AFTER_EXECUTE this execution owes and re-raises.
+                            raise MissingKernelError(error_info.get("evalue", ""))
                         error_output = [
                             f"[ERROR: {error_info.get('ename', 'Unknown')}: {error_info.get('evalue', '')}]"
                         ]
@@ -1175,6 +1202,8 @@ async def execute_via_execution_stack(
                 error=e,
                 context=hook_ctx,
             )
+        if isinstance(e, MissingKernelError):
+            raise
         return [f"[ERROR: {e!s}]"]
 
 

--- a/tests/test_execute_cell_dead_kernel_retry.py
+++ b/tests/test_execute_cell_dead_kernel_retry.py
@@ -1,0 +1,147 @@
+# Copyright (c) 2024- Datalayer, Inc.
+#
+# BSD 3-Clause License
+
+"""execute_cell's dead-kernel retry in JUPYTER_SERVER mode.
+
+ExecutionStack reports a kernel it cannot reach as a terminal result rather than
+by raising, so the retry that execute_cell wraps around it needs that one failure
+to leave execute_via_execution_stack as an exception. These tests drive the real
+helper, so nothing on the fault path is stubbed out apart from the ExecutionStack
+and the kernel manager the server would provide.
+"""
+
+import json
+from types import SimpleNamespace
+
+import nbformat
+import pytest
+
+from jupyter_mcp_server.notebook_manager import NotebookManager
+from jupyter_mcp_server.tools._base import ServerMode
+from jupyter_mcp_server.tools.execute_cell_tool import ExecuteCellTool
+from jupyter_mcp_server.utils import MissingKernelError, execute_via_execution_stack
+
+KERNEL_GONE = "HTTP 404: Not Found (Kernel does not exist: kernel-1)"
+
+
+class DeadKernelExecutionStack:
+    """First request reports the kernel gone; a later one runs normally."""
+
+    def __init__(self):
+        self.put_kernels: list[str] = []
+
+    def put(self, kernel_id, code, metadata):
+        self.put_kernels.append(kernel_id)
+        return f"request-{len(self.put_kernels)}"
+
+    def get(self, kernel_id, request_id):
+        if request_id == "request-1":
+            return {"error": KERNEL_GONE, "pending": False, "request_status": "complete"}
+        return {
+            "pending": False,
+            "request_status": "complete",
+            "status": "ok",
+            "execution_count": 1,
+            "outputs": json.dumps(
+                [{"output_type": "stream", "name": "stdout", "text": "ran on the replacement\n"}]
+            ),
+        }
+
+    def cancel(self, kernel_id):
+        pass
+
+
+class _Extension:
+    def __init__(self, execution_stack):
+        self._Extension__execution_stack = execution_stack
+
+
+class _ExtensionManager:
+    def __init__(self, extension):
+        self.extension_apps = {"jupyter_server_nbmodel": {extension}}
+
+
+class _FileIdManager:
+    def get_id(self, _path):
+        return "file-id"
+
+    def index(self, _path):
+        return "file-id"
+
+
+class StaleKernelManager:
+    """Still lists the culled kernel, so execute_cell's pre-check passes and the
+    request reaches an ExecutionStack that knows the kernel is gone."""
+
+    def __init__(self):
+        self.started_paths: list[str] = []
+
+    def list_kernels(self):
+        return [{"id": "kernel-1"}]
+
+    async def start_kernel(self, path=None):
+        self.started_paths.append(path)
+        return "kernel-2"
+
+
+@pytest.mark.asyncio
+async def test_missing_kernel_raises_instead_of_returning_a_formatted_output():
+    stack = DeadKernelExecutionStack()
+    serverapp = SimpleNamespace(extension_manager=_ExtensionManager(_Extension(stack)))
+
+    with pytest.raises(MissingKernelError) as raised:
+        await execute_via_execution_stack(
+            serverapp=serverapp, kernel_id="kernel-1", code="print('hi')", poll_interval=0
+        )
+
+    assert str(raised.value) == KERNEL_GONE
+
+
+@pytest.mark.asyncio
+async def test_execute_cell_starts_a_replacement_kernel_and_retries_once(monkeypatch):
+    stack = DeadKernelExecutionStack()
+    serverapp = SimpleNamespace(
+        root_dir="/srv/notebooks",
+        web_app=SimpleNamespace(settings={"file_id_manager": _FileIdManager()}),
+        extension_manager=_ExtensionManager(_Extension(stack)),
+    )
+
+    async def no_ydoc(_serverapp, _file_id):
+        return None
+
+    async def no_sleep(_seconds):
+        return None
+
+    async def no_write(*_args, **_kwargs):
+        return None
+
+    async def read_notebook(_path):
+        return nbformat.v4.new_notebook(cells=[nbformat.v4.new_code_cell("print('hi')")])
+
+    monkeypatch.setattr(
+        "jupyter_mcp_server.jupyter_extension.context.get_server_context",
+        lambda: SimpleNamespace(serverapp=serverapp),
+    )
+    monkeypatch.setattr(
+        "jupyter_mcp_server.tools.execute_cell_tool.get_current_notebook_context",
+        lambda _manager: ("demo.ipynb", "kernel-1"),
+    )
+    monkeypatch.setattr("jupyter_mcp_server.tools.execute_cell_tool.get_jupyter_ydoc", no_ydoc)
+    monkeypatch.setattr("jupyter_mcp_server.tools.execute_cell_tool.asyncio.sleep", no_sleep)
+    monkeypatch.setattr(ExecuteCellTool, "_write_outputs_to_cell", no_write)
+
+    tool = ExecuteCellTool()
+    monkeypatch.setattr(tool, "_read_notebook_file_with_retry", read_notebook)
+    kernel_manager = StaleKernelManager()
+
+    outputs = await tool.execute(
+        mode=ServerMode.JUPYTER_SERVER,
+        kernel_manager=kernel_manager,
+        notebook_manager=NotebookManager(),
+        cell_index=0,
+    )
+
+    assert outputs == ["ran on the replacement\n"]
+    assert kernel_manager.started_paths == ["demo.ipynb"]
+    assert stack.put_kernels == ["kernel-1", "kernel-2"]

--- a/tests/test_execute_hook_pairing.py
+++ b/tests/test_execute_hook_pairing.py
@@ -19,7 +19,11 @@ import zmq.asyncio
 
 from jupyter_mcp_server.hooks import HookEvent, HookRegistry
 from jupyter_mcp_server.otel_hook import create_otel_handler
-from jupyter_mcp_server.utils import execute_code_local, execute_via_execution_stack
+from jupyter_mcp_server.utils import (
+    MissingKernelError,
+    execute_code_local,
+    execute_via_execution_stack,
+)
 
 
 class RecordingHandler:
@@ -216,6 +220,28 @@ async def test_unexpected_error_after_submission_fires_after_execute(handler):
     assert outputs == ["[ERROR: stack blew up]"]
     after = assert_paired(handler)
     assert isinstance(after["error"], ValueError)
+
+
+@pytest.mark.asyncio
+async def test_missing_kernel_fires_after_execute_before_it_propagates(handler):
+    """The one request-level failure that leaves as an exception still owes its AFTER."""
+    stack = _ExecutionStack(
+        results=[
+            {
+                "error": "HTTP 404: Not Found (Kernel does not exist: kernel-1)",
+                "pending": False,
+                "request_status": "complete",
+            }
+        ]
+    )
+
+    with pytest.raises(MissingKernelError):
+        await execute_via_execution_stack(
+            serverapp=_ServerApp(stack), kernel_id="kernel-1", code="print(1)", poll_interval=0
+        )
+
+    after = assert_paired(handler)
+    assert isinstance(after["error"], MissingKernelError)
 
 
 @pytest.mark.asyncio

--- a/tests/test_execute_via_execution_stack.py
+++ b/tests/test_execute_via_execution_stack.py
@@ -99,14 +99,16 @@ async def test_rich_pending_snapshots_are_not_treated_as_completion():
 async def test_string_shaped_error_keeps_its_message():
     # jupyter-server-nbmodel writes a request-level failure as a plain string,
     # which is the only shape it ever writes for the "error" key: a kernel it
-    # could not connect to, a superseded request, a cancelled request.
+    # could not connect to, a superseded request, a cancelled request. The
+    # missing-kernel one leaves as an exception instead, so execute_cell can
+    # retry it; see tests/test_execute_cell_dead_kernel_retry.py.
     raw_outputs = []
 
     outputs = await execute_via_execution_stack(
         serverapp=_ServerApp(
             _SingleResultExecutionStack(
                 {
-                    "error": "HTTP 404: Not Found (Kernel does not exist: kernel-id)",
+                    "error": "Request superseded by a newer execution for this cell",
                     "pending": False,
                     "request_status": "complete",
                 }
@@ -119,13 +121,13 @@ async def test_string_shaped_error_keeps_its_message():
     )
 
     assert outputs == [
-        "[ERROR: ExecutionError: HTTP 404: Not Found (Kernel does not exist: kernel-id)]"
+        "[ERROR: ExecutionError: Request superseded by a newer execution for this cell]"
     ]
     assert raw_outputs == [
         {
             "output_type": "error",
             "ename": "ExecutionError",
-            "evalue": "HTTP 404: Not Found (Kernel does not exist: kernel-id)",
+            "evalue": "Request superseded by a newer execution for this cell",
             "traceback": [],
         }
     ]


### PR DESCRIPTION
Fixes #398

## The problem

`execute_cell` starts a replacement kernel and retries once when the kernel it was using went away, in both JUPYTER_SERVER branches (`execute_cell_tool.py:340` and `:398`). It looks for that failure in an exception, and `execute_via_execution_stack` never produces one: a missing kernel arrives as a completed request carrying an `error` key, and that branch returns a formatted output at `utils.py:1065`. The rest of the function is covered by a single `except Exception` that turns every other failure into an output too, so nothing but `asyncio.CancelledError` leaves it.

The retry has therefore been dead code since it was added in #331. Details and a standalone repro are in the issue.

## The change

One request-level failure now leaves as an exception, and every other one is unchanged:

- `MissingKernelError`, a `RuntimeError` subclass, plus `is_missing_kernel_message`, which applies the same two-word test `execute_cell` already uses to decide whether to retry.
- The `if "error" in result:` branch raises it instead of returning, when the reason reads as a missing kernel.
- The outer handler re-raises that one type after firing `AFTER_EXECUTE`, so the pairing contract from #360 still holds: exactly one `AFTER_EXECUTE`, carrying the exception, on this exit as on the others.

`execute_cell` is untouched. Its existing predicate matches by construction, because the same predicate is what selected the failure for raising.

## What I did not change, and why it is a question rather than a decision

Having `utils.py` apply the caller's own string test means that predicate is now written in two places, and if either copy drifts the retry goes quietly dead again in exactly the way it is dead now. Letting `execute_cell` catch `MissingKernelError` and drop its string sniff would leave one copy, but that edits working code of yours rather than unblocking it, so I left it out of this PR. Say the word and I will add it here.

## Behaviour change to be aware of

If the retry also fails because the replacement kernel is gone too, the second `MissingKernelError` propagates out of `execute_cell` rather than being returned as an output string. `execute()` already raises `ValueError` and `RuntimeError` on several paths, so this is not a new mode for the tool, but it is a real difference from today, where that case returns text.

## Verification

Clean `python:3.12-slim` container, `pip install -e ".[test]"`, `__file__` = `/build/app/jupyter_mcp_server/__init__.py`, both sides of the differential in the same container.

The issue's repro script, run verbatim, at `99080012` and with this patch:

```
baseline  returned           : ['[ERROR: ExecutionError: HTTP 404: Not Found (Kernel does not exist: kernel-1)]']
          replacement kernels: []
          requests submitted : ['kernel-1']

patched   returned           : ['ran on the replacement\n']
          replacement kernels: ['demo.ipynb']
          requests submitted : ['kernel-1', 'kernel-2']
```

### Tests

`tests/test_execute_cell_dead_kernel_retry.py` is new and covers the two claims above:

- `test_missing_kernel_raises_instead_of_returning_a_formatted_output` for the helper
- `test_execute_cell_starts_a_replacement_kernel_and_retries_once` drives the real `ExecuteCellTool.execute()` over the real `execute_via_execution_stack`, so nothing on the fault path is stubbed apart from the `ExecutionStack` and the kernel manager the server would supply

`tests/test_execute_hook_pairing.py` gains `test_missing_kernel_fires_after_execute_before_it_propagates` for the pairing claim.

`tests/test_execute_via_execution_stack.py::test_string_shaped_error_keeps_its_message` is the one existing expectation this changes. It used the `HTTP 404 ... Kernel does not exist` payload, which now raises, so it moves to the superseded-request payload and keeps covering the string-shaped wrapping from #395. The kernel payload is covered by the new file.

Targeted, on the patched tree:

```
tests/test_execute_cell_dead_kernel_retry.py     2 passed   (new)
tests/test_execute_hook_pairing.py             11 passed
tests/test_execute_via_execution_stack.py       3 passed
                                               16 passed in 3.58s

plus the rest of the execute surface, unchanged:
tests/test_execute_cell_kernel_start_path.py, test_execute_cell_output_fidelity.py,
test_execute_cell_kernel_execution_count.py, test_execute_orphaned_timeout.py,
test_execute_progress_keepalive.py, test_execute_cell_stream.py
                                               43 passed in 37.25s
```

Whole suite, same container both sides, `tests/` with `test_execute_cell_sandbox_routing.py` ignored (it needs the optional `jupyter_mcp_sandboxes` package, which is not installed here):

```
99080012          2 failed, 375 passed, 1 skipped, 1 warning, 121 errors in 80.04s
99080012 + this   2 failed, 378 passed, 1 skipped, 1 warning, 121 errors in 77.97s
```

The 121 errors and 2 failures are identical on both sides, module for module and count for
count. They are the tests that need the live `jupyter_server` fixture, which does not come up
in this bare container: `test_tools.py` 37, `test_move_cell.py` 28, `test_edit_cell_source.py`
24, `test_auth.py` 9, `test_jupyter_extension.py` 7, `test_otel_integration.py` 6,
`test_use_notebook_ui_open.py` 4, `test_execute_code_kernel_id.py` 4,
`test_extension_legacy_hook.py` 3, `test_use_notebook_split_servers.py` 2,
`test_notebook_connection_disconnect_timeout.py` 1. I could not get a clean local baseline for
those, so CI is the real check there. The +3 passed are the three tests this PR adds.

### Not verified

I have not driven a live culling race end to end. `execute_cell` pre-checks with `_kernel_exists` before submitting, so the window this retry covers is the gap between that check and `ExecutionStack.put`, plus the case where `_kernel_exists` fails open. I am not claiming how often that is hit, only that the handler cannot run today and does run after this change.
