### PR TITLE
fix(cell-source): report no changes only when the sources are equal

### DIFF
--- a/jupyter_mcp_server/tools/edit_cell_source_tool.py
+++ b/jupyter_mcp_server/tools/edit_cell_source_tool.py
@@ -55,7 +55,19 @@ class EditCellSourceTool(BaseTool):
         return source.replace(old_string, new_string, 1)
 
     def _generate_diff(self, old_source: str, new_source: str) -> str:
-        """Generate unified diff between old and new source."""
+        """Generate unified diff between old and new source.
+
+        Whether anything changed is decided by comparing the two sources, not by
+        the size of the line diff. str.splitlines() drops the final line
+        terminator and treats "\\r\\n", "\\f", "\\v", "\\x1c"-"\\x1e", "\\x85",
+        "\\u2028" and "\\u2029" as line breaks, so an edit confined to those
+        characters leaves both sides splitting identically and unified_diff
+        returns nothing. Reporting that as "no changes detected" tells the caller
+        the cell was untouched when it has in fact been rewritten.
+        """
+        if old_source == new_source:
+            return "no changes detected"
+
         old_lines = old_source.splitlines(keepends=False)
         new_lines = new_source.splitlines(keepends=False)
 
@@ -68,9 +80,12 @@ class EditCellSourceTool(BaseTool):
             )
         )
 
-        if len(diff_lines) > 3:
-            return "\n".join(diff_lines)
-        return "no changes detected"
+        if not diff_lines:
+            # The sources differ only in characters splitlines() consumes, so
+            # there is nothing to show line by line. Show the escaped forms
+            # instead, which is the only rendering the change is visible in.
+            return f"@@ line terminators changed @@\n-{old_source!r}\n+{new_source!r}"
+        return "\n".join(diff_lines)
 
     def _edit_source(
         self, old_source: str, old_string: str, new_string: str, replace_all: bool

--- a/jupyter_mcp_server/tools/overwrite_cell_source_tool.py
+++ b/jupyter_mcp_server/tools/overwrite_cell_source_tool.py
@@ -25,7 +25,19 @@ class OverwriteCellSourceTool(BaseTool):
     """Tool to overwrite the source of an existing cell."""
 
     def _generate_diff(self, old_source: str, new_source: str) -> str:
-        """Generate unified diff between old and new source."""
+        """Generate unified diff between old and new source.
+
+        Whether anything changed is decided by comparing the two sources, not by
+        the size of the line diff. str.splitlines() drops the final line
+        terminator and treats "\\r\\n", "\\f", "\\v", "\\x1c"-"\\x1e", "\\x85",
+        "\\u2028" and "\\u2029" as line breaks, so an edit confined to those
+        characters leaves both sides splitting identically and unified_diff
+        returns nothing. Reporting that as "no changes detected" tells the caller
+        the cell was untouched when it has in fact been rewritten.
+        """
+        if old_source == new_source:
+            return "no changes detected"
+
         old_lines = old_source.splitlines(keepends=False)
         new_lines = new_source.splitlines(keepends=False)
 
@@ -38,9 +50,12 @@ class OverwriteCellSourceTool(BaseTool):
             )
         )
 
-        if len(diff_lines) > 3:
-            return "\n".join(diff_lines)
-        return "no changes detected"
+        if not diff_lines:
+            # The sources differ only in characters splitlines() consumes, so
+            # there is nothing to show line by line. Show the escaped forms
+            # instead, which is the only rendering the change is visible in.
+            return f"@@ line terminators changed @@\n-{old_source!r}\n+{new_source!r}"
+        return "\n".join(diff_lines)
 
     async def _overwrite_cell_ydoc(
         self, serverapp: Any, notebook_path: str, cell_index: int, cell_source: str

--- a/tests/test_cell_source_diff_reporting.py
+++ b/tests/test_cell_source_diff_reporting.py
@@ -1,0 +1,81 @@
+# Copyright (c) 2024- Datalayer, Inc.
+#
+# BSD 3-Clause License
+
+"""
+Tests for the diff reporting of edit_cell_source and overwrite_cell_source.
+
+Both tools build their report with _generate_diff(). The report has to agree
+with what was actually written to the cell: "no changes detected" may only come
+back when the two sources are equal.
+
+Launch the tests:
+```
+$ pytest tests/test_cell_source_diff_reporting.py -v
+```
+"""
+
+import pytest
+
+from jupyter_mcp_server.tools.edit_cell_source_tool import EditCellSourceTool
+from jupyter_mcp_server.tools.overwrite_cell_source_tool import OverwriteCellSourceTool
+
+
+# Pairs that differ only in characters str.splitlines() consumes, so a
+# line-based diff of them is empty even though the sources are not equal.
+TERMINATOR_ONLY_CHANGES = [
+    pytest.param("a = 1\r\nb = 2", "a = 1\nb = 2", id="crlf-to-lf"),
+    pytest.param("a = 1\x0cb = 2", "a = 1\nb = 2", id="form-feed-to-lf"),
+    pytest.param("a = 1\x0bb = 2", "a = 1\nb = 2", id="vertical-tab-to-lf"),
+    pytest.param("a = 1\u2028b = 2", "a = 1\nb = 2", id="line-separator-to-lf"),
+    pytest.param("a = 1\n", "a = 1", id="drop-trailing-newline"),
+    pytest.param("a = 1", "a = 1\n", id="add-trailing-newline"),
+]
+
+
+@pytest.fixture(params=[EditCellSourceTool, OverwriteCellSourceTool], ids=["edit", "overwrite"])
+def tool(request):
+    """Both tools carry the same _generate_diff, so both are held to it."""
+    return request.param()
+
+
+@pytest.mark.parametrize("old_source,new_source", TERMINATOR_ONLY_CHANGES)
+def test_terminator_only_change_is_not_reported_as_unchanged(tool, old_source, new_source):
+    """A change splitlines() cannot see must not be reported as no change."""
+    diff = tool._generate_diff(old_source, new_source)
+    assert diff != "no changes detected"
+    assert diff.strip()
+
+
+@pytest.mark.parametrize("old_source,new_source", TERMINATOR_ONLY_CHANGES)
+def test_terminator_only_change_shows_both_sources(tool, old_source, new_source):
+    """The escaped forms are the only rendering the change is visible in."""
+    diff = tool._generate_diff(old_source, new_source)
+    assert repr(old_source) in diff
+    assert repr(new_source) in diff
+
+
+def test_equal_sources_report_no_changes(tool):
+    """Equal sources are the one case that reports no change."""
+    assert tool._generate_diff("a = 1\nb = 2", "a = 1\nb = 2") == "no changes detected"
+
+
+def test_empty_sources_report_no_changes(tool):
+    """Two empty sources are equal, so they report no change."""
+    assert tool._generate_diff("", "") == "no changes detected"
+
+
+def test_ordinary_edit_still_renders_a_unified_diff(tool):
+    """The usual line-level rendering is unchanged."""
+    diff = tool._generate_diff("a = 1\nb = 2", "a = 2\nb = 2")
+    assert diff.startswith("--- ")
+    assert "-a = 1" in diff
+    assert "+a = 2" in diff
+    assert " b = 2" in diff
+
+
+def test_added_line_still_renders_a_unified_diff(tool):
+    """A pure insertion keeps its line-level rendering too."""
+    diff = tool._generate_diff("a = 1", "a = 1\nb = 2")
+    assert "+b = 2" in diff
+    assert diff != "no changes detected"


### PR DESCRIPTION
Closes #410.

## The problem

`edit_cell_source` and `overwrite_cell_source` carry the same `_generate_diff`, which decides whether anything changed from the size of the line diff:

```python
old_lines = old_source.splitlines(keepends=False)
new_lines = new_source.splitlines(keepends=False)
diff_lines = list[str](difflib.unified_diff(old_lines, new_lines, lineterm="", n=3))
if len(diff_lines) > 3:
    return "\n".join(diff_lines)
return "no changes detected"
```

`str.splitlines()` drops the final line terminator and treats `\r\n`, `\f`, `\v`, `\x1c` to `\x1e`, `\x85`, `\u2028` and `\u2029` as line breaks. For an edit confined to those characters both sides split identically, `unified_diff` returns an empty list, and the tool reports `no changes detected` for a cell it has just rewritten.

The `> 3` threshold looks vestigial rather than intended as a change test: it arrived in `31ddbcf` (#95) beside `return '\n'.join(diff_lines[3:])`, where 3 was the number of unified-diff header lines being stripped, and `1ea92f2` (#139) dropped the slice while keeping the threshold.

## The change

Decide the change from `old_source == new_source`, which is the property the report is making a claim about. When the sources differ but the line diff is empty, show the escaped forms rather than the empty diff, since that is the only rendering the change is visible in:

```
@@ line terminators changed @@
-'a = 1\r\nb = 2'
+'a = 1\nb = 2'
```

Ordinary edits keep their existing unified-diff rendering, and equal sources still report `no changes detected`. Both tools are changed together because they carry the same function.

## Verification

Run in a clean `python:3.12-slim` container against this branch and against its base, `pip install .` from the checkout each time.

Base `87ed23211d7541f750c5a526d8867cacd49b4f4d`, new test file only:

```
24 failed, 8 passed in 3.24s
```

This branch, same file:

```
32 passed in 2.55s
```

The new tests are pure unit tests over `_generate_diff`, parametrized across both tool classes and across the six input shapes, so each tool is held to the same contract.

No regression in the suites that exercise these tools. `tests/test_edit_cell_source.py` and `tests/test_cell_tools_explicit_notebook_target.py` report `33 passed, 24 errors` on the base commit and `33 passed, 24 errors` on this branch. The 24 errors are the integration tests that need a live Jupyter and MCP server, which that container does not start; they are identical before and after and are not touched by this change.

I have not run the integration legs against a live server, so the claim above is about the unit-level contract and the absence of a regression in what the container can run.
