### PR TITLE
fix: reject execution for missing local kernels

### DIFF
--- a/jupyter_mcp_server/jupyter_extension/backends/local_backend.py
+++ b/jupyter_mcp_server/jupyter_extension/backends/local_backend.py
@@ -330,6 +330,9 @@ class LocalBackend(Backend):
         cell = cells[cell_index]
         source = "".join(cell["source"]) if isinstance(cell["source"], list) else cell["source"]
 
+        if kernel_id not in self.kernel_manager:
+            raise RuntimeError(f"Kernel '{kernel_id}' is not running")
+
         # Get kernel client. Its ZMQ identity must not collide with any
         # long-lived client on the same kernel (see create_isolated_kernel_client).
         kernel = self.kernel_manager.get_kernel(kernel_id)

--- a/tests/test_local_backend_contents_manager.py
+++ b/tests/test_local_backend_contents_manager.py
@@ -86,6 +86,14 @@ class _FakeServerApp:
         self.kernel_spec_manager = None
 
 
+class _KernelManagerWithoutKernel:
+    def __contains__(self, kernel_id):
+        return False
+
+    def get_kernel(self, kernel_id):
+        raise AssertionError("a missing kernel must be rejected before lookup")
+
+
 MANAGERS = [
     pytest.param(SyncContentsManager, id="sync"),
     pytest.param(AsyncContentsManager, id="async"),
@@ -137,3 +145,12 @@ async def test_append_cell_saves_with_sync_and_async_managers(manager_cls):
     index = await backend.append_cell("notebook.ipynb", "code", "print(2)")
     assert index == len(_CELLS)
     assert cm.saved and cm.saved[-1][0] == "notebook.ipynb"
+
+
+@pytest.mark.asyncio
+async def test_execute_cell_rejects_missing_kernel_before_client_creation():
+    backend = LocalBackend(_FakeServerApp(SyncContentsManager()))
+    backend.kernel_manager = _KernelManagerWithoutKernel()
+
+    with pytest.raises(RuntimeError, match="Kernel 'missing' is not running"):
+        await backend.execute_cell("notebook.ipynb", 0, "missing")


### PR DESCRIPTION
## Summary

Fixes #21 by rejecting local notebook execution when the requested kernel is no longer running. Previously, execution could proceed to create a client for a stale kernel reference and wait for IOPub messages until the timeout.

## Changes

- Check kernel membership before creating an isolated kernel client.
- Add a regression test proving missing kernels fail immediately with a clear error.

## Validation

- `python -m pytest tests/test_local_backend_contents_manager.py -q` — 11 passed.
- `git diff --check` — passed.

Ruff still reports pre-existing diagnostics in the touched module and test stubs; no new diagnostic is introduced by this change.
