### PR TITLE
fix: support raw cell insertion

### DIFF
--- a/jupyter_mcp_server/jupyter_extension/protocol/messages.py
+++ b/jupyter_mcp_server/jupyter_extension/protocol/messages.py
@@ -80,7 +80,7 @@ class AppendCellRequest(BaseModel):
     """Request to append a cell"""
 
     path: str | None = Field(None, description="Notebook path")
-    cell_type: Literal["code", "markdown"] = Field(..., description="Cell type")
+    cell_type: Literal["code", "markdown", "raw"] = Field(..., description="Cell type")
     source: str | list[str] = Field(..., description="Cell source")
 
 
@@ -96,7 +96,7 @@ class InsertCellRequest(BaseModel):
 
     path: str | None = Field(None, description="Notebook path")
     cell_index: int = Field(..., description="Index where to insert")
-    cell_type: Literal["code", "markdown"] = Field(..., description="Cell type")
+    cell_type: Literal["code", "markdown", "raw"] = Field(..., description="Cell type")
     source: str | list[str] = Field(..., description="Cell source")
 
 

--- a/jupyter_mcp_server/server.py
+++ b/jupyter_mcp_server/server.py
@@ -654,7 +654,9 @@ async def insert_cell(
         int,
         Field(description="Target index for insertion (0-based), use -1 to append at end", ge=-1),
     ],
-    cell_type: Annotated[Literal["code", "markdown"], Field(description="Type of cell to insert")],
+    cell_type: Annotated[
+        Literal["code", "markdown", "raw"], Field(description="Type of cell to insert")
+    ],
     cell_source: Annotated[str, Field(description="Source content for the cell")],
     notebook_name: Annotated[
         str | None,

--- a/jupyter_mcp_server/tools/insert_cell_tool.py
+++ b/jupyter_mcp_server/tools/insert_cell_tool.py
@@ -41,6 +41,11 @@ class InsertCellTool(BaseTool):
             IndexError: When cell_index is out of valid range
             ValueError: When cell_type is invalid
         """
+        if cell_type not in ("code", "markdown"):
+            raise ValueError(
+                f"Invalid cell type {cell_type!r}; expected 'code' or 'markdown'."
+            )
+
         if cell_index < -1 or cell_index > total_cells:
             raise IndexError(
                 f"Index {cell_index} is outside valid range [-1, {total_cells}]. "

--- a/jupyter_mcp_server/tools/insert_cell_tool.py
+++ b/jupyter_mcp_server/tools/insert_cell_tool.py
@@ -41,9 +41,9 @@ class InsertCellTool(BaseTool):
             IndexError: When cell_index is out of valid range
             ValueError: When cell_type is invalid
         """
-        if cell_type not in ("code", "markdown"):
+        if cell_type not in ("code", "markdown", "raw"):
             raise ValueError(
-                f"Invalid cell type {cell_type!r}; expected 'code' or 'markdown'."
+                f"Invalid cell type {cell_type!r}; expected 'code', 'markdown', or 'raw'."
             )
 
         if cell_index < -1 or cell_index > total_cells:
@@ -61,7 +61,7 @@ class InsertCellTool(BaseTool):
         serverapp: Any,
         notebook_path: str,
         cell_index: int,
-        cell_type: Literal["code", "markdown"],
+        cell_type: Literal["code", "markdown", "raw"],
         cell_source: str,
     ) -> tuple[Notebook, int, int]:
         """Insert cell using YDoc (collaborative editing mode).
@@ -99,7 +99,7 @@ class InsertCellTool(BaseTool):
         self,
         notebook_path: str,
         cell_index: int,
-        cell_type: Literal["code", "markdown"],
+        cell_type: Literal["code", "markdown", "raw"],
         cell_source: str,
     ) -> tuple[Notebook, int, int]:
         """Insert cell using file operations (non-collaborative mode).
@@ -136,6 +136,8 @@ class InsertCellTool(BaseTool):
             new_cell = nbformat.v4.new_code_cell(source=cell_source or "")
         elif cell_type == "markdown":
             new_cell = nbformat.v4.new_markdown_cell(source=cell_source or "")
+        elif cell_type == "raw":
+            new_cell = nbformat.v4.new_raw_cell(source=cell_source or "")
         notebook.cells.insert(actual_index, new_cell)
 
         # Write back to file
@@ -150,7 +152,7 @@ class InsertCellTool(BaseTool):
         self,
         notebook_manager: NotebookManager,
         cell_index: int,
-        cell_type: Literal["code", "markdown"],
+        cell_type: Literal["code", "markdown", "raw"],
         cell_source: str,
         notebook_name: str | None = None,
     ) -> tuple[Notebook, int, int]:
@@ -192,7 +194,7 @@ class InsertCellTool(BaseTool):
         notebook_manager: NotebookManager | None = None,
         # Tool-specific parameters
         cell_index: int = None,
-        cell_type: Literal["code", "markdown"] = None,
+        cell_type: Literal["code", "markdown", "raw"] = None,
         cell_source: str = None,
         notebook_name: str | None = None,
         **kwargs,

--- a/tests/test_insert_cell_validation.py
+++ b/tests/test_insert_cell_validation.py
@@ -1,3 +1,4 @@
+import nbformat
 import pytest
 
 from jupyter_mcp_server.tools.insert_cell_tool import InsertCellTool
@@ -6,12 +7,27 @@ from jupyter_mcp_server.tools.insert_cell_tool import InsertCellTool
 def test_insert_cell_rejects_invalid_cell_type_before_insertion():
     tool = InsertCellTool()
 
-    with pytest.raises(ValueError, match="expected 'code' or 'markdown'"):
-        tool._validate_cell_insertion_params(0, 0, "raw")
+    with pytest.raises(ValueError, match="expected 'code', 'markdown', or 'raw'"):
+        tool._validate_cell_insertion_params(0, 0, "unsupported")
 
 
-@pytest.mark.parametrize("cell_type", ["code", "markdown"])
+@pytest.mark.parametrize("cell_type", ["code", "markdown", "raw"])
 def test_insert_cell_accepts_supported_cell_types(cell_type):
     tool = InsertCellTool()
 
     assert tool._validate_cell_insertion_params(0, 0, cell_type) == 0
+
+
+@pytest.mark.asyncio
+async def test_insert_cell_file_supports_raw_cell(tmp_path):
+    notebook_path = tmp_path / "test.ipynb"
+    notebook = nbformat.v4.new_notebook()
+    nbformat.write(notebook, notebook_path)
+
+    result, index, total = await InsertCellTool()._insert_cell_file(
+        str(notebook_path), -1, "raw", "raw text"
+    )
+
+    assert (index, total) == (0, 1)
+    assert result.cells[0].cell_type == "raw"
+    assert result.cells[0].source == "raw text"

--- a/tests/test_insert_cell_validation.py
+++ b/tests/test_insert_cell_validation.py
@@ -1,0 +1,17 @@
+import pytest
+
+from jupyter_mcp_server.tools.insert_cell_tool import InsertCellTool
+
+
+def test_insert_cell_rejects_invalid_cell_type_before_insertion():
+    tool = InsertCellTool()
+
+    with pytest.raises(ValueError, match="expected 'code' or 'markdown'"):
+        tool._validate_cell_insertion_params(0, 0, "raw")
+
+
+@pytest.mark.parametrize("cell_type", ["code", "markdown"])
+def test_insert_cell_accepts_supported_cell_types(cell_type):
+    tool = InsertCellTool()
+
+    assert tool._validate_cell_insertion_params(0, 0, cell_type) == 0


### PR DESCRIPTION
## Summary

Allow the cell insertion tools to create valid Jupyter `raw` cells and reject unsupported cell types with a clear validation error.

## Changes

- Extend the MCP request and tool annotations to include `raw`.
- Add runtime validation before insertion.
- Construct raw cells through `nbformat` in file mode.
- Add focused regression coverage for accepted and rejected cell types.

## Testing

- `python -m pytest tests/test_insert_cell_validation.py -q` (5 passed)
- `git diff --check` (passed)

The repository-wide Ruff and format checks currently report pre-existing violations outside this change, so no unrelated formatting was included.
