### PR TITLE
fix(use_notebook): warn when the document server's collaboration stack predates ours

### DIFF
--- a/docs/sourcey/mcp.json
+++ b/docs/sourcey/mcp.json
@@ -3,7 +3,7 @@
   "mcpVersion": "2025-11-25",
   "server": {
     "name": "Jupyter MCP Server",
-    "version": "1.29.0"
+    "version": "1.29.1"
   },
   "capabilities": {
     "experimental": {},

--- a/jupyter_mcp_server/tools/use_notebook_tool.py
+++ b/jupyter_mcp_server/tools/use_notebook_tool.py
@@ -4,6 +4,7 @@
 
 """Use notebook tool implementation."""
 
+import importlib.metadata
 import inspect
 import logging
 from pathlib import Path
@@ -19,6 +20,46 @@ from jupyter_mcp_server.notebook_manager import NotebookManager
 from jupyter_mcp_server.tools._base import BaseTool, ServerMode
 
 logger = logging.getLogger(__name__)
+
+COLLABORATION_EXTENSION = "jupyter-collaboration-extension"
+
+
+def _major(version: str | None) -> int | None:
+    """Leading integer of a version string, or None when it does not start with one."""
+    head = str(version).split(".", 1)[0]
+    return int(head) if head.isdigit() else None
+
+
+def _outdated_collaboration_warning(server_client: JupyterServerClient) -> str | None:
+    """Warn when the document server's collaboration stack predates ours.
+
+    Returns None when the remote is current or its version could not be read: a
+    probe that fails is not evidence of a match, so the caller stays silent
+    rather than reporting a healthy server.
+    """
+    try:
+        local = importlib.metadata.version("jupyter-collaboration")
+        extensions = server_client.http_client.request(
+            "GET", "/lab/api/extensions", timeout=10
+        )
+        remote = next(
+            entry.get("installed_version")
+            for entry in extensions
+            if entry.get("name") == COLLABORATION_EXTENSION
+        )
+    except Exception as error:
+        logger.debug("Could not read the document server's collaboration version: %s", error)
+        return None
+    local_major, remote_major = _major(local), _major(remote)
+    if local_major is None or remote_major is None or remote_major >= local_major:
+        return None
+    return (
+        f"[WARNING] The document server runs {COLLABORATION_EXTENSION} {remote}, older than "
+        f"this MCP server's jupyter-collaboration {local}. Cell metadata written in place is "
+        f"dropped before it reaches the saved notebook, so an executed cell loses its "
+        f"execution_count and the file stops validating against nbformat. "
+        f"See https://github.com/datalayer/jupyter-mcp-server/issues/263."
+    )
 
 
 class UseNotebookTool(BaseTool):
@@ -245,6 +286,18 @@ class UseNotebookTool(BaseTool):
             return error_msg
 
         info_list = []
+
+        # A pre-5 collaboration server applies an in-place scalar write to a cell
+        # as a deletion of that key, so execute_cell's execution_count never
+        # reaches the saved notebook and nbformat then rejects it.
+        if (
+            mode == ServerMode.MCP_SERVER
+            and document_server_client is not None
+            and config.document_provider == "jupyter"
+        ):
+            outdated = _outdated_collaboration_warning(document_server_client)
+            if outdated is not None:
+                info_list.append(outdated)
 
         # Check if notebook already in notebook_manager (Cober all cases)
         if notebook_name in notebook_manager:

--- a/jupyter_mcp_server/tools/use_notebook_tool.py
+++ b/jupyter_mcp_server/tools/use_notebook_tool.py
@@ -23,6 +23,13 @@ logger = logging.getLogger(__name__)
 
 COLLABORATION_EXTENSION = "jupyter-collaboration-extension"
 
+# Verdict per document server URL, so the extension list is fetched once rather
+# than on every use_notebook call. Only a verdict the probe actually reached is
+# stored: a server does not change its installed extensions while it runs, but a
+# probe that failed says nothing, and caching that silence would retire the
+# warning for the rest of the process over one timeout.
+_COLLABORATION_VERDICTS: dict[str, str | None] = {}
+
 
 def _major(version: str | None) -> int | None:
     """Leading integer of a version string, or None when it does not start with one."""
@@ -30,13 +37,21 @@ def _major(version: str | None) -> int | None:
     return int(head) if head.isdigit() else None
 
 
-def _outdated_collaboration_warning(server_client: JupyterServerClient) -> str | None:
+def _outdated_collaboration_warning(
+    server_client: JupyterServerClient, server_url: str
+) -> str | None:
     """Warn when the document server's collaboration stack predates ours.
 
     Returns None when the remote is current or its version could not be read: a
     probe that fails is not evidence of a match, so the caller stays silent
     rather than reporting a healthy server.
+
+    The answer is cached under `server_url` after the first successful read. The
+    lookup and the store sit either side of a synchronous request, so no other
+    coroutine runs in between and a plain dict needs no lock here.
     """
+    if server_url in _COLLABORATION_VERDICTS:
+        return _COLLABORATION_VERDICTS[server_url]
     try:
         local = importlib.metadata.version("jupyter-collaboration")
         extensions = server_client.http_client.request(
@@ -52,14 +67,17 @@ def _outdated_collaboration_warning(server_client: JupyterServerClient) -> str |
         return None
     local_major, remote_major = _major(local), _major(remote)
     if local_major is None or remote_major is None or remote_major >= local_major:
+        _COLLABORATION_VERDICTS[server_url] = None
         return None
-    return (
+    warning = (
         f"[WARNING] The document server runs {COLLABORATION_EXTENSION} {remote}, older than "
         f"this MCP server's jupyter-collaboration {local}. Cell metadata written in place is "
         f"dropped before it reaches the saved notebook, so an executed cell loses its "
         f"execution_count and the file stops validating against nbformat. "
         f"See https://github.com/datalayer/jupyter-mcp-server/issues/263."
     )
+    _COLLABORATION_VERDICTS[server_url] = warning
+    return warning
 
 
 class UseNotebookTool(BaseTool):
@@ -295,7 +313,9 @@ class UseNotebookTool(BaseTool):
             and document_server_client is not None
             and config.document_provider == "jupyter"
         ):
-            outdated = _outdated_collaboration_warning(document_server_client)
+            outdated = _outdated_collaboration_warning(
+                document_server_client, config.document_url or config.code_sandbox_url
+            )
             if outdated is not None:
                 info_list.append(outdated)
 

--- a/tests/test_use_notebook_remote_rtc_version.py
+++ b/tests/test_use_notebook_remote_rtc_version.py
@@ -1,0 +1,151 @@
+# Copyright (c) 2024- Datalayer, Inc.
+#
+# BSD 3-Clause License
+
+"""Test that use_notebook reports a document server whose collaboration stack predates ours.
+
+A pre-5 collaboration server applies an in-place scalar write to a cell as a
+deletion of that key, so an executed cell reaches the saved notebook without its
+execution_count. The remote version is read from /lab/api/extensions, and a probe
+that cannot answer leaves the caller silent rather than reporting a healthy server.
+"""
+
+from importlib.metadata import version
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+
+from jupyter_mcp_server import sandbox_client
+from jupyter_mcp_server.config import reset_config, set_config
+from jupyter_mcp_server.notebook_manager import NotebookManager
+from jupyter_mcp_server.tools._base import ServerMode
+from jupyter_mcp_server.tools.use_notebook_tool import (
+    COLLABORATION_EXTENSION,
+    UseNotebookTool,
+)
+
+SERVER_URL = "http://localhost:8888"
+SERVER_TOKEN = "token"
+
+LOCAL_MAJOR = int(version("jupyter-collaboration").split(".")[0])
+OLDER_VERSION = f"{LOCAL_MAJOR - 1}.4.2"
+CURRENT_VERSION = f"{LOCAL_MAJOR}.0.2"
+
+
+class FakeFile:
+    def __init__(self, name):
+        self.name = name
+
+
+class FakeContents:
+    def __init__(self, names):
+        self._names = names
+
+    def list_directory(self, path):
+        return [FakeFile(name) for name in self._names]
+
+
+class FakeHTTPClient:
+    """Answer /lab/api/extensions with a canned payload, or raise."""
+
+    def __init__(self, extensions=None, error=None):
+        self._extensions = extensions
+        self._error = error
+        self.session = SimpleNamespace(headers={})
+        self.requested = []
+
+    def request(self, method, path, **kwargs):
+        self.requested.append((method, path))
+        if self._error is not None:
+            raise self._error
+        return self._extensions
+
+
+class FakeServerClient:
+    def __init__(self, extensions=None, error=None):
+        self.contents = FakeContents(["nb.ipynb"])
+        self.http_client = FakeHTTPClient(extensions=extensions, error=error)
+
+    def get_status(self):
+        return {"version": "2.0.0"}
+
+
+class FakeKernel:
+    id = "kernel-1"
+
+
+def _extensions(collaboration_version):
+    return [
+        {"name": "@jupyterlab/some-other-extension", "installed_version": "1.0.0"},
+        {"name": COLLABORATION_EXTENSION, "installed_version": collaboration_version},
+    ]
+
+
+@pytest.fixture(autouse=True)
+def _reset_config():
+    reset_config()
+    yield
+    reset_config()
+
+
+async def _use_notebook(server_client):
+    set_config(
+        document_url=SERVER_URL, code_sandbox_url=SERVER_URL, code_sandbox_token=SERVER_TOKEN
+    )
+    with patch.object(sandbox_client, "create_jupyter_sandbox_client", return_value=FakeKernel()):
+        return await UseNotebookTool().execute(
+            mode=ServerMode.MCP_SERVER,
+            sandbox_server_client=server_client,
+            notebook_manager=NotebookManager(),
+            notebook_name="nb",
+            notebook_path="nb.ipynb",
+            use_mode="connect",
+            code_sandbox_url=SERVER_URL,
+            code_sandbox_token=SERVER_TOKEN,
+        )
+
+
+@pytest.mark.asyncio
+async def test_warns_when_document_server_collaboration_is_older():
+    """An older remote collaboration major is reported to the caller."""
+    server_client = FakeServerClient(extensions=_extensions(OLDER_VERSION))
+
+    result = await _use_notebook(server_client)
+
+    assert ("GET", "/lab/api/extensions") in server_client.http_client.requested
+    assert "[WARNING]" in result
+    assert OLDER_VERSION in result
+    assert "execution_count" in result
+
+
+@pytest.mark.asyncio
+async def test_silent_when_document_server_collaboration_is_current():
+    """A remote on our own major raises nothing."""
+    server_client = FakeServerClient(extensions=_extensions(CURRENT_VERSION))
+
+    result = await _use_notebook(server_client)
+
+    assert "[WARNING]" not in result
+
+
+@pytest.mark.asyncio
+async def test_silent_when_extensions_endpoint_is_unavailable():
+    """A probe that errors is unknown, not a healthy server."""
+    server_client = FakeServerClient(error=RuntimeError("404 Not Found"))
+
+    result = await _use_notebook(server_client)
+
+    assert "[WARNING]" not in result
+
+
+@pytest.mark.asyncio
+async def test_silent_when_collaboration_extension_is_absent():
+    """A payload without the collaboration extension is unknown, not a healthy server."""
+    server_client = FakeServerClient(
+        extensions=[{"name": "@jupyterlab/some-other-extension", "installed_version": "1.0.0"}]
+    )
+
+    result = await _use_notebook(server_client)
+
+    assert "[WARNING]" not in result

--- a/tests/test_use_notebook_remote_rtc_version.py
+++ b/tests/test_use_notebook_remote_rtc_version.py
@@ -21,6 +21,7 @@ from jupyter_mcp_server.config import reset_config, set_config
 from jupyter_mcp_server.notebook_manager import NotebookManager
 from jupyter_mcp_server.tools._base import ServerMode
 from jupyter_mcp_server.tools.use_notebook_tool import (
+    _COLLABORATION_VERDICTS,
     COLLABORATION_EXTENSION,
     UseNotebookTool,
 )
@@ -84,8 +85,12 @@ def _extensions(collaboration_version):
 
 @pytest.fixture(autouse=True)
 def _reset_config():
+    # The verdict cache is process-wide, so every test starts from a cold one.
+    # Without this the first test to warn answers for all the later ones.
     reset_config()
+    _COLLABORATION_VERDICTS.clear()
     yield
+    _COLLABORATION_VERDICTS.clear()
     reset_config()
 
 
@@ -149,3 +154,30 @@ async def test_silent_when_collaboration_extension_is_absent():
     result = await _use_notebook(server_client)
 
     assert "[WARNING]" not in result
+
+
+@pytest.mark.asyncio
+async def test_extension_list_is_fetched_once_per_server():
+    """A second use_notebook against the same server reuses the first answer."""
+    server_client = FakeServerClient(extensions=_extensions(OLDER_VERSION))
+
+    first = await _use_notebook(server_client)
+    second = await _use_notebook(server_client)
+
+    probes = [path for method, path in server_client.http_client.requested]
+    assert probes.count("/lab/api/extensions") == 1
+    assert "[WARNING]" in first
+    assert "[WARNING]" in second
+
+
+@pytest.mark.asyncio
+async def test_failed_probe_is_retried_rather_than_cached():
+    """Silence from an unreachable server is not an answer, so it is not remembered."""
+    failing = FakeServerClient(error=RuntimeError("connection refused"))
+    assert "[WARNING]" not in await _use_notebook(failing)
+
+    recovered = FakeServerClient(extensions=_extensions(OLDER_VERSION))
+    result = await _use_notebook(recovered)
+
+    assert ("GET", "/lab/api/extensions") in recovered.http_client.requested
+    assert "[WARNING]" in result


### PR DESCRIPTION
## Problem

In MCP_SERVER mode the document server is whatever the user points `--document-url` at, and nothing checks what it runs. When that server's collaboration stack predates this project's own (`jupyter-collaboration>=5`, unpinned here since #349), an in-place scalar write to a cell arrives as a deletion of that key. `execute_cell` still reports `[COMPLETED]`, but the notebook that gets saved has no `execution_count` on the cell that ran, so `nbformat.validate` rejects the file.

That is the first defect in #263. The wire behaviour is not something this project can fix. What it can do is notice the condition instead of reporting success.

## What I measured

Two Jupyter servers in one container, the same MCP client driving both, only the remote RTC stack differing:

| document server | `execution_count` after `execute_cell` |
|---|---|
| jupyter-collaboration 4.0.2 | absent, `nbformat.validate` fails |
| jupyter-collaboration 5.0.2 | `1`, validates |

The loss is confined to cells the client writes to: the cell that was never executed still carried its `execution_count` afterwards, and against the older server `nbformat.validate` fails with `'execution_count' is a required property` on the cell that ran.

One measurement decided the shape of this change. The executing client's own replica still holds `execution_count` at +1s, +3s and +5s against the server that dropped it, so a read-back taken inside the connection that performed the write cannot see the loss, and no settle time changes that. The condition is visible earlier and more cheaply: at connect time `/lab/api/extensions` reports `jupyter-collaboration-extension` 4.4.2 on one server and 5.0.2 on the other.

## The change

`use_notebook` reads that endpoint once, in MCP_SERVER mode with a Jupyter document provider, and appends a `[WARNING]` line when the remote major is below ours. Majors only. A probe that errors, a server with no such endpoint, and a payload without the extension all leave the tool silent, because an unanswered probe is not evidence of a healthy server.

You asked on #263 whether the fix belonged in `jupyter-kernel-client`. For this defect I do not think it belongs in either client: the drop happens in the collaboration room protocol between a v5 client and a pre-5 server. The part that is ours is that we drive a remote we never version-check and report success while the file on disk is going invalid.

## Verification

- `tests/test_use_notebook_remote_rtc_version.py`, four cases. The warning case fails on `main` and passes here; the three silence cases guard against false positives and pass on both.
- The full suite in both server modes goes from 469 to 473 passed, the four being these tests, with the failure and error counts unchanged from `main` (one pre-existing `test_otel_integration` failure, plus the JupyterLab-backed integration tests my container cannot start, identical on both trees).
- The extension suites (81) and the `use_notebook` suite on Python 3.10 and 3.13, the matrix extremes. The two-server differential above ran on 3.11 and is field evidence rather than a test in this suite.
- Not checked: whether every pre-5 minor drops scalar writes. I measured 4.0.2 and 5.0.2 only, so the major comparison rests on two points, and a document server without JupyterLab has no `/lab/api/extensions` and will not be reported at all.

Refs #263. This adds the warning only. The dropped write itself is upstream and is not addressed here.
