### PR TITLE
fix(list_files): report the size of notebooks in JUPYTER_SERVER mode

### DIFF
--- a/jupyter_mcp_server/tools/list_files_tool.py
+++ b/jupyter_mcp_server/tools/list_files_tool.py
@@ -119,7 +119,10 @@ async def _list_files_local(
         for item in model["content"]:
             item_path = item["path"]
             item_type = item["type"]
-            item_size = item.get("size", 0) if item_type == "file" else 0
+            # The contents API types a notebook as "notebook", not "file", and reports a
+            # size for both. Keying on the type discarded every notebook size; take any
+            # size the model carries, which leaves directories (size None) blank as before.
+            item_size = item.get("size") or 0
 
             # Format size
             size_str = format_size(item_size) if item_size else ""

--- a/tests/test_list_files_notebook_size.py
+++ b/tests/test_list_files_notebook_size.py
@@ -1,0 +1,70 @@
+#!/usr/bin/env python3
+# Copyright (c) 2024- Datalayer, Inc.
+#
+# BSD 3-Clause License
+
+"""Regression tests for the Size column of list_files in JUPYTER_SERVER mode.
+
+The Jupyter contents API types a ``.ipynb`` as ``"notebook"`` rather than
+``"file"`` and reports a byte size for it, exactly as it does for a regular
+file. ``_list_files_local`` used to read the size only when the type was
+``"file"``, so every notebook came back with an empty Size while MCP_SERVER
+mode, which reads any size the model carries, reported the real one. The two
+transport modes have to answer the same question the same way.
+
+These tests drive the real ``LargeFileManager`` against a temporary root, not a
+stand-in, so the type/size pairing is the server's own rather than a fixture's
+assumption.
+"""
+
+import pytest
+from jupyter_server.services.contents.largefilemanager import LargeFileManager
+
+from jupyter_mcp_server.tools.list_files_tool import _list_files_local, format_size
+
+_NOTEBOOK = b'{"cells": [], "metadata": {}, "nbformat": 4, "nbformat_minor": 5}'
+_CSV = b"a,b\n" + b"1,2\n" * 64
+
+
+@pytest.fixture
+def content_root(tmp_path):
+    (tmp_path / "analysis.ipynb").write_bytes(_NOTEBOOK)
+    (tmp_path / "data.csv").write_bytes(_CSV)
+    (tmp_path / "sub").mkdir()
+    return tmp_path
+
+
+@pytest.mark.asyncio
+async def test_list_files_local_reports_notebook_size(content_root):
+    """A notebook reports its size, the same as any other file."""
+    files = {
+        f["path"]: f
+        for f in await _list_files_local(LargeFileManager(root_dir=str(content_root)), path="", max_depth=0)
+    }
+
+    assert files["analysis.ipynb"]["type"] == "notebook"
+    assert files["analysis.ipynb"]["size"] == format_size(len(_NOTEBOOK))
+
+
+@pytest.mark.asyncio
+async def test_list_files_local_still_reports_plain_file_size(content_root):
+    """A regular file is unaffected by the change."""
+    files = {
+        f["path"]: f
+        for f in await _list_files_local(LargeFileManager(root_dir=str(content_root)), path="", max_depth=0)
+    }
+
+    assert files["data.csv"]["type"] == "file"
+    assert files["data.csv"]["size"] == format_size(len(_CSV))
+
+
+@pytest.mark.asyncio
+async def test_list_files_local_leaves_directory_size_blank(content_root):
+    """A directory carries no size in the contents model and must stay blank."""
+    files = {
+        f["path"]: f
+        for f in await _list_files_local(LargeFileManager(root_dir=str(content_root)), path="", max_depth=0)
+    }
+
+    assert files["sub"]["type"] == "directory"
+    assert files["sub"]["size"] == ""


### PR DESCRIPTION
Fixes #403.

The Jupyter contents API types a `.ipynb` as `"notebook"`, not `"file"`, and reports a byte size for it either way. `_list_files_local` read the size only when the type was `"file"`, so it discarded every notebook size and the Size column came back empty. `_list_files_mcp` reports any size the model carries, so the same tool against the same server answered differently depending on transport mode.

The fix takes whatever size the model carries. Directories have `size: None` in the contents model, so they stay blank exactly as before.

Measured on `39022e70` in a clean container running a real `jupyter lab`, with a 170 byte notebook and a 2004 byte CSV in its root. The contents REST API reports `analysis.ipynb type=notebook size=170`. Before the change, JUPYTER_SERVER mode printed the notebook with an empty Size while MCP_SERVER mode printed `170B`; after it, both print `170B` and the full (Path, Type, Size) tables are identical. Directory rows are blank in both, before and after.

Three tests in `tests/test_list_files_notebook_size.py`, one per scenario named above: a notebook reports its size, a plain file is unaffected, a directory stays blank. They drive the real `LargeFileManager` against a `tmp_path` rather than a stand-in, so the type and size pairing comes from the server's own contents manager. On the unpatched tree the first fails (`assert '' == '65B'`) and the other two pass; with the change all three pass, alongside the existing `tests/test_contents_manager_sync.py`.

One thing worth your call, and I raised it in the issue too. If the blank is deliberate, on the view that a notebook's on-disk size is not what a caller wants, then the right fix is the opposite one: stop reporting it in MCP_SERVER mode as well. Either direction removes the divergence and I am happy to switch this PR to the other one.
