### PR TITLE
feat: mcp2 next

### DIFF
--- a/docs/docs/architecture/caching/_category_.yaml
+++ b/docs/docs/architecture/caching/_category_.yaml
@@ -1,0 +1,2 @@
+label: "Caching"
+position: 4

--- a/docs/docs/architecture/caching/index.mdx
+++ b/docs/docs/architecture/caching/index.mdx
@@ -1,0 +1,87 @@
+# Caching and revalidation
+
+A tool that answers the same thing twice should not have to send it twice.
+
+Two mechanisms, from SEP-2549 and the Transports WG's extension of it, and
+they answer different questions.
+
+## A time to live
+
+A result may carry how long it is worth holding:
+
+```json
+"_meta": {
+  "io.modelcontextprotocol/cache": { "ttlMs": 30000, "cacheScope": "private" }
+}
+```
+
+`cacheScope` is `private` for anything narrowed by who is asking — which is
+almost everything here. A shared cache holding one person's notebooks for
+another is the failure this field exists to prevent.
+
+A TTL alone forces a choice between a stale answer and fetching again, which
+is why the reads carry the second thing.
+
+## An ETag
+
+`read_cell` and `read_notebook` also carry a version:
+
+```json
+"_meta": {
+  "io.modelcontextprotocol/cache": {
+    "ttlMs": 5000,
+    "cacheScope": "private",
+    "etag": "W/\"015abd7f5cc57a2dd94b7590f04ad808\""
+  }
+}
+```
+
+Send it back on the next call and the server answers *not modified* instead
+of the payload:
+
+```json
+"_meta": {
+  "io.modelcontextprotocol/cache": {
+    "ttlMs": 5000, "cacheScope": "private",
+    "etag": "W/\"015abd7f5cc57a2dd94b7590f04ad808\"",
+    "notModified": true
+  }
+}
+```
+
+It says `notModified` rather than simply being empty, because a client that
+read an empty result as an empty *notebook* would show somebody no cells at
+all.
+
+:::caution This saves bandwidth, not work
+
+The tool still runs. The version is computed from what it answered, so there
+is no way to know the answer is unchanged without producing it.
+
+Where it pays is `read_notebook` on a large notebook: the answer is megabytes
+and the comparison is a hash. Where it does not is anything cheap to produce —
+there the round trip costs the same either way.
+:::
+
+## Why the version is over the content
+
+A notebook's version is not one number here. A cell can be read through the
+contents manager, through a live CRDT document, or through a sandbox, and the
+three do not share a counter. A tool that read one and reported another's
+version would hand out an identifier comparing equal to answers it has
+nothing to do with.
+
+Hashing what was actually answered cannot be wrong that way: two reads of an
+unchanged cell compare equal, and a changed one does not. The ETag is weak
+(`W/`) for the same reason — it says *this means the same thing*, not *this
+is byte-for-byte what you had*, because the answer is assembled per call.
+
+The Datalayer gateway stamps the same form on the results it synthesises, so
+a client sees one kind of ETag whichever end produced it.
+
+## What is not revalidated
+
+- **A tool that stamps no ETag.** Answering "unchanged" about something
+  nobody is tracking is worse than answering it again.
+- **An error.** A client that treated a refusal as its cached answer being
+  current would go on using a result the server has just declined to confirm.

--- a/docs/docs/architecture/tasks/_category_.yaml
+++ b/docs/docs/architecture/tasks/_category_.yaml
@@ -1,0 +1,2 @@
+label: "Tasks"
+position: 3

--- a/docs/docs/architecture/tasks/index.mdx
+++ b/docs/docs/architecture/tasks/index.mdx
@@ -146,7 +146,7 @@ A store that cannot be imported is a **startup failure**, not a fallback to
 memory. A deployment that asked for durable tasks and silently got in-process
 ones looks healthy right up to the restart that loses them.
 
-A store implements four methods:
+A store implements five methods:
 
 ```python
 class TaskStore(Protocol):
@@ -154,7 +154,12 @@ class TaskStore(Protocol):
     async def get(self, task_id: str) -> TaskRecord | None: ...
     async def list(self, *, limit: int = 50) -> list[TaskRecord]: ...
     async def update(self, task_id: str, **changes) -> TaskRecord | None: ...
+    async def find_by_key(self, idempotency_key: str) -> TaskRecord | None: ...
 ```
+
+`get` and `find_by_key` are both responsible for retention: a task past its
+`ttl` is answered as absent by each, and freeing the key is what lets a client
+reuse it.
 
 ## An extension, for now
 

--- a/docs/docs/architecture/tasks/index.mdx
+++ b/docs/docs/architecture/tasks/index.mdx
@@ -44,6 +44,37 @@ This is why the server never decides for you. A client that has not asked for
 a task does not know what a task id is, and would read that object as the
 tool's output.
 
+## A retry is one task
+
+Name the call with an idempotency key and a retry answers the task the first
+attempt created, rather than starting the work again:
+
+```json
+{
+  "method": "tools/call",
+  "params": {
+    "name": "execute_cell",
+    "arguments": { "cell_index": 3 },
+    "task": {},
+    "_meta": { "io.datalayer/idempotency-key": "run-3-attempt-1" }
+  }
+}
+```
+
+This matters most exactly when it is hardest to notice: the connection drops
+after the request arrived and before the answer got back. Without a key the
+client retries and gets two ten-minute cells, and pays for both.
+
+The same key on a **different** call is refused rather than replayed.
+Answering the first task would hand the client the result of work it did not
+ask for, under an id it believes it just created. The same call written with
+its arguments in another order is still the same call.
+
+A key belongs to a task, so it lives as long as the task does: once a task
+has expired its key is free again. And a call that did not ask for a task is
+not deduplicated — a synchronous call carrying a key is still a synchronous
+call.
+
 ## The five states
 
 | Status | Meaning |

--- a/docs/docs/architecture/tasks/index.mdx
+++ b/docs/docs/architecture/tasks/index.mdx
@@ -108,6 +108,33 @@ Both refusals exist for the same reason: the alternative is answering with an
 empty result, and a client that reads an empty result as "the tool produced
 nothing" is wrong in a way it cannot detect.
 
+## Cancelling stops the work
+
+`tasks/cancel` does two things, in this order: it interrupts the work, then
+it stops waiting for it.
+
+The order matters, and so does the first half. Cancelling the coroutine that
+is *waiting* for a cell does not stop the cell — the kernel keeps running it,
+keeps holding the sandbox and keeps costing money, while the task says
+`cancelled` and everybody believes it stopped.
+
+A tool that can actually stop its work says so:
+
+```python
+from jupyter_mcp_server.tasks import register_interrupt
+
+await register_interrupt(kernel.interrupt)
+```
+
+Outside a task this answers `False` and does nothing, which is right: a
+synchronous call has the client on the other end of the connection, and the
+client can drop it.
+
+An interrupt that fails does not stop the cancellation. Half of what the
+client asked for is better than none of it, and the failure is logged at
+error — a kernel that could not be interrupted is a sandbox somebody has to
+go and look at.
+
 ## Retention
 
 A finished task is kept for its `ttl` — 15 minutes by default, capped at 24

--- a/docs/docs/architecture/tasks/index.mdx
+++ b/docs/docs/architecture/tasks/index.mdx
@@ -1,0 +1,138 @@
+# Tasks
+
+Running a cell can take ten minutes. A client that holds a connection open for
+those ten minutes loses the work when the laptop sleeps, and one that gives up
+waiting has no way to find out what happened.
+
+A **task** is the protocol's answer. `tools/call` returns a task id
+immediately, the work goes on without the caller, and the client asks for the
+result whenever it likes — from another connection, after a reconnect,
+tomorrow.
+
+## Nothing changes unless you ask
+
+A task is created **only** when the request carries `task` metadata. Without
+it, `tools/call` runs exactly as it always has and returns the tool's output.
+
+```json
+{
+  "method": "tools/call",
+  "params": {
+    "name": "execute_cell",
+    "arguments": { "cell_index": 3 },
+    "task": { "ttl": 900000 }
+  }
+}
+```
+
+The answer is a `CreateTaskResult` rather than the tool's output:
+
+```json
+{
+  "task": {
+    "taskId": "tsk_9f2c…",
+    "status": "working",
+    "createdAt": "2026-08-28T10:00:00Z",
+    "lastUpdatedAt": "2026-08-28T10:00:00Z",
+    "ttl": 900000,
+    "pollInterval": 1000
+  }
+}
+```
+
+This is why the server never decides for you. A client that has not asked for
+a task does not know what a task id is, and would read that object as the
+tool's output.
+
+## The five states
+
+| Status | Meaning |
+|---|---|
+| `working` | Running now |
+| `input_required` | Waiting on something only a person can give |
+| `completed` | Done; ask `tasks/result` for the output |
+| `failed` | Stopped on an error; `tasks/result` raises it |
+| `cancelled` | Stopped because somebody asked |
+
+The last three are terminal: the record stops changing.
+
+## The four methods
+
+| Method | Answers |
+|---|---|
+| `tasks/get` | One task's status |
+| `tasks/list` | The tasks this server holds, newest first |
+| `tasks/cancel` | Stops the work and answers the task |
+| `tasks/result` | The output, once the task is terminal |
+
+There is no `tasks/update`. A client does not change a task; the server tells
+it through `notifications/tasks/status`.
+
+## A failure is a failed task, not an empty one
+
+A tool that raised ends `failed`, carrying the error, and `tasks/result`
+raises it. `tasks/result` on a task that is still `working` is refused too.
+
+Both refusals exist for the same reason: the alternative is answering with an
+empty result, and a client that reads an empty result as "the tool produced
+nothing" is wrong in a way it cannot detect.
+
+## Retention
+
+A finished task is kept for its `ttl` — 15 minutes by default, capped at 24
+hours — and is then gone. Asking for an expired task answers **no such task**,
+the same answer as for one that never existed. That is deliberate:
+distinguishing the two would tell a caller that an id they invented happens to
+have existed.
+
+A task that is still running never expires. Retention that killed work in
+flight would be a timeout wearing retention's name, and the two are set by
+different people for different reasons.
+
+## Polling, and the notification
+
+Every working task carries a `pollInterval` in milliseconds. Polling is the
+way a client learns a task's state; `notifications/tasks/status` is an
+optimisation on top, sent when a task reaches a terminal state.
+
+Treat the notification as advisory. A session that cannot carry it costs
+latency and nothing else — the task still completes, and the next poll finds
+it. The notification carries the status and never the result: a result can be
+a megabyte of output, and `tasks/result` is where the client decides whether
+it wants it.
+
+## Where tasks live
+
+By default, in the server process — which for a single-user server is where
+its tasks belong. `JUPYTER_MCP_TASK_STORE_CLASS` names another as
+`module:Class`:
+
+```bash
+export JUPYTER_MCP_TASK_STORE_CLASS=my_package.stores:RedisTaskStore
+```
+
+A store that cannot be imported is a **startup failure**, not a fallback to
+memory. A deployment that asked for durable tasks and silently got in-process
+ones looks healthy right up to the restart that loses them.
+
+A store implements four methods:
+
+```python
+class TaskStore(Protocol):
+    async def create(self, record: TaskRecord) -> TaskRecord: ...
+    async def get(self, task_id: str) -> TaskRecord | None: ...
+    async def list(self, *, limit: int = 50) -> list[TaskRecord]: ...
+    async def update(self, task_id: str, **changes) -> TaskRecord | None: ...
+```
+
+## An extension, for now
+
+`mcp.types` already defines every shape on this page — `Task`, `TaskStatus`,
+`CreateTaskResult`, the `tasks/*` requests. What the SDK does not yet do is
+*route* the methods, so the server binds them as an extension advertised
+under `io.datalayer/tasks`.
+
+That identifier is one constant. When the SDK routes `tasks/*` itself, the
+binding is removed and nothing else about a task changes — and until then the
+binding will refuse to construct the moment the SDK claims those methods,
+which is the loud way to find out.

--- a/docs/sourcey/mcp.json
+++ b/docs/sourcey/mcp.json
@@ -3,7 +3,7 @@
   "mcpVersion": "2025-11-25",
   "server": {
     "name": "Jupyter MCP Server",
-    "version": "2.1.0"
+    "version": "2.1.1"
   },
   "capabilities": {
     "experimental": {},

--- a/ext/mcpb/manifest.json
+++ b/ext/mcpb/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": "0.4",
   "name": "jupyter-mcp-server",
   "display_name": "Jupyter MCP Server",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "description": "Connect AI agents to Jupyter Notebooks - execute code, manage notebooks, and interact with kernels in real-time",
   "long_description": "The Jupyter MCP Server enables AI agents like Claude to connect to and manage Jupyter Notebooks in real-time. It provides 14 tools to execute code, manage notebooks, read and write cells, and interact with Jupyter kernels through the standardized Model Context Protocol.\n\n**Requirements:** You need a running Jupyter server (JupyterLab or Jupyter Notebook) to connect to. Start one with:\n```\npip install jupyterlab\njupyter lab --port 8888 --IdentityProvider.token MY_TOKEN\n```",
   "author": {

--- a/ext/mcpb/pyproject.toml
+++ b/ext/mcpb/pyproject.toml
@@ -4,7 +4,7 @@
 
 [project]
 name = "jupyter-mcp-server-mcpb"
-version = "2.1.0"
+version = "2.1.1"
 description = "Jupyter MCP Server - MCPB bundle for one-click installation in Claude Desktop"
 requires-python = ">=3.10"
 dependencies = [

--- a/jupyter_mcp_server/__version__.py
+++ b/jupyter_mcp_server/__version__.py
@@ -4,4 +4,4 @@
 
 """Jupyter MCP Server."""
 
-__version__ = "2.1.0"
+__version__ = "2.1.1"

--- a/jupyter_mcp_server/results.py
+++ b/jupyter_mcp_server/results.py
@@ -30,8 +30,8 @@ up through helpers that have no business carrying it.
 from __future__ import annotations
 
 import contextvars
-import json
 import hashlib
+import json
 import logging
 from collections.abc import Callable, Iterable, Mapping, Sequence
 from functools import wraps

--- a/jupyter_mcp_server/results.py
+++ b/jupyter_mcp_server/results.py
@@ -31,6 +31,7 @@ from __future__ import annotations
 
 import contextvars
 import json
+import hashlib
 import logging
 from collections.abc import Callable, Iterable, Mapping, Sequence
 from functools import wraps
@@ -229,6 +230,29 @@ def _default_shape(value: Any) -> dict[str, Any]:
     return {"result": as_text(value)}
 
 
+def etag_for(payload: Any) -> str:
+    """A version identifier for whatever this answer is made of.
+
+    Derived from the content rather than from a document version, and that is
+    a decision worth stating because the plan asked for the version.
+
+    A notebook's version is not one number here. A cell can be read through
+    the contents manager, through a live CRDT document or through a sandbox,
+    and the three do not share a counter; a tool that read one and reported
+    another's version would hand out an identifier that compares equal to
+    answers it has nothing to do with. Hashing what was actually answered
+    cannot be wrong in that way: two reads of an unchanged cell compare
+    equal, and a changed one does not.
+
+    Weak (`W/`), because it says *this means the same thing* rather than
+    *this is byte-for-byte what you had* — the same form the Datalayer
+    gateway stamps on the answers it synthesises, so a client sees one kind
+    of ETag whichever end produced it.
+    """
+    canonical = json.dumps(payload, sort_keys=True, separators=(",", ":"), default=str)
+    return 'W/"' + hashlib.sha256(canonical.encode("utf-8")).hexdigest()[:32] + '"'
+
+
 def answer(
     value: Any,
     *,
@@ -239,6 +263,7 @@ def answer(
     priority: float | None = None,
     ttl_ms: int | None = None,
     cache_scope: str = SCOPE_PRIVATE,
+    etag: bool = False,
 ) -> CallToolResult:
     """Build the one result shape from what a tool returned.
 
@@ -260,6 +285,9 @@ def answer(
         cache_scope: `private` unless the answer genuinely is the same for
             every caller. A shared cache holding one person's notebooks for
             another is the failure this exists to prevent.
+        etag: Also carry a version of this answer, so a client can ask
+            whether what it holds is still current instead of choosing
+            between a stale copy and fetching again. See `etag_for`.
     """
     annotations = _annotations(audience, priority)
     structured: dict[str, Any] = {"kind": kind}
@@ -275,7 +303,13 @@ def answer(
     collected = dict(_pending.get() or {})
     collected.update(meta or {})
     if ttl_ms is not None:
-        collected[CACHE_META_KEY] = {"ttlMs": ttl_ms, "cacheScope": cache_scope}
+        block: dict[str, Any] = {"ttlMs": ttl_ms, "cacheScope": cache_scope}
+        if etag:
+            # Over the structured answer, not the whole result: the content
+            # blocks are a rendering of the same facts, and hashing them too
+            # would make an ETag change when the prose does.
+            block["etag"] = etag_for(structured)
+        collected[CACHE_META_KEY] = block
     return CallToolResult(
         content=_content_of(value, annotations=annotations),
         structured_content=structured,
@@ -291,6 +325,7 @@ def structured(
     priority: float | None = None,
     ttl_ms: int | None = None,
     cache_scope: str = SCOPE_PRIVATE,
+    etag: bool = False,
 ) -> Callable:
     """Wrap a tool so its answer comes back in the one shape.
 
@@ -322,6 +357,7 @@ def structured(
                     priority=priority,
                     ttl_ms=ttl_ms,
                     cache_scope=cache_scope,
+                    etag=etag,
                 )
             finally:
                 _pending.reset(token)

--- a/jupyter_mcp_server/revalidation.py
+++ b/jupyter_mcp_server/revalidation.py
@@ -1,3 +1,7 @@
+# Copyright (c) 2024- Datalayer, Inc.
+#
+# BSD 3-Clause License
+
 # Copyright (c) 2023-2026 Datalayer, Inc.
 # BSD 3-Clause License
 

--- a/jupyter_mcp_server/revalidation.py
+++ b/jupyter_mcp_server/revalidation.py
@@ -31,7 +31,7 @@ somebody no cells at all.
 from __future__ import annotations
 
 import logging
-from typing import Any, Sequence
+from typing import Any
 
 from mcp.server.extension import Extension
 from mcp.types import CallToolRequestParams, CallToolResult

--- a/jupyter_mcp_server/revalidation.py
+++ b/jupyter_mcp_server/revalidation.py
@@ -1,0 +1,113 @@
+# Copyright (c) 2023-2026 Datalayer, Inc.
+# BSD 3-Clause License
+
+"""Telling a client that what it already holds is still current.
+
+A tool that stamps an ETag lets a client ask a cheaper question. Instead of
+choosing between a copy that may be stale and fetching the whole thing again,
+it sends the version it holds and is told, in one field, that it is still
+right.
+
+**This saves bandwidth, not work.** The tool still runs — the version is
+computed from what it answered, so there is no way to know the answer is
+unchanged without producing it. That is worth stating plainly, because an
+ETag on an HTTP endpoint often saves both and somebody will reasonably assume
+this one does too. Where it pays is `read_notebook` on a large notebook: the
+answer is megabytes and the comparison is a hash.
+
+The reply is the shape the Datalayer gateway already uses for the results it
+synthesises, so a client sees one kind of *not modified* whichever end
+produced it — and it says so in a named field rather than by being empty,
+because a client that read an empty result as an empty *notebook* would show
+somebody no cells at all.
+
+@module jupyter_mcp_server.revalidation
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Sequence
+
+from mcp.server.extension import Extension
+from mcp.types import CallToolRequestParams, CallToolResult
+
+from jupyter_mcp_server.results import CACHE_META_KEY
+
+logger = logging.getLogger(__name__)
+
+#: The extension identifier, advertised so a client knows it may ask.
+REVALIDATION_EXTENSION = "io.datalayer/revalidation"
+
+#: The field that says there is no payload, as opposed to an empty one.
+NOT_MODIFIED_KEY = "notModified"
+
+
+def _cache_block(meta: Any) -> dict[str, Any]:
+    if not isinstance(meta, dict):
+        return {}
+    block = meta.get(CACHE_META_KEY)
+    return block if isinstance(block, dict) else {}
+
+
+def requested_etag(params: Any) -> str:
+    """The version a client says it already has, from the request's `_meta`."""
+    return str(_cache_block(getattr(params, "meta", None)).get("etag") or "")
+
+
+def answered_etag(result: Any) -> str:
+    """The version a result carries, or `""` when the tool stamps none."""
+    return str(_cache_block(getattr(result, "meta", None)).get("etag") or "")
+
+
+def not_modified(block: dict[str, Any]) -> CallToolResult:
+    """The answer to a client that already has this result.
+
+    Carries the hints again, so holding it for another window costs nothing,
+    and says plainly that there is no payload rather than answering an empty
+    one.
+    """
+    return CallToolResult(
+        content=[],
+        structured_content=None,
+        meta={CACHE_META_KEY: {**block, NOT_MODIFIED_KEY: True}},
+    )
+
+
+class RevalidationExtension(Extension):
+    """Turns a matching ETag into *not modified*."""
+
+    identifier = REVALIDATION_EXTENSION
+
+    def settings(self) -> dict[str, Any]:
+        return {"notModifiedKey": NOT_MODIFIED_KEY}
+
+    async def intercept_tool_call(
+        self, params: CallToolRequestParams, ctx: Any, call_next: Any
+    ) -> Any:
+        wanted = requested_etag(params)
+        result = await call_next(ctx)
+        if getattr(result, "is_error", False):
+            # An error is never "what you already have". A client that
+            # treated a refusal as its cached answer being current would go
+            # on using a result the server has just declined to confirm.
+            return result
+        block = _cache_block(getattr(result, "meta", None))
+        current = str(block.get("etag") or "")
+        if not current or current != wanted:
+            # No ETag on this answer, or a different one: send the answer.
+            #
+            # `not current` is doing real work and is not a tidier way of
+            # writing the comparison. A tool that stamps no ETag answers
+            # `""`, and a client that holds none asks with `""` — without it
+            # the two would compare equal and a first call to an unstamped
+            # tool would come back "unchanged" about something the client
+            # has never seen.
+            return result
+        logger.debug("Answering not-modified for %s", getattr(params, "name", ""))
+        return not_modified(block)
+
+
+def revalidation_extension() -> RevalidationExtension:
+    """The extension, for `MCPServer(extensions=[...])`."""
+    return RevalidationExtension()

--- a/jupyter_mcp_server/server.py
+++ b/jupyter_mcp_server/server.py
@@ -34,6 +34,7 @@ from jupyter_mcp_server.capabilities import (
 from jupyter_mcp_server.config import get_config, set_config
 from jupyter_mcp_server.enroll import auto_enroll_document
 from jupyter_mcp_server.extensions import get_extension_manager
+from jupyter_mcp_server.tasks import tasks_extension
 from jupyter_mcp_server.hooks import HookEvent, HookRegistry, with_hooks
 from jupyter_mcp_server.jupyter_extension.context import get_server_context
 from jupyter_mcp_server.log import logger
@@ -322,7 +323,7 @@ mcp = MCPServerWithCORS(
     # The capability registry, advertised where a client will find it
     # rather than only at `capabilities://`, which a client has to know to
     # ask for. See `jupyter_mcp_server.capabilities`.
-    extensions=[capabilities_extension()],
+    extensions=[capabilities_extension(), tasks_extension()],
     # No `middleware=` here on purpose. mcp 2 installs its own
     # `OpenTelemetryMiddleware` by default, which is the span per inbound
     # message — `tools/list`, `tools/call`, the `gen_ai.*` attributes, the

--- a/jupyter_mcp_server/server.py
+++ b/jupyter_mcp_server/server.py
@@ -34,6 +34,7 @@ from jupyter_mcp_server.capabilities import (
 from jupyter_mcp_server.config import get_config, set_config
 from jupyter_mcp_server.enroll import auto_enroll_document
 from jupyter_mcp_server.extensions import get_extension_manager
+from jupyter_mcp_server.revalidation import revalidation_extension
 from jupyter_mcp_server.tasks import tasks_extension
 from jupyter_mcp_server.hooks import HookEvent, HookRegistry, with_hooks
 from jupyter_mcp_server.jupyter_extension.context import get_server_context
@@ -323,7 +324,7 @@ mcp = MCPServerWithCORS(
     # The capability registry, advertised where a client will find it
     # rather than only at `capabilities://`, which a client has to know to
     # ask for. See `jupyter_mcp_server.capabilities`.
-    extensions=[capabilities_extension(), tasks_extension()],
+    extensions=[capabilities_extension(), tasks_extension(), revalidation_extension()],
     # No `middleware=` here on purpose. mcp 2 installs its own
     # `OpenTelemetryMiddleware` by default, which is the span per inbound
     # message — `tools/list`, `tools/call`, the `gen_ai.*` attributes, the
@@ -749,7 +750,10 @@ async def unuse_notebook(
         openWorldHint=False,
     ),
 )
-@structured("notebook.read")
+# A read, so it carries a version a client can revalidate against. The
+# TTL is short because a notebook somebody is working in changes: the
+# ETag is what makes holding it worthwhile, not the seconds.
+@structured("notebook.read", ttl_ms=5000, etag=True)
 @with_hooks("read_notebook")
 async def read_notebook(
     notebook_name: Annotated[str, Field(description="Notebook identifier to read")],
@@ -1133,7 +1137,7 @@ async def insert_execute_code_cell(
         openWorldHint=False,
     ),
 )
-@structured("cell.read", shape=_outputs)
+@structured("cell.read", shape=_outputs, ttl_ms=5000, etag=True)
 @with_hooks("read_cell")
 async def read_cell(
     *,

--- a/jupyter_mcp_server/tasks.py
+++ b/jupyter_mcp_server/tasks.py
@@ -1,3 +1,7 @@
+# Copyright (c) 2024- Datalayer, Inc.
+#
+# BSD 3-Clause License
+
 # Copyright (c) 2023-2026 Datalayer, Inc.
 # BSD 3-Clause License
 

--- a/jupyter_mcp_server/tasks.py
+++ b/jupyter_mcp_server/tasks.py
@@ -1,0 +1,456 @@
+# Copyright (c) 2023-2026 Datalayer, Inc.
+# BSD 3-Clause License
+
+"""Tasks: a call whose answer outlives the request that asked for it.
+
+Running a cell can take ten minutes. A client that has to hold a connection
+open for those ten minutes loses the work when the laptop sleeps, and a client
+that gives up waiting has no way to find out what happened. Tasks are the
+protocol's answer: `tools/call` returns a **task id** immediately, the work
+goes on, and the client asks for the result whenever it likes — from another
+connection, after a reconnect, tomorrow.
+
+MCP defines this. `mcp.types` carries `Task`, `TaskStatus`, `CreateTaskResult`
+and the `tasks/*` request shapes; what the SDK does not yet do is *route* the
+methods, so this binds them as an extension. `TASKS_EXTENSION` is one
+constant, and the day the SDK routes `tasks/*` itself this file loses its
+`methods()` and keeps everything else.
+
+Three rules, and most of the code is one of them.
+
+**A task is created only when the client asks for one.** `tools/call` carries
+`task` metadata when the client wants a task. Without it the call is
+synchronous, exactly as before. Turning a synchronous call into a task
+because the server thought it would be slow would break every client that
+does not know what a task id is — they would read `CreateTaskResult` as the
+tool's output.
+
+**A failure is a failed task, not an empty one.** A tool that raised must end
+`failed` carrying the error. The alternative — `completed` with no output —
+is the worst outcome available: the client believes the work succeeded and
+produced nothing.
+
+**A task nobody can see is gone, not empty.** An expired task answers "no
+such task" rather than a record with no result. A client that reads an empty
+result as "it produced nothing" is wrong in a way it cannot detect.
+
+@module jupyter_mcp_server.tasks
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+import time
+import uuid
+from dataclasses import dataclass, field
+from typing import Any, Callable, Optional, Protocol, Sequence
+
+from mcp.server.extension import Extension, MethodBinding
+from mcp.shared.exceptions import MCPError
+from mcp.types import (
+    INVALID_PARAMS,
+    CallToolRequestParams,
+    CancelTaskRequestParams,
+    CancelTaskResult,
+    CreateTaskResult,
+    GetTaskPayloadRequestParams,
+    GetTaskRequestParams,
+    GetTaskResult,
+    ListTasksResult,
+    PaginatedRequestParams,
+    Task,
+)
+
+logger = logging.getLogger(__name__)
+
+#: The extension identifier, in one place. Tasks are a protocol feature the
+#: SDK does not route yet; when it does, this file drops `methods()` and the
+#: identifier stops being advertised — nothing else about a task changes.
+TASKS_EXTENSION = "io.datalayer/tasks"
+
+#: How long a finished task is kept when the client asks for no particular
+#: retention. Long enough to survive a reconnect and a coffee; short enough
+#: that a server that is never restarted does not accumulate every result it
+#: ever produced.
+DEFAULT_TTL_MS = 15 * 60 * 1000
+
+#: The ceiling on what a client may ask to retain. A client asking for a year
+#: is asking this process to be a database.
+MAX_TTL_MS = 24 * 60 * 60 * 1000
+
+#: What a client is told to wait between polls. Advisory, and worth sending:
+#: without it a client picks its own interval, and the one it picks is 100ms.
+POLL_INTERVAL_MS = 1000
+
+#: The statuses from which nothing more happens.
+TERMINAL_STATUSES = frozenset({"completed", "failed", "cancelled"})
+
+#: How many tasks one `tasks/list` returns.
+LIST_PAGE = 50
+
+#: The store implementation, as `module:Class`. A deployment that wants tasks
+#: to survive a restart points this at its own; the default keeps them in this
+#: process, which is what a single-user server is anyway.
+TASK_STORE_CLASS_ENV = "JUPYTER_MCP_TASK_STORE_CLASS"
+
+
+def _now_iso() -> str:
+    return time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime())
+
+
+@dataclass
+class TaskRecord:
+    """One task, as this server keeps it.
+
+    The protocol's `Task` is the public half. The result, the error and the
+    handle to the work in flight stay here: a client asks for the result
+    through `tasks/result`, which is where the *whether it may* is decided.
+    """
+
+    task_id: str
+    status: str = "working"
+    status_message: str | None = None
+    created_at: str = field(default_factory=_now_iso)
+    last_updated_at: str = field(default_factory=_now_iso)
+    #: Milliseconds from creation, or `None` for unlimited.
+    ttl: int | None = DEFAULT_TTL_MS
+    #: What the call produced. `None` until it produced something.
+    result: Any = None
+    #: Why it failed, for a `failed` task.
+    error: str = ""
+    #: The tool this task is running, for `tasks/list` and for a log line.
+    tool: str = ""
+    #: The work in flight, so `tasks/cancel` can actually stop it.
+    handle: Any = field(default=None, repr=False)
+    #: Monotonic, for expiry. Not `created_at`: a clock that steps backwards
+    #: would make a task un-expire, and NTP steps clocks backwards.
+    started_monotonic: float = field(default_factory=time.monotonic)
+
+    def public(self) -> Task:
+        """The protocol's view. Never the result, never the handle."""
+        return Task(
+            task_id=self.task_id,
+            status=self.status,  # type: ignore[arg-type]
+            status_message=self.status_message,
+            created_at=self.created_at,
+            last_updated_at=self.last_updated_at,
+            ttl=self.ttl,
+            poll_interval=None if self.is_terminal else POLL_INTERVAL_MS,
+        )
+
+    @property
+    def is_terminal(self) -> bool:
+        return self.status in TERMINAL_STATUSES
+
+    def expired(self, *, now: float | None = None) -> bool:
+        """Whether this task is past its retention.
+
+        A task still running never expires — a retention that killed work in
+        flight would be a timeout wearing retention's name, and the two are
+        set by different people for different reasons.
+        """
+        if self.ttl is None or not self.is_terminal:
+            return False
+        moment = now if now is not None else time.monotonic()
+        return (moment - self.started_monotonic) * 1000 >= self.ttl
+
+
+class TaskStore(Protocol):
+    """Where tasks live between the call that made one and the call that reads it."""
+
+    async def create(self, record: TaskRecord) -> TaskRecord: ...
+
+    async def get(self, task_id: str) -> TaskRecord | None: ...
+
+    async def list(self, *, limit: int = LIST_PAGE) -> list[TaskRecord]: ...
+
+    async def update(self, task_id: str, **changes: Any) -> TaskRecord | None: ...
+
+
+class MemoryTaskStore:
+    """Tasks in this process, which is where a single-user server's are.
+
+    Expiry is applied on read rather than on a timer. A sweeper would need a
+    loop that runs whether or not anybody is asking, and the only observable
+    difference is memory held a little longer by a server nobody is using.
+    """
+
+    def __init__(self) -> None:
+        self._tasks: dict[str, TaskRecord] = {}
+        self._lock = asyncio.Lock()
+
+    async def create(self, record: TaskRecord) -> TaskRecord:
+        async with self._lock:
+            self._tasks[record.task_id] = record
+            return record
+
+    async def get(self, task_id: str) -> TaskRecord | None:
+        async with self._lock:
+            record = self._tasks.get(task_id)
+            if record is None:
+                return None
+            if record.expired():
+                # Gone, not empty. A caller that read an expired record as a
+                # result would read "produced nothing" for work that produced
+                # something an hour ago.
+                del self._tasks[task_id]
+                return None
+            return record
+
+    async def list(self, *, limit: int = LIST_PAGE) -> list[TaskRecord]:
+        async with self._lock:
+            live = [record for record in self._tasks.values() if not record.expired()]
+            for record in self._tasks.values():
+                if record.expired():
+                    self._tasks.pop(record.task_id, None)
+        return sorted(live, key=lambda record: record.created_at, reverse=True)[: max(1, limit)]
+
+    async def update(self, task_id: str, **changes: Any) -> TaskRecord | None:
+        async with self._lock:
+            record = self._tasks.get(task_id)
+            if record is None:
+                return None
+            for name, value in changes.items():
+                setattr(record, name, value)
+            record.last_updated_at = _now_iso()
+            return record
+
+
+_store: TaskStore | None = None
+
+
+def get_task_store() -> TaskStore:
+    """The store this process uses, built once.
+
+    `JUPYTER_MCP_TASK_STORE_CLASS` names another as `module:Class`. A name
+    that cannot be imported is **fatal** rather than a fallback to memory: a
+    deployment that asked for durable tasks and silently got in-process ones
+    looks healthy right up to the restart that loses them.
+    """
+    global _store
+    if _store is None:
+        _store = _build_store(os.environ.get(TASK_STORE_CLASS_ENV, "").strip())
+    return _store
+
+
+def _build_store(spec: str) -> TaskStore:
+    if not spec:
+        return MemoryTaskStore()
+    module_name, _, class_name = spec.partition(":")
+    if not module_name or not class_name:
+        raise ValueError(
+            f"{TASK_STORE_CLASS_ENV} must be 'module:Class'; got {spec!r}"
+        )
+    import importlib  # noqa: PLC0415
+
+    module = importlib.import_module(module_name)
+    return getattr(module, class_name)()
+
+
+def use_task_store(replacement: TaskStore | None) -> None:
+    """Swap the process store — for the tests, and at startup."""
+    global _store
+    _store = replacement
+
+
+def _no_such_task(task_id: str) -> MCPError:
+    """The one answer for a task that never existed and one that expired.
+
+    Deliberately the same. Distinguishing them tells a caller that a task id
+    they made up happens to have existed, and tells a caller whose task
+    expired nothing more useful than "it is not here".
+    """
+    return MCPError(code=INVALID_PARAMS, message=f"No such task: {task_id}")
+
+
+def requested_ttl(metadata: Any) -> int | None:
+    """What to retain a task for, given what the client asked.
+
+    `None` from the client means "you decide", which is the default rather
+    than "forever": a client that omits the field is not asking this process
+    to hold its result until the heat death of the server. An explicit
+    `null`, which the protocol allows for unlimited, is honoured but capped —
+    the cap is what stops one client's forever from being everybody's memory.
+    """
+    asked = getattr(metadata, "ttl", None)
+    if asked is None:
+        return DEFAULT_TTL_MS
+    try:
+        value = int(asked)
+    except (TypeError, ValueError):
+        return DEFAULT_TTL_MS
+    if value <= 0:
+        return DEFAULT_TTL_MS
+    return min(value, MAX_TTL_MS)
+
+
+class TasksExtension(Extension):
+    """`tasks/*`, and the interception that creates one.
+
+    The methods are bound rather than implemented on the server because the
+    SDK does not route `tasks/*` yet — `SPEC_CLIENT_METHODS` does not name
+    them, so `MethodBinding` accepts them. When the SDK does route them, this
+    binding will raise at construction, loudly, which is the right way to
+    find out.
+    """
+
+    identifier = TASKS_EXTENSION
+
+    def __init__(self, store: TaskStore | None = None) -> None:
+        self._store = store
+
+    @property
+    def store(self) -> TaskStore:
+        return self._store if self._store is not None else get_task_store()
+
+    def settings(self) -> dict[str, Any]:
+        return {
+            "defaultTtlMs": DEFAULT_TTL_MS,
+            "maxTtlMs": MAX_TTL_MS,
+            "pollIntervalMs": POLL_INTERVAL_MS,
+        }
+
+    def methods(self) -> Sequence[MethodBinding]:
+        return (
+            MethodBinding(
+                method="tasks/get",
+                params_type=GetTaskRequestParams,
+                handler=self._handle_get,
+            ),
+            MethodBinding(
+                method="tasks/list",
+                # `tasks/list` takes the ordinary pagination params. Named
+                # directly rather than dug out of `ListTasksRequest`, whose
+                # `params` is `PaginatedRequestParams | None` — a union, which
+                # is not a model class and would fail validation setup.
+                params_type=PaginatedRequestParams,
+                handler=self._handle_list,
+            ),
+            MethodBinding(
+                method="tasks/cancel",
+                params_type=CancelTaskRequestParams,
+                handler=self._handle_cancel,
+            ),
+            MethodBinding(
+                method="tasks/result",
+                params_type=GetTaskPayloadRequestParams,
+                handler=self._handle_result,
+            ),
+        )
+
+    # -- the four methods ---------------------------------------------------
+
+    async def _handle_get(self, params: Any, ctx: Any) -> GetTaskResult:
+        record = await self.store.get(params.task_id)
+        if record is None:
+            raise _no_such_task(params.task_id)
+        return GetTaskResult(**record.public().model_dump(by_alias=False))
+
+    async def _handle_list(self, params: Any, ctx: Any) -> ListTasksResult:
+        records = await self.store.list()
+        return ListTasksResult(tasks=[record.public() for record in records])
+
+    async def _handle_cancel(self, params: Any, ctx: Any) -> CancelTaskResult:
+        record = await self.store.get(params.task_id)
+        if record is None:
+            raise _no_such_task(params.task_id)
+        if not record.is_terminal:
+            handle = record.handle
+            if handle is not None:
+                handle.cancel()
+            record = await self.store.update(
+                params.task_id, status="cancelled", status_message="cancelled by the client"
+            ) or record
+        # A terminal task is answered as it is rather than refused: cancelling
+        # something that already finished is not an error, it is a race the
+        # client lost, and telling it so as a failure teaches it to retry.
+        return CancelTaskResult(**record.public().model_dump(by_alias=False))
+
+    async def _handle_result(self, params: Any, ctx: Any) -> Any:
+        record = await self.store.get(params.task_id)
+        if record is None:
+            raise _no_such_task(params.task_id)
+        if not record.is_terminal:
+            # Not an empty result. A client that got `{}` here would show the
+            # user "no output" for work that is still running.
+            raise MCPError(
+                code=INVALID_PARAMS,
+                message=(
+                    f"Task {params.task_id} is {record.status}; ask again when it "
+                    f"is done, or poll tasks/get every {POLL_INTERVAL_MS}ms"
+                ),
+            )
+        if record.status == "failed":
+            raise MCPError(
+                code=INVALID_PARAMS, message=record.error or "the task failed"
+            )
+        return record.result
+
+    # -- creating one -------------------------------------------------------
+
+    async def intercept_tool_call(
+        self, params: CallToolRequestParams, ctx: Any, call_next: Callable[[Any], Any]
+    ) -> Any:
+        """Run the call as a task when the client asked for one.
+
+        Asked for: `params.task` is present. Absent, this passes through and
+        the call is synchronous exactly as it was — which is the whole reason
+        this is an interception rather than a change to the tools.
+        """
+        asked = getattr(params, "task", None)
+        if asked is None:
+            return await call_next(ctx)
+
+        record = TaskRecord(
+            task_id=f"tsk_{uuid.uuid4().hex}",
+            ttl=requested_ttl(asked),
+            tool=getattr(params, "name", "") or "",
+        )
+        await self.store.create(record)
+        record.handle = asyncio.ensure_future(self._run(record.task_id, ctx, call_next))
+        logger.info(
+            "Task %s created for %s, retained for %sms",
+            record.task_id,
+            record.tool or "a tool call",
+            record.ttl,
+        )
+        return CreateTaskResult(task=record.public())
+
+    async def _run(self, task_id: str, ctx: Any, call_next: Callable[[Any], Any]) -> None:
+        """The work, and every way it can end recorded.
+
+        Nothing raises out of here. This runs as a detached task, and an
+        exception that escapes goes to the event loop's exception handler —
+        which is to say to a log line nobody reads, while the task stays
+        `working` for its whole retention and the client polls it forever.
+        """
+        try:
+            result = await call_next(ctx)
+        except asyncio.CancelledError:
+            # Cancelled by `tasks/cancel`, which already wrote the status. Do
+            # not overwrite it with `failed`: "you cancelled this" and "this
+            # broke" are different things to show a person.
+            await self._mark_cancelled(task_id)
+            raise
+        except Exception as error:  # noqa: BLE001 - every failure is a failed task
+            logger.exception("Task %s failed", task_id)
+            await self.store.update(
+                task_id,
+                status="failed",
+                error=f"{type(error).__name__}: {error}",
+                status_message=str(error)[:200],
+            )
+            return
+        await self.store.update(task_id, status="completed", result=result)
+
+    async def _mark_cancelled(self, task_id: str) -> None:
+        record = await self.store.get(task_id)
+        if record is not None and not record.is_terminal:
+            await self.store.update(task_id, status="cancelled")
+
+
+def tasks_extension(store: TaskStore | None = None) -> TasksExtension:
+    """The extension, for `MCPServer(extensions=[...])`."""
+    return TasksExtension(store)

--- a/jupyter_mcp_server/tasks.py
+++ b/jupyter_mcp_server/tasks.py
@@ -40,6 +40,7 @@ result as "it produced nothing" is wrong in a way it cannot detect.
 from __future__ import annotations
 
 import asyncio
+import contextvars
 import logging
 import os
 import time
@@ -136,6 +137,9 @@ class TaskRecord:
     #: Monotonic, for expiry. Not `created_at`: a clock that steps backwards
     #: would make a task un-expire, and NTP steps clocks backwards.
     started_monotonic: float = field(default_factory=time.monotonic)
+    #: How to stop the work itself, as opposed to stopping the wait for it.
+    #: See `register_interrupt`.
+    interrupt: Any = field(default=None, repr=False)
     #: What the client called this call, so a retry is one task.
     idempotency_key: str = ""
     #: A digest of the call the key was used for. A key reused for a
@@ -289,6 +293,41 @@ def use_task_store(replacement: TaskStore | None) -> None:
     _store = replacement
 
 
+#: The task the current call is running as, or `""` when it is synchronous.
+#: A context variable rather than an argument, because the thing that knows
+#: how to interrupt a kernel is several frames below the thing that knows
+#: about tasks, and threading a task id through every tool signature would
+#: make tasks a concern of every tool.
+CURRENT_TASK: contextvars.ContextVar[str] = contextvars.ContextVar(
+    "jupyter_mcp_current_task", default=""
+)
+
+
+def current_task() -> str:
+    """The task this call is running as, or `""` for a synchronous call."""
+    return CURRENT_TASK.get()
+
+
+async def register_interrupt(stop: Callable[[], Any], *, store: TaskStore | None = None) -> bool:
+    """Say how to stop the work this task is doing.
+
+    Cancelling a task cancels the coroutine that is *waiting* for a cell.
+    That is not the same as stopping the cell: the kernel keeps running it,
+    keeps holding the sandbox, and keeps costing money, while the task says
+    `cancelled` and everybody believes it stopped. A tool that can actually
+    stop its work registers that here, and `tasks/cancel` calls it first.
+
+    Answers whether it was registered — `False` for a synchronous call, which
+    has no task to attach to and needs none, since the client is still on the
+    other end of the connection and can drop it.
+    """
+    task_id = current_task()
+    if not task_id:
+        return False
+    where = store or get_task_store()
+    return await where.update(task_id, interrupt=stop) is not None
+
+
 def _idempotency_key(params: Any) -> str:
     """What the client called this call, if it named it."""
     meta = getattr(params, "meta", None) or {}
@@ -318,6 +357,32 @@ def _request_hash(params: Any) -> str:
         default=str,
     )
     return hashlib.sha256(body.encode()).hexdigest()
+
+
+async def _interrupt(record: TaskRecord) -> bool:
+    """Run a task's interrupt, if it has one. Never raises.
+
+    A failure here must not stop the cancellation: the client asked for the
+    work to stop, and half of that succeeding is better than none of it. The
+    failure is logged, because a kernel that could not be interrupted is a
+    sandbox somebody has to go and look at.
+    """
+    stop = getattr(record, "interrupt", None)
+    if stop is None:
+        return False
+    try:
+        outcome = stop()
+        if hasattr(outcome, "__await__"):
+            await outcome
+    except Exception as error:  # noqa: BLE001 - the cancel proceeds regardless
+        logger.error(
+            "Task %s could not be interrupted (%s); the task is cancelled but "
+            "the work it started may still be running",
+            record.task_id,
+            error,
+        )
+        return False
+    return True
 
 
 def _no_such_task(task_id: str) -> MCPError:
@@ -422,6 +487,11 @@ class TasksExtension(Extension):
         if record is None:
             raise _no_such_task(params.task_id)
         if not record.is_terminal:
+            # Stop the work before stopping the wait for it. Cancelling the
+            # handle alone leaves a cell running on a kernel that nobody is
+            # watching, holding a sandbox and costing money, while the task
+            # says `cancelled`.
+            await _interrupt(record)
             handle = record.handle
             if handle is not None:
                 handle.cancel()
@@ -564,6 +634,7 @@ class TasksExtension(Extension):
         which is to say to a log line nobody reads, while the task stays
         `working` for its whole retention and the client polls it forever.
         """
+        CURRENT_TASK.set(task_id)
         try:
             result = await call_next(ctx)
         except asyncio.CancelledError:

--- a/jupyter_mcp_server/tasks.py
+++ b/jupyter_mcp_server/tasks.py
@@ -95,6 +95,10 @@ LIST_PAGE = 50
 #: The notification the server sends when a task changes state.
 TASK_STATUS_NOTIFICATION = "notifications/tasks/status"
 
+#: Where a client puts a key that makes a retried `tools/call` one task.
+#: `_meta` is an open map, so this rides along without a protocol change.
+IDEMPOTENCY_KEY_META = "io.datalayer/idempotency-key"
+
 #: The store implementation, as `module:Class`. A deployment that wants tasks
 #: to survive a restart points this at its own; the default keeps them in this
 #: process, which is what a single-user server is anyway.
@@ -132,6 +136,11 @@ class TaskRecord:
     #: Monotonic, for expiry. Not `created_at`: a clock that steps backwards
     #: would make a task un-expire, and NTP steps clocks backwards.
     started_monotonic: float = field(default_factory=time.monotonic)
+    #: What the client called this call, so a retry is one task.
+    idempotency_key: str = ""
+    #: A digest of the call the key was used for. A key reused for a
+    #: *different* call is a mistake, not a replay — see `intercept_tool_call`.
+    request_hash: str = ""
 
     def public(self) -> Task:
         """The protocol's view. Never the result, never the handle."""
@@ -172,6 +181,10 @@ class TaskStore(Protocol):
     async def list(self, *, limit: int = LIST_PAGE) -> list[TaskRecord]: ...
 
     async def update(self, task_id: str, **changes: Any) -> TaskRecord | None: ...
+
+    async def find_by_key(self, idempotency_key: str) -> TaskRecord | None:
+        """The task a previous call under this key created, if it is still here."""
+        ...
 
 
 class MemoryTaskStore:
@@ -222,6 +235,22 @@ class MemoryTaskStore:
             record.last_updated_at = _now_iso()
             return record
 
+    async def find_by_key(self, idempotency_key: str) -> TaskRecord | None:
+        if not idempotency_key:
+            return None
+        async with self._lock:
+            for record in list(self._tasks.values()):
+                if record.idempotency_key != idempotency_key:
+                    continue
+                if record.expired():
+                    # An expired task is gone, and its key is free again. The
+                    # alternative — answering a record whose result has been
+                    # swept — hands the client a task it can never read.
+                    del self._tasks[record.task_id]
+                    return None
+                return record
+        return None
+
 
 _store: TaskStore | None = None
 
@@ -258,6 +287,37 @@ def use_task_store(replacement: TaskStore | None) -> None:
     """Swap the process store — for the tests, and at startup."""
     global _store
     _store = replacement
+
+
+def _idempotency_key(params: Any) -> str:
+    """What the client called this call, if it named it."""
+    meta = getattr(params, "meta", None) or {}
+    try:
+        return str(meta.get(IDEMPOTENCY_KEY_META) or "")
+    except AttributeError:
+        return ""
+
+
+def _request_hash(params: Any) -> str:
+    """A digest of the call, so a key reused for another call is caught.
+
+    Canonical JSON of the tool and its arguments: the same call serialised
+    with its keys in another order is the same call, and treating it as a
+    different one would turn every retry into a conflict.
+    """
+    import hashlib  # noqa: PLC0415
+    import json  # noqa: PLC0415
+
+    body = json.dumps(
+        {
+            "name": getattr(params, "name", "") or "",
+            "arguments": getattr(params, "arguments", None) or {},
+        },
+        sort_keys=True,
+        separators=(",", ":"),
+        default=str,
+    )
+    return hashlib.sha256(body.encode()).hexdigest()
 
 
 def _no_such_task(task_id: str) -> MCPError:
@@ -404,15 +464,46 @@ class TasksExtension(Extension):
         Asked for: `params.task` is present. Absent, this passes through and
         the call is synchronous exactly as it was — which is the whole reason
         this is an interception rather than a change to the tools.
+
+        A client may name the call with an idempotency key in `_meta`. A
+        retry under the same key answers the task the first attempt created
+        rather than starting the work a second time — which matters most
+        exactly when it is hardest to notice: the connection dropped after
+        the request arrived and before the answer got back, so the client
+        retries and, without this, gets two ten-minute cells and pays for
+        both.
+
+        The same key on a *different* call is a conflict rather than a
+        replay. Answering the first task would hand the client the result of
+        work it did not ask for, under an id it believes it just created.
         """
         asked = getattr(params, "task", None)
         if asked is None:
             return await call_next(ctx)
 
+        key = _idempotency_key(params)
+        digest = _request_hash(params)
+        if key:
+            existing = await self.store.find_by_key(key)
+            if existing is not None:
+                if existing.request_hash != digest:
+                    raise MCPError(
+                        code=INVALID_PARAMS,
+                        message=(
+                            f"The idempotency key {key!r} was already used for a "
+                            f"different call ({existing.tool or 'another tool'}). "
+                            f"Use a new key, or repeat the original call exactly."
+                        ),
+                    )
+                logger.info("Task %s answered again for key %s", existing.task_id, key)
+                return CreateTaskResult(task=existing.public())
+
         record = TaskRecord(
             task_id=f"tsk_{uuid.uuid4().hex}",
             ttl=requested_ttl(asked),
             tool=getattr(params, "name", "") or "",
+            idempotency_key=key,
+            request_hash=digest,
         )
         await self.store.create(record)
         record.handle = asyncio.ensure_future(self._run(record.task_id, ctx, call_next))

--- a/jupyter_mcp_server/tasks.py
+++ b/jupyter_mcp_server/tasks.py
@@ -61,6 +61,8 @@ from mcp.types import (
     ListTasksResult,
     PaginatedRequestParams,
     Task,
+    TaskStatusNotification,
+    TaskStatusNotificationParams,
 )
 
 logger = logging.getLogger(__name__)
@@ -89,6 +91,9 @@ TERMINAL_STATUSES = frozenset({"completed", "failed", "cancelled"})
 
 #: How many tasks one `tasks/list` returns.
 LIST_PAGE = 50
+
+#: The notification the server sends when a task changes state.
+TASK_STATUS_NOTIFICATION = "notifications/tasks/status"
 
 #: The store implementation, as `module:Class`. A deployment that wants tasks
 #: to survive a restart points this at its own; the default keeps them in this
@@ -363,6 +368,7 @@ class TasksExtension(Extension):
             record = await self.store.update(
                 params.task_id, status="cancelled", status_message="cancelled by the client"
             ) or record
+            await self._publish(ctx, record)
         # A terminal task is answered as it is rather than refused: cancelling
         # something that already finished is not an error, it is a race the
         # client lost, and telling it so as a failure teaches it to retry.
@@ -418,6 +424,47 @@ class TasksExtension(Extension):
         )
         return CreateTaskResult(task=record.public())
 
+    async def _publish(self, ctx: Any, record: TaskRecord | None) -> None:
+        """Tell the client a task changed, if the session can carry it.
+
+        Best effort, and that is a design position rather than a shrug. The
+        protocol makes polling the way a client learns a task's state — that
+        is what `poll_interval` on every working task is for — and a
+        notification is an optimisation on top. So a session that cannot send
+        this one costs latency and nothing else, and failing the task because
+        the *news about* the task would not go out would be trading the work
+        for the story about the work.
+
+        `ServerSession.send_notification` types its argument as the union of
+        spec notifications, which does not yet include this one; the SDK is
+        mid-adoption, the same reason `methods()` exists at all. The private
+        path is a thin wrapper that dumps the model, so it carries this
+        correctly today and will be replaced by the public one the moment the
+        union grows.
+        """
+        if record is None:
+            return
+        session = getattr(ctx, "session", None)
+        if session is None:
+            return
+        notification = TaskStatusNotification(
+            method=TASK_STATUS_NOTIFICATION,
+            params=TaskStatusNotificationParams(**record.public().model_dump(by_alias=False)),
+        )
+        try:
+            send = getattr(session, "send_notification", None)
+            if send is not None:
+                await send(notification)
+                return
+            await session._notify(notification, request_scoped=False)  # noqa: SLF001
+        except Exception as error:  # noqa: BLE001 - the client still polls
+            logger.debug(
+                "The status of task %s could not be sent (%s); the client polls "
+                "for it instead",
+                record.task_id,
+                error,
+            )
+
     async def _run(self, task_id: str, ctx: Any, call_next: Callable[[Any], Any]) -> None:
         """The work, and every way it can end recorded.
 
@@ -433,17 +480,23 @@ class TasksExtension(Extension):
             # not overwrite it with `failed`: "you cancelled this" and "this
             # broke" are different things to show a person.
             await self._mark_cancelled(task_id)
+            await self._publish(ctx, await self.store.get(task_id))
             raise
         except Exception as error:  # noqa: BLE001 - every failure is a failed task
             logger.exception("Task %s failed", task_id)
-            await self.store.update(
-                task_id,
-                status="failed",
-                error=f"{type(error).__name__}: {error}",
-                status_message=str(error)[:200],
+            await self._publish(
+                ctx,
+                await self.store.update(
+                    task_id,
+                    status="failed",
+                    error=f"{type(error).__name__}: {error}",
+                    status_message=str(error)[:200],
+                ),
             )
             return
-        await self.store.update(task_id, status="completed", result=result)
+        await self._publish(
+            ctx, await self.store.update(task_id, status="completed", result=result)
+        )
 
     async def _mark_cancelled(self, task_id: str) -> None:
         record = await self.store.get(task_id)

--- a/jupyter_mcp_server/tasks.py
+++ b/jupyter_mcp_server/tasks.py
@@ -49,8 +49,9 @@ import logging
 import os
 import time
 import uuid
+from collections.abc import Callable, Sequence
 from dataclasses import dataclass, field
-from typing import Any, Callable, Optional, Protocol, Sequence
+from typing import Any, Protocol
 
 from mcp.server.extension import Extension, MethodBinding
 from mcp.shared.exceptions import MCPError
@@ -227,10 +228,17 @@ class MemoryTaskStore:
 
     async def list(self, *, limit: int = LIST_PAGE) -> list[TaskRecord]:
         async with self._lock:
-            live = [record for record in self._tasks.values() if not record.expired()]
-            for record in self._tasks.values():
+            # One pass over a snapshot. The previous version walked
+            # `self._tasks.values()` while popping from `self._tasks`, which
+            # raises `RuntimeError: dictionary changed size during iteration`
+            # the moment anything has expired — so `tasks/list` failed
+            # outright rather than degrading.
+            live: list[TaskRecord] = []
+            for task_id, record in list(self._tasks.items()):
                 if record.expired():
-                    self._tasks.pop(record.task_id, None)
+                    self._tasks.pop(task_id, None)
+                else:
+                    live.append(record)
         return sorted(live, key=lambda record: record.created_at, reverse=True)[: max(1, limit)]
 
     async def update(self, task_id: str, **changes: Any) -> TaskRecord | None:
@@ -285,7 +293,7 @@ def _build_store(spec: str) -> TaskStore:
         raise ValueError(
             f"{TASK_STORE_CLASS_ENV} must be 'module:Class'; got {spec!r}"
         )
-    import importlib  # noqa: PLC0415
+    import importlib
 
     module = importlib.import_module(module_name)
     return getattr(module, class_name)()
@@ -348,8 +356,8 @@ def _request_hash(params: Any) -> str:
     with its keys in another order is the same call, and treating it as a
     different one would turn every retry into a conflict.
     """
-    import hashlib  # noqa: PLC0415
-    import json  # noqa: PLC0415
+    import hashlib
+    import json
 
     body = json.dumps(
         {
@@ -378,7 +386,8 @@ async def _interrupt(record: TaskRecord) -> bool:
         outcome = stop()
         if hasattr(outcome, "__await__"):
             await outcome
-    except Exception as error:  # noqa: BLE001 - the cancel proceeds regardless
+    # Broad on purpose: the cancel proceeds regardless.
+    except Exception as error:
         logger.error(
             "Task %s could not be interrupted (%s); the task is cancelled but "
             "the work it started may still be running",
@@ -621,8 +630,9 @@ class TasksExtension(Extension):
             if send is not None:
                 await send(notification)
                 return
-            await session._notify(notification, request_scoped=False)  # noqa: SLF001
-        except Exception as error:  # noqa: BLE001 - the client still polls
+            await session._notify(notification, request_scoped=False)
+        # Broad on purpose: the client still polls.
+        except Exception as error:
             logger.debug(
                 "The status of task %s could not be sent (%s); the client polls "
                 "for it instead",
@@ -648,7 +658,8 @@ class TasksExtension(Extension):
             await self._mark_cancelled(task_id)
             await self._publish(ctx, await self.store.get(task_id))
             raise
-        except Exception as error:  # noqa: BLE001 - every failure is a failed task
+        # Broad on purpose: every failure is a failed task.
+        except Exception as error:
             logger.exception("Task %s failed", task_id)
             await self._publish(
                 ctx,

--- a/jupyter_mcp_server/utils.py
+++ b/jupyter_mcp_server/utils.py
@@ -211,6 +211,22 @@ _TRUE_VALUES = frozenset({"1", "true", "t", "yes", "y", "on"})
 _FALSE_VALUES = frozenset({"0", "false", "f", "no", "n", "off"})
 
 
+def _env_flag(name: str) -> bool | None:
+    """A three-state environment flag: on, off, or not set.
+
+    Three rather than two because "not set" is a real answer here — it means
+    *use the default for this way of running* — and collapsing it into
+    `False` would make an unset variable indistinguishable from one somebody
+    set to `false` on purpose.
+    """
+    import os
+
+    raw = (os.environ.get(name) or "").strip().lower()
+    if not raw:
+        return None
+    return raw in ("1", "true", "yes", "on")
+
+
 def parse_bool_option(value, option_name: str) -> bool:
     """Parse a CLI boolean option that accepts explicit True/False values."""
     if isinstance(value, bool):
@@ -388,7 +404,31 @@ def do_start(
     if transport == "stdio":
         mcp.run(transport="stdio")
     elif transport == "streamable-http":
-        uvicorn.run(mcp.streamable_http_app(), host="0.0.0.0", port=port)  # noqa: S104
+        # Stateless unless the deployment says otherwise.
+        #
+        # Stateless is right for a server many people reach: each request runs
+        # in its own context, so `IdentityMiddleware` sees the caller of
+        # *that* request rather than whoever opened the session. The cost is
+        # that no `Mcp-Session-Id` is issued, because there is no session to
+        # name — and a Streamable HTTP client that expects one gets nothing.
+        #
+        # It is the wrong default for a worker the Datalayer gateway starts,
+        # where there is one process per user: every request on it is the same
+        # caller by construction, so the reason for statelessness does not
+        # apply. `JUPYTER_MCP_STATEFUL=true` turns sessions on for that case.
+        stateless = _env_flag("JUPYTER_MCP_STATEFUL") is not True
+        logger.info(
+            "Streamable HTTP transport is %s: %s",
+            "stateless" if stateless else "stateful",
+            "no Mcp-Session-Id is issued"
+            if stateless
+            else "each client is given an Mcp-Session-Id",
+        )
+        uvicorn.run(
+            mcp.streamable_http_app(stateless_http=stateless),
+            host="0.0.0.0",  # noqa: S104
+            port=port,
+        )
     else:
         raise Exception("Transport should be `stdio` or `streamable-http`.")
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,7 +57,7 @@ test = [
     "jupyter_server>=1.6,<3",
     "pytest>=7.0",
     "pytest-asyncio",
-    "pytest-timeout>=2.1.0",
+    "pytest-timeout>=2.1.1",
     "jupyterlab",
     "pillow>=10.0.0"
 ]

--- a/tests/test_documented_features.py
+++ b/tests/test_documented_features.py
@@ -100,11 +100,24 @@ class TestTheTasksPage:
         assert re.search(rf"{MAX_TTL_MS // 3600000}\s+hours", page)
 
     def test_the_store_methods_it_tells_you_to_write_are_the_ones_called(self, page):
+        """Both directions, and that is the half that was missing.
+
+        A method on the page that the code does not call is a store somebody
+        wrote for nothing. A method the code *does* call and the page omits
+        is worse: the store gets written without it, and the first call is an
+        `AttributeError` from inside the server. Adding `find_by_key` for the
+        idempotency key is exactly how that happens — nothing about adding a
+        protocol method makes you re-read a documentation page.
+        """
         from jupyter_mcp_server.tasks import TaskStore
 
-        for method in ("create", "get", "list", "update"):
-            assert f"async def {method}(" in page
-            assert hasattr(TaskStore, method)
+        required = {
+            name
+            for name in dir(TaskStore)
+            if not name.startswith("_") and callable(getattr(TaskStore, name, None))
+        }
+        documented = set(re.findall(r"async def ([a-z_]+)\(", page))
+        assert documented == required
 
 
 class TestTheAuditPage:

--- a/tests/test_documented_features.py
+++ b/tests/test_documented_features.py
@@ -22,6 +22,7 @@ $ pytest tests/test_documented_features.py -v
 import asyncio
 import pathlib
 import re
+import typing
 
 import pytest
 
@@ -33,6 +34,69 @@ def _page(*parts: str) -> str:
     if not path.is_file():
         pytest.skip(f"{path} is not in this checkout")
     return path.read_text()
+
+
+class TestTheTasksPage:
+    @pytest.fixture(scope="class")
+    def page(self):
+        return _page("architecture", "tasks", "index.mdx")
+
+    def test_it_names_the_variable_the_server_reads(self, page):
+        """Whole-word, not a substring: a page naming a prefix of the real
+        variable passes a loose check while telling the reader to set
+        something nothing reads."""
+        from jupyter_mcp_server.tasks import TASK_STORE_CLASS_ENV
+
+        assert re.search(rf"\b{re.escape(TASK_STORE_CLASS_ENV)}\b", page)
+
+    def test_it_names_the_extension_identifier_the_server_advertises(self, page):
+        from jupyter_mcp_server.tasks import TASKS_EXTENSION
+
+        assert TASKS_EXTENSION in page
+
+    def test_it_documents_the_methods_the_server_actually_binds(self, page):
+        """Both ways. A method on the page that is not bound sends somebody to
+        a `METHOD_NOT_FOUND`; one bound but undocumented is a feature nobody
+        can find."""
+        from jupyter_mcp_server.tasks import TasksExtension
+
+        bound = {binding.method for binding in TasksExtension().methods()}
+        # From the methods table alone. The page also *names* `tasks/update`
+        # in order to say it does not exist, and reading that as a documented
+        # method would make the page contradict itself here.
+        documented = set(re.findall(r"^\| `(tasks/[a-z]+)` \|", page, re.MULTILINE))
+        assert documented == bound
+
+    def test_it_says_there_is_no_tasks_update_and_there_is_not(self, page):
+        """The page makes a negative claim, which is the kind most likely to
+        stop being true without anyone noticing."""
+        from jupyter_mcp_server.tasks import TasksExtension
+
+        assert "no `tasks/update`" in page
+        assert "tasks/update" not in {b.method for b in TasksExtension().methods()}
+
+    def test_the_statuses_it_lists_are_the_protocol_s(self, page):
+        import mcp.types as types
+
+        for status in typing.get_args(types.TaskStatus):
+            assert re.search(rf"`{status}`", page), status
+
+    def test_the_retention_numbers_are_the_ones_the_server_uses(self, page):
+        """A page that says fifteen minutes while the code says five sends
+        somebody looking for a bug in their client."""
+        from jupyter_mcp_server.tasks import DEFAULT_TTL_MS, MAX_TTL_MS
+
+        # Whitespace-tolerant: prose wraps, and reflowing a paragraph to
+        # satisfy a test is the test telling the page how to look.
+        assert re.search(rf"{DEFAULT_TTL_MS // 60000}\s+minutes", page)
+        assert re.search(rf"{MAX_TTL_MS // 3600000}\s+hours", page)
+
+    def test_the_store_methods_it_tells_you_to_write_are_the_ones_called(self, page):
+        from jupyter_mcp_server.tasks import TaskStore
+
+        for method in ("create", "get", "list", "update"):
+            assert f"async def {method}(" in page
+            assert hasattr(TaskStore, method)
 
 
 class TestTheAuditPage:

--- a/tests/test_documented_features.py
+++ b/tests/test_documented_features.py
@@ -99,6 +99,14 @@ class TestTheTasksPage:
         assert re.search(rf"{DEFAULT_TTL_MS // 60000}\s+minutes", page)
         assert re.search(rf"{MAX_TTL_MS // 3600000}\s+hours", page)
 
+    def test_the_interrupt_helper_it_shows_is_the_one_that_exists(self, page):
+        """A page showing a call that raises `ImportError` reads to whoever
+        typed it as their own mistake."""
+        from jupyter_mcp_server import tasks
+
+        assert "register_interrupt" in page
+        assert hasattr(tasks, "register_interrupt")
+
     def test_the_store_methods_it_tells_you_to_write_are_the_ones_called(self, page):
         """Both directions, and that is the half that was missing.
 

--- a/tests/test_documented_features.py
+++ b/tests/test_documented_features.py
@@ -75,6 +75,14 @@ class TestTheTasksPage:
         assert "no `tasks/update`" in page
         assert "tasks/update" not in {b.method for b in TasksExtension().methods()}
 
+    def test_it_names_the_meta_key_a_client_actually_sends(self, page):
+        """The key travels in an open `_meta` map, so nothing validates the
+        spelling. A page with the wrong one gives a client no error and no
+        deduplication — every retry a second ten-minute cell."""
+        from jupyter_mcp_server.tasks import IDEMPOTENCY_KEY_META
+
+        assert IDEMPOTENCY_KEY_META in page
+
     def test_the_statuses_it_lists_are_the_protocol_s(self, page):
         import mcp.types as types
 

--- a/tests/test_documented_features.py
+++ b/tests/test_documented_features.py
@@ -128,6 +128,40 @@ class TestTheTasksPage:
         assert documented == required
 
 
+class TestTheCachingPage:
+    @pytest.fixture(scope="class")
+    def page(self):
+        return _page("architecture", "caching", "index.mdx")
+
+    def test_it_names_the_meta_key_the_server_actually_writes(self, page):
+        from jupyter_mcp_server.results import CACHE_META_KEY
+
+        assert CACHE_META_KEY in page
+
+    def test_it_names_the_not_modified_field_a_client_reads(self, page):
+        """The page tells a client to look for this. A page and a server that
+        spell it differently give the client an answer it cannot recognise,
+        and it would refetch forever without an error anywhere."""
+        from jupyter_mcp_server.revalidation import NOT_MODIFIED_KEY
+
+        assert NOT_MODIFIED_KEY in page
+
+    def test_the_tools_it_says_carry_an_etag_do(self, page):
+        """Both directions: a tool named here that does not stamp one sends a
+        client revalidating against nothing, and one that stamps without
+        being documented is a saving nobody takes."""
+        import re as _re
+
+        from jupyter_mcp_server import server
+
+        source = pathlib.Path(server.__file__).read_text()
+        stamping = set(
+            _re.findall(r'@structured\(\s*"([a-z_.]+)".*?etag=True', source)
+        )
+        assert stamping == {"cell.read", "notebook.read"}
+        assert "`read_cell`" in page and "`read_notebook`" in page
+
+
 class TestTheAuditPage:
     @pytest.fixture(scope="class")
     def page(self):

--- a/tests/test_results.py
+++ b/tests/test_results.py
@@ -350,18 +350,60 @@ class TestCacheHints:
         assert results.CACHE_META_KEY == "io.modelcontextprotocol/cache"
         assert not results.CACHE_META_KEY.startswith(results.META_NAMESPACE)
 
-    def test_only_listings_are_hinted(self):
-        """Reading a cell, executing code and every edit answer something
-        that has just moved or is about to. Hinting those would hand an agent
-        a stale notebook and no way to tell."""
+    def _hinted(self):
+        """Every tool carrying a cache hint, and whether it also carries an
+        ETag. Read off the source, because a decorator's arguments are not
+        recoverable from the wrapped function."""
         import pathlib
         import re
 
         import jupyter_mcp_server.server as server_module
 
         source = pathlib.Path(server_module.__file__).read_text()
-        hinted = set(re.findall(r'@structured\("([\w.]+)"[^)]*ttl_ms=', source))
-        assert hinted == {"files.list", "kernels.list", "notebooks.list"}, hinted
+        found = {}
+        for kind, arguments in re.findall(
+            r'@structured\("([\w.]+)"([^)]*)\)', source
+        ):
+            if "ttl_ms=" in arguments:
+                found[kind] = "etag=True" in arguments
+        return found
+
+    def test_a_hint_needs_a_listing_or_an_etag(self):
+        """The rule was "only listings are hinted", and its reason was that
+        hinting a read hands an agent a stale notebook *and no way to tell*.
+
+        The ETag is the way to tell: the client sends back the version it
+        holds and is told whether it is still current. So a read may be
+        hinted once it carries one — and a hint without either is still the
+        thing to refuse, because that is the case the original rule was
+        about.
+        """
+        for kind, has_etag in self._hinted().items():
+            assert kind.endswith(".list") or has_etag, (
+                f"{kind} carries a cache hint but is neither a listing nor "
+                f"revalidatable; a client would hold a stale answer with no "
+                f"way to tell"
+            )
+
+    def test_nothing_that_changes_a_notebook_is_hinted(self):
+        """An edit, an execution or a deletion answers something that has
+        just moved. No ETag makes that cacheable — the next call would be
+        told "unchanged" about a notebook the caller itself changed."""
+        moving = {"insert", "overwrite", "edit", "execute", "delete", "clear", "move"}
+        for kind in self._hinted():
+            verb = kind.rsplit(".", 1)[-1]
+            assert not any(word in verb for word in moving), kind
+
+    def test_the_hinted_set_is_the_one_intended(self):
+        """Named, so adding a hint is a decision somebody makes here rather
+        than a line that slips in beside a tool."""
+        assert set(self._hinted()) == {
+            "files.list",
+            "kernels.list",
+            "notebooks.list",
+            "cell.read",
+            "notebook.read",
+        }
 
 
 class TestATooThatAlreadyReturnsData:

--- a/tests/test_revalidation.py
+++ b/tests/test_revalidation.py
@@ -1,0 +1,160 @@
+# Copyright (c) 2023-2026 Datalayer, Inc.
+# BSD 3-Clause License
+
+"""Telling a client that what it holds is still current.
+
+The failure to avoid is the one where *not modified* and *nothing* look the
+same. A client that read an empty result as an empty notebook would show
+somebody no cells at all, so the answer says so in a named field rather than
+by being empty.
+
+Launch the tests:
+```
+$ pytest tests/test_revalidation.py -v
+```
+"""
+
+from __future__ import annotations
+
+import pytest
+from mcp.types import CallToolRequestParams, CallToolResult, TextContent
+
+from jupyter_mcp_server.results import CACHE_META_KEY, answer, etag_for
+from jupyter_mcp_server.revalidation import (
+    NOT_MODIFIED_KEY,
+    REVALIDATION_EXTENSION,
+    RevalidationExtension,
+    answered_etag,
+    requested_etag,
+)
+
+
+def holding(etag: str = "", name: str = "read_notebook") -> CallToolRequestParams:
+    meta = {CACHE_META_KEY: {"etag": etag}} if etag else None
+    return CallToolRequestParams(name=name, arguments={}, _meta=meta)
+
+
+def read(value: dict, **overrides) -> CallToolResult:
+    fields = {"kind": "notebook.read", "ttl_ms": 5000, "etag": True}
+    fields.update(overrides)
+    return answer(value, **fields)
+
+
+@pytest.fixture
+def extension() -> RevalidationExtension:
+    return RevalidationExtension()
+
+
+async def served(extension, params, result):
+    async def call_next(ctx):
+        return result
+
+    return await extension.intercept_tool_call(params, object(), call_next)
+
+
+class TestReadingTheVersions:
+    def test_a_client_that_holds_nothing_says_nothing(self):
+        assert requested_etag(holding()) == ""
+
+    def test_a_tool_that_stamps_nothing_answers_nothing(self):
+        assert answered_etag(answer("hi", kind="cell.read")) == ""
+
+    def test_a_read_carries_a_version(self):
+        assert answered_etag(read({"cells": [1]})).startswith('W/"')
+
+    def test_the_same_answer_has_the_same_version(self):
+        assert answered_etag(read({"cells": [1]})) == answered_etag(read({"cells": [1]}))
+
+    def test_a_changed_answer_has_a_different_one(self):
+        assert answered_etag(read({"cells": [1]})) != answered_etag(read({"cells": [2]}))
+
+    def test_the_version_is_weak(self):
+        """It says *this means the same thing*, not *this is byte-for-byte
+        what you had* — the answer is assembled per call."""
+        assert etag_for({"a": 1}).startswith('W/"')
+
+
+@pytest.mark.asyncio
+class TestRevalidating:
+    async def test_a_matching_version_answers_not_modified(self, extension):
+        result = read({"cells": [1, 2]})
+        served_back = await served(extension, holding(answered_etag(result)), result)
+        block = served_back.meta[CACHE_META_KEY]
+        assert block[NOT_MODIFIED_KEY] is True
+        assert served_back.content == []
+        assert served_back.structured_content is None
+
+    async def test_not_modified_says_so_rather_than_being_empty(self, extension):
+        """A client that read an empty result as an empty notebook would show
+        somebody no cells at all."""
+        result = read({"cells": [1, 2]})
+        served_back = await served(extension, holding(answered_etag(result)), result)
+        assert NOT_MODIFIED_KEY in served_back.meta[CACHE_META_KEY]
+
+    async def test_not_modified_carries_the_hints_again(self, extension):
+        """So holding it for another window costs nothing."""
+        result = read({"cells": [1]})
+        etag = answered_etag(result)
+        block = (await served(extension, holding(etag), result)).meta[CACHE_META_KEY]
+        assert block["ttlMs"] == 5000 and block["etag"] == etag
+        assert block["cacheScope"] == "private"
+
+    async def test_a_different_version_answers_the_whole_thing(self, extension):
+        result = read({"cells": [1, 2]})
+        served_back = await served(extension, holding('W/"something-else"'), result)
+        assert served_back is result
+
+    async def test_a_client_holding_nothing_gets_the_whole_thing(self, extension):
+        result = read({"cells": [1, 2]})
+        assert await served(extension, holding(), result) is result
+
+    async def test_an_unstamped_tool_and_an_empty_client_do_not_match(self, extension):
+        """Both are the empty string, and comparing them equal would answer
+        "unchanged" on a first call about something the client has never
+        seen. The most likely way to get this wrong, and invisible from
+        either side alone."""
+        result = answer({"cells": [1]}, kind="cell.read")
+        assert await served(extension, holding(), result) is result
+
+    async def test_a_tool_that_stamps_no_version_is_never_revalidated(self, extension):
+        """Answering "unchanged" about something nobody is tracking is worse
+        than answering it again."""
+        result = answer({"cells": [1]}, kind="cell.read")
+        assert await served(extension, holding('W/"anything"'), result) is result
+
+    async def test_an_error_is_never_turned_into_not_modified(self, extension):
+        """A client that treated a refusal as its cached answer being current
+        would go on using a result the server has just declined to confirm."""
+        result = read({"cells": [1]})
+        etag = answered_etag(result)
+        failed = CallToolResult(
+            content=[TextContent(type="text", text="no")],
+            is_error=True,
+            meta=result.meta,
+        )
+        assert await served(extension, holding(etag), failed) is failed
+
+    async def test_the_tool_still_runs(self, extension):
+        """This saves bandwidth, not work: the version comes from what the
+        tool answered, so there is no way to know it is unchanged without
+        producing it. Stating it in a test so nobody optimises on a promise
+        this does not make."""
+        ran = []
+
+        async def call_next(ctx):
+            ran.append(1)
+            return read({"cells": [1]})
+
+        result = read({"cells": [1]})
+        await extension.intercept_tool_call(
+            holding(answered_etag(result)), object(), call_next
+        )
+        assert ran == [1]
+
+
+def test_the_extension_identifier_is_one_constant():
+    assert RevalidationExtension.identifier == REVALIDATION_EXTENSION
+
+
+def test_the_settings_name_the_field_a_client_reads():
+    assert RevalidationExtension().settings()["notModifiedKey"] == NOT_MODIFIED_KEY

--- a/tests/test_revalidation.py
+++ b/tests/test_revalidation.py
@@ -1,3 +1,7 @@
+# Copyright (c) 2024- Datalayer, Inc.
+#
+# BSD 3-Clause License
+
 # Copyright (c) 2023-2026 Datalayer, Inc.
 # BSD 3-Clause License
 

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -1,3 +1,7 @@
+# Copyright (c) 2024- Datalayer, Inc.
+#
+# BSD 3-Clause License
+
 # Copyright (c) 2023-2026 Datalayer, Inc.
 # BSD 3-Clause License
 

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -25,6 +25,7 @@ from mcp.types import CallToolRequestParams, CreateTaskResult, TaskMetadata
 
 from jupyter_mcp_server.tasks import (
     DEFAULT_TTL_MS,
+    IDEMPOTENCY_KEY_META,
     TASK_STATUS_NOTIFICATION,
     MAX_TTL_MS,
     POLL_INTERVAL_MS,
@@ -308,6 +309,181 @@ async def test_work_cancelled_from_outside_still_ends_the_task(extension, store)
 async def test_cancelling_a_task_that_does_not_exist_says_so(extension):
     with pytest.raises(MCPError):
         await extension._handle_cancel(_Params("tsk_never"), object())
+
+
+# ---------------------------------------------------------------------------
+# A retry is one task
+# ---------------------------------------------------------------------------
+
+
+def keyed(key: str, name: str = "execute_cell", **arguments) -> CallToolRequestParams:
+    return CallToolRequestParams(
+        name=name,
+        arguments=arguments or {},
+        task=TaskMetadata(),
+        _meta={IDEMPOTENCY_KEY_META: key},
+    )
+
+
+@pytest.mark.asyncio
+async def test_a_retry_under_the_same_key_answers_the_same_task(extension, store):
+    """The case this exists for is the one hardest to notice: the connection
+    dropped after the request arrived and before the answer got back. Without
+    this the client retries and gets two ten-minute cells, and pays for both.
+    """
+    ran = []
+
+    async def call_next(ctx):
+        ran.append(1)
+        await asyncio.Event().wait()
+
+    first = await extension.intercept_tool_call(keyed("k1"), object(), call_next)
+    await settle()
+    again = await extension.intercept_tool_call(keyed("k1"), object(), call_next)
+
+    assert again.task.task_id == first.task.task_id
+    assert ran == [1], "the work started a second time"
+    assert len(await store.list()) == 1
+
+
+@pytest.mark.asyncio
+async def test_the_same_call_written_differently_is_still_the_same_call(extension):
+    """Otherwise every retry that serialised its arguments in another order
+    would be refused as a conflict."""
+
+    async def call_next(ctx):
+        await asyncio.Event().wait()
+
+    first = await extension.intercept_tool_call(
+        keyed("k1", a=1, b=2), object(), call_next
+    )
+    again = await extension.intercept_tool_call(
+        CallToolRequestParams(
+            name="execute_cell",
+            arguments={"b": 2, "a": 1},
+            task=TaskMetadata(),
+            _meta={IDEMPOTENCY_KEY_META: "k1"},
+        ),
+        object(),
+        call_next,
+    )
+    assert again.task.task_id == first.task.task_id
+
+
+@pytest.mark.asyncio
+async def test_the_same_key_on_a_different_call_is_a_conflict(extension):
+    """Answering the first task would hand the client the result of work it
+    did not ask for, under an id it believes it just created."""
+
+    async def call_next(ctx):
+        await asyncio.Event().wait()
+
+    await extension.intercept_tool_call(keyed("k1", cell_index=1), object(), call_next)
+    with pytest.raises(MCPError) as refused:
+        await extension.intercept_tool_call(keyed("k1", cell_index=2), object(), call_next)
+    assert "already used" in str(refused.value)
+
+
+@pytest.mark.asyncio
+async def test_a_different_tool_under_the_same_key_is_a_conflict(extension):
+    async def call_next(ctx):
+        await asyncio.Event().wait()
+
+    await extension.intercept_tool_call(keyed("k1"), object(), call_next)
+    with pytest.raises(MCPError):
+        await extension.intercept_tool_call(keyed("k1", name="delete_cell"), object(), call_next)
+
+
+@pytest.mark.asyncio
+async def test_different_keys_are_different_tasks(extension, store):
+    ran = []
+
+    async def call_next(ctx):
+        ran.append(1)
+        await asyncio.Event().wait()
+
+    first = await extension.intercept_tool_call(keyed("k1"), object(), call_next)
+    second = await extension.intercept_tool_call(keyed("k2"), object(), call_next)
+    await settle()
+    assert first.task.task_id != second.task.task_id
+    assert len(ran) == 2
+
+
+@pytest.mark.asyncio
+async def test_no_key_means_every_call_is_its_own_task(extension):
+    """A client that names nothing gets what it asked for, twice."""
+    ran = []
+
+    async def call_next(ctx):
+        ran.append(1)
+        await asyncio.Event().wait()
+
+    first = await extension.intercept_tool_call(call(task=TaskMetadata()), object(), call_next)
+    second = await extension.intercept_tool_call(call(task=TaskMetadata()), object(), call_next)
+    await settle()
+    assert first.task.task_id != second.task.task_id
+    assert len(ran) == 2
+
+
+@pytest.mark.asyncio
+async def test_a_retry_after_the_task_finished_still_answers_it(extension):
+    """Within retention, a replay reads the result rather than re-running the
+    work — which is the whole value of the key surviving the call."""
+
+    async def call_next(ctx):
+        return {"content": "done"}
+
+    first = await extension.intercept_tool_call(keyed("k1"), object(), call_next)
+    await settle()
+    again = await extension.intercept_tool_call(keyed("k1"), object(), call_next)
+    assert again.task.task_id == first.task.task_id
+    assert again.task.status == "completed"
+
+
+@pytest.mark.asyncio
+async def test_an_expired_task_frees_its_key(extension, store):
+    """The alternative hands the client a task whose result has been swept
+    and can never be read."""
+    ran = []
+
+    async def call_next(ctx):
+        ran.append(1)
+        return {"content": "done"}
+
+    first = await extension.intercept_tool_call(keyed("k1"), object(), call_next)
+    await settle()
+    record = await store.get(first.task.task_id)
+    record.ttl = 1
+    record.started_monotonic -= 10
+
+    again = await extension.intercept_tool_call(keyed("k1"), object(), call_next)
+    await settle()
+    assert again.task.task_id != first.task.task_id
+    assert len(ran) == 2
+
+
+@pytest.mark.asyncio
+async def test_a_call_without_a_task_is_not_deduplicated(extension, store):
+    """The key only names a task. A synchronous call carrying one is still a
+    synchronous call, and silently answering an old task's id instead of the
+    tool's output would be the worst of both.
+    """
+    ran = []
+
+    async def call_next(ctx):
+        ran.append(1)
+        return {"content": "done"}
+
+    params = CallToolRequestParams(
+        name="execute_cell", arguments={}, _meta={IDEMPOTENCY_KEY_META: "k1"}
+    )
+    assert await extension.intercept_tool_call(params, object(), call_next) == {
+        "content": "done"
+    }
+    assert await extension.intercept_tool_call(params, object(), call_next) == {
+        "content": "done"
+    }
+    assert len(ran) == 2 and await store.list() == []
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -207,6 +207,40 @@ async def test_an_expired_task_is_gone_rather_than_a_record_with_no_result(store
 
 
 @pytest.mark.asyncio
+async def test_listing_sweeps_expired_tasks_without_being_asked_for_one_first(store):
+    """`list` has to do its own sweeping, and the test above never made it.
+
+    That test calls `get` first, which deletes the expired record itself — so
+    by the time `list` ran there was nothing left to sweep and the sweep was
+    never executed. It walked the dictionary while popping from it, which
+    raises `RuntimeError: dictionary changed size during iteration` on the
+    first expired task, and `tasks/list` failed outright rather than
+    degrading. Found in review, not here.
+    """
+    for index in range(3):
+        record = TaskRecord(task_id=f"tsk_old_{index}", status="completed", ttl=1)
+        record.started_monotonic -= 10
+        await store.create(record)
+    await store.create(TaskRecord(task_id="tsk_live", status="working"))
+
+    listed = await store.list()
+
+    assert [item.task_id for item in listed] == ["tsk_live"]
+    # And they are really gone, not merely left out of the answer.
+    assert await store.get("tsk_old_0") is None
+
+
+@pytest.mark.asyncio
+async def test_listing_only_expired_tasks_answers_nothing_rather_than_raising(store):
+    """The narrowest case, and the one the old code failed on first: every
+    task expired, so the very first iteration pops."""
+    record = TaskRecord(task_id="tsk_1", status="completed", ttl=1)
+    record.started_monotonic -= 10
+    await store.create(record)
+    assert await store.list() == []
+
+
+@pytest.mark.asyncio
 async def test_a_task_still_running_does_not_expire(store):
     """Retention that killed work in flight would be a timeout wearing
     retention's name, and the two are set by different people."""

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -1,0 +1,400 @@
+# Copyright (c) 2023-2026 Datalayer, Inc.
+# BSD 3-Clause License
+
+"""Tasks: a call whose answer outlives the request that asked for it.
+
+Three failures these tests are about, and all three are quiet ones. A
+synchronous call turned into a task behind a client's back, which the client
+reads as the tool's output. A tool that raised reported as a task that
+completed with nothing, which the client reads as "it produced nothing". And
+an expired task answered as an empty result rather than as gone.
+
+Launch the tests:
+```
+$ pytest tests/test_tasks.py -v
+```
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+from mcp.shared.exceptions import MCPError
+from mcp.types import CallToolRequestParams, CreateTaskResult, TaskMetadata
+
+from jupyter_mcp_server.tasks import (
+    DEFAULT_TTL_MS,
+    MAX_TTL_MS,
+    POLL_INTERVAL_MS,
+    TASK_STORE_CLASS_ENV,
+    TASKS_EXTENSION,
+    MemoryTaskStore,
+    TaskRecord,
+    TasksExtension,
+    _build_store,
+    get_task_store,
+    requested_ttl,
+    use_task_store,
+)
+
+
+@pytest.fixture
+def store() -> MemoryTaskStore:
+    replacement = MemoryTaskStore()
+    use_task_store(replacement)
+    yield replacement
+    use_task_store(None)
+
+
+@pytest.fixture
+def extension(store: MemoryTaskStore) -> TasksExtension:
+    return TasksExtension(store)
+
+
+def call(name: str = "execute_cell", *, task: TaskMetadata | None = None) -> CallToolRequestParams:
+    return CallToolRequestParams(name=name, arguments={}, task=task)
+
+
+async def settle() -> None:
+    """Let the detached task run to its end."""
+    for _ in range(200):
+        await asyncio.sleep(0)
+
+
+class _Params:
+    def __init__(self, task_id: str) -> None:
+        self.task_id = task_id
+
+
+# ---------------------------------------------------------------------------
+# A task is created only when the client asks for one
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_a_call_without_task_metadata_stays_synchronous(extension, store):
+    """The property everything else rests on.
+
+    A client that does not know what a task id is would read
+    `CreateTaskResult` as the tool's output.
+    """
+    ran = []
+
+    async def call_next(ctx):
+        ran.append(1)
+        return {"content": "done"}
+
+    answer = await extension.intercept_tool_call(call(), object(), call_next)
+    assert answer == {"content": "done"}
+    assert ran == [1]
+    assert await store.list() == []
+
+
+@pytest.mark.asyncio
+async def test_a_call_that_asks_for_a_task_gets_a_task_id_at_once(extension, store):
+    started = asyncio.Event()
+    release = asyncio.Event()
+
+    async def call_next(ctx):
+        started.set()
+        await release.wait()
+        return {"content": "done"}
+
+    answer = await extension.intercept_tool_call(call(task=TaskMetadata()), object(), call_next)
+    assert isinstance(answer, CreateTaskResult)
+    assert answer.task.status == "working"
+    assert answer.task.task_id.startswith("tsk_")
+    # The work is under way rather than waited for.
+    await settle()
+    assert started.is_set()
+    release.set()
+    await settle()
+    assert (await store.get(answer.task.task_id)).status == "completed"
+
+
+@pytest.mark.asyncio
+async def test_a_working_task_suggests_how_often_to_ask(extension):
+    async def call_next(ctx):
+        await asyncio.Event().wait()
+
+    answer = await extension.intercept_tool_call(call(task=TaskMetadata()), object(), call_next)
+    assert answer.task.poll_interval == POLL_INTERVAL_MS
+    answer.task.status = "completed"
+
+
+# ---------------------------------------------------------------------------
+# A failure is a failed task, not an empty one
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_a_tool_that_raised_ends_failed_carrying_the_error(extension, store):
+    """`completed` with no output is the worst outcome available: the client
+    believes the work succeeded and produced nothing."""
+
+    async def call_next(ctx):
+        raise ValueError("the kernel is dead")
+
+    answer = await extension.intercept_tool_call(call(task=TaskMetadata()), object(), call_next)
+    await settle()
+    record = await store.get(answer.task.task_id)
+    assert record.status == "failed"
+    assert "the kernel is dead" in record.error
+    assert record.result is None
+
+
+@pytest.mark.asyncio
+async def test_asking_for_the_result_of_a_failed_task_is_an_error_not_a_blank(
+    extension, store
+):
+    async def call_next(ctx):
+        raise ValueError("the kernel is dead")
+
+    answer = await extension.intercept_tool_call(call(task=TaskMetadata()), object(), call_next)
+    await settle()
+    with pytest.raises(MCPError) as refused:
+        await extension._handle_result(_Params(answer.task.task_id), object())
+    assert "the kernel is dead" in str(refused.value)
+
+
+@pytest.mark.asyncio
+async def test_asking_for_the_result_of_a_running_task_is_refused(extension):
+    """A client given `{}` here would show a user "no output" for work that is
+    still running."""
+
+    async def call_next(ctx):
+        await asyncio.Event().wait()
+
+    answer = await extension.intercept_tool_call(call(task=TaskMetadata()), object(), call_next)
+    with pytest.raises(MCPError) as refused:
+        await extension._handle_result(_Params(answer.task.task_id), object())
+    assert "working" in str(refused.value)
+
+
+@pytest.mark.asyncio
+async def test_the_result_of_a_completed_task_is_what_the_tool_returned(extension):
+    async def call_next(ctx):
+        return {"content": [{"type": "text", "text": "42"}]}
+
+    answer = await extension.intercept_tool_call(call(task=TaskMetadata()), object(), call_next)
+    await settle()
+    assert await extension._handle_result(_Params(answer.task.task_id), object()) == {
+        "content": [{"type": "text", "text": "42"}]
+    }
+
+
+# ---------------------------------------------------------------------------
+# A task nobody can see is gone, not empty
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_an_expired_task_is_gone_rather_than_a_record_with_no_result(store):
+    record = TaskRecord(task_id="tsk_1", status="completed", ttl=1, result={"x": 1})
+    record.started_monotonic -= 10  # ten seconds ago, ttl of one millisecond
+    await store.create(record)
+    assert await store.get("tsk_1") is None
+    assert await store.list() == []
+
+
+@pytest.mark.asyncio
+async def test_a_task_still_running_does_not_expire(store):
+    """Retention that killed work in flight would be a timeout wearing
+    retention's name, and the two are set by different people."""
+    record = TaskRecord(task_id="tsk_1", status="working", ttl=1)
+    record.started_monotonic -= 10
+    await store.create(record)
+    assert (await store.get("tsk_1")) is not None
+
+
+@pytest.mark.asyncio
+async def test_a_task_that_never_existed_and_one_that_expired_answer_the_same(
+    extension, store
+):
+    """Distinguishing them tells a caller that an id they made up happens to
+    have existed."""
+    gone = TaskRecord(task_id="tsk_gone", status="completed", ttl=1)
+    gone.started_monotonic -= 10
+    await store.create(gone)
+
+    messages = []
+    for task_id in ("tsk_gone", "tsk_never"):
+        with pytest.raises(MCPError) as refused:
+            await extension._handle_get(_Params(task_id), object())
+        messages.append(str(refused.value).replace(task_id, "<id>"))
+    assert messages[0] == messages[1]
+
+
+# ---------------------------------------------------------------------------
+# Cancelling
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_cancelling_stops_the_work_and_records_why(extension, store):
+    started = asyncio.Event()
+
+    async def call_next(ctx):
+        started.set()
+        await asyncio.Event().wait()
+
+    answer = await extension.intercept_tool_call(call(task=TaskMetadata()), object(), call_next)
+    await settle()
+    assert started.is_set()
+
+    cancelled = await extension._handle_cancel(_Params(answer.task.task_id), object())
+    assert cancelled.status == "cancelled"
+    await settle()
+    # The work really stopped rather than the record merely saying so.
+    record = await store.get(answer.task.task_id)
+    assert record.handle.cancelled() or record.handle.done()
+
+
+@pytest.mark.asyncio
+async def test_cancelling_a_finished_task_answers_it_as_it_is(extension, store):
+    """A race the client lost, not an error. Refusing teaches it to retry."""
+
+    async def call_next(ctx):
+        return {"content": "done"}
+
+    answer = await extension.intercept_tool_call(call(task=TaskMetadata()), object(), call_next)
+    await settle()
+    cancelled = await extension._handle_cancel(_Params(answer.task.task_id), object())
+    assert cancelled.status == "completed"
+
+
+@pytest.mark.asyncio
+async def test_a_cancelled_task_is_not_then_reported_as_failed(extension, store):
+    """"You cancelled this" and "this broke" are different things to show."""
+    started = asyncio.Event()
+
+    async def call_next(ctx):
+        started.set()
+        await asyncio.Event().wait()
+
+    answer = await extension.intercept_tool_call(call(task=TaskMetadata()), object(), call_next)
+    await settle()
+    await extension._handle_cancel(_Params(answer.task.task_id), object())
+    await settle()
+    assert (await store.get(answer.task.task_id)).status == "cancelled"
+
+
+@pytest.mark.asyncio
+async def test_work_cancelled_from_outside_still_ends_the_task(extension, store):
+    """A shutdown cancels every pending task on the loop.
+
+    `tasks/cancel` writes the status before the cancellation lands, so the
+    handler in `_run` looks like dead code — until the loop itself does the
+    cancelling, and then it is the only thing that stops a task saying
+    `working` for its whole retention while nothing is running.
+    """
+    started = asyncio.Event()
+
+    async def call_next(ctx):
+        started.set()
+        await asyncio.Event().wait()
+
+    answer = await extension.intercept_tool_call(call(task=TaskMetadata()), object(), call_next)
+    await settle()
+    record = await store.get(answer.task.task_id)
+    record.handle.cancel()  # as a shutdown would, with nobody writing a status
+    await settle()
+    assert (await store.get(answer.task.task_id)).status == "cancelled"
+
+
+@pytest.mark.asyncio
+async def test_cancelling_a_task_that_does_not_exist_says_so(extension):
+    with pytest.raises(MCPError):
+        await extension._handle_cancel(_Params("tsk_never"), object())
+
+
+# ---------------------------------------------------------------------------
+# Retention
+# ---------------------------------------------------------------------------
+
+
+def test_a_client_that_says_nothing_gets_the_default_not_forever():
+    assert requested_ttl(TaskMetadata()) == DEFAULT_TTL_MS
+    assert requested_ttl(None) == DEFAULT_TTL_MS
+
+
+def test_a_clients_retention_is_capped():
+    """One client's forever must not become everybody's memory."""
+    assert requested_ttl(TaskMetadata(ttl=MAX_TTL_MS * 100)) == MAX_TTL_MS
+
+
+def test_a_nonsense_retention_falls_back_rather_than_crashing():
+    assert requested_ttl(TaskMetadata(ttl=0)) == DEFAULT_TTL_MS
+    assert requested_ttl(TaskMetadata(ttl=-5)) == DEFAULT_TTL_MS
+
+
+def test_a_reasonable_retention_is_honoured():
+    assert requested_ttl(TaskMetadata(ttl=60_000)) == 60_000
+
+
+# ---------------------------------------------------------------------------
+# The store choice
+# ---------------------------------------------------------------------------
+
+
+def test_no_setting_means_tasks_in_this_process():
+    assert isinstance(_build_store(""), MemoryTaskStore)
+
+
+def test_a_store_that_cannot_be_imported_is_fatal_rather_than_a_fallback():
+    """A deployment that asked for durable tasks and silently got in-process
+    ones looks healthy right up to the restart that loses them."""
+    with pytest.raises(ModuleNotFoundError):
+        _build_store("nowhere.at.all:Store")
+
+
+def test_a_malformed_store_setting_names_the_shape_it_wanted():
+    with pytest.raises(ValueError) as refused:
+        _build_store("just_a_module")
+    assert TASK_STORE_CLASS_ENV in str(refused.value)
+
+
+def test_the_store_is_built_once(store):
+    assert get_task_store() is get_task_store()
+
+
+# ---------------------------------------------------------------------------
+# The extension itself
+# ---------------------------------------------------------------------------
+
+
+def test_the_extension_identifier_is_one_constant():
+    """So tasks entering the core protocol is a rename."""
+    assert TasksExtension.identifier == TASKS_EXTENSION
+
+
+def test_the_bound_methods_are_the_four_the_protocol_defines():
+    bound = {binding.method for binding in TasksExtension().methods()}
+    assert bound == {"tasks/get", "tasks/list", "tasks/cancel", "tasks/result"}
+
+
+def test_the_settings_tell_a_client_the_retention_and_the_poll_interval():
+    settings = TasksExtension().settings()
+    assert settings["defaultTtlMs"] == DEFAULT_TTL_MS
+    assert settings["maxTtlMs"] == MAX_TTL_MS
+    assert settings["pollIntervalMs"] == POLL_INTERVAL_MS
+
+
+@pytest.mark.asyncio
+async def test_a_task_record_never_shows_the_result_or_the_handle(store):
+    record = TaskRecord(task_id="tsk_1", status="completed", result={"secret": 1})
+    record.handle = object()
+    public = record.public().model_dump()
+    assert "result" not in public and "handle" not in public
+    assert public["task_id"] == "tsk_1"
+
+
+@pytest.mark.asyncio
+async def test_listing_answers_newest_first(store, extension):
+    for index in range(3):
+        await store.create(
+            TaskRecord(task_id=f"tsk_{index}", created_at=f"2026-08-2{index}T00:00:00Z")
+        )
+    listed = await extension._handle_list(None, object())
+    assert [task.task_id for task in listed.tasks] == ["tsk_2", "tsk_1", "tsk_0"]

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -25,6 +25,7 @@ from mcp.types import CallToolRequestParams, CreateTaskResult, TaskMetadata
 
 from jupyter_mcp_server.tasks import (
     DEFAULT_TTL_MS,
+    TASK_STATUS_NOTIFICATION,
     MAX_TTL_MS,
     POLL_INTERVAL_MS,
     TASK_STORE_CLASS_ENV,
@@ -307,6 +308,114 @@ async def test_work_cancelled_from_outside_still_ends_the_task(extension, store)
 async def test_cancelling_a_task_that_does_not_exist_says_so(extension):
     with pytest.raises(MCPError):
         await extension._handle_cancel(_Params("tsk_never"), object())
+
+
+# ---------------------------------------------------------------------------
+# Telling the client
+# ---------------------------------------------------------------------------
+
+
+class _Session:
+    """A session that records what it was asked to send."""
+
+    def __init__(self, *, explode: bool = False) -> None:
+        self.sent: list = []
+        self.explode = explode
+
+    async def send_notification(self, notification):
+        if self.explode:
+            raise RuntimeError("the connection is gone")
+        self.sent.append(notification)
+
+
+class _Ctx:
+    def __init__(self, session=None) -> None:
+        self.session = session
+
+
+@pytest.mark.asyncio
+async def test_a_finished_task_is_announced(extension):
+    session = _Session()
+
+    async def call_next(ctx):
+        return {"content": "done"}
+
+    answer = await extension.intercept_tool_call(
+        call(task=TaskMetadata()), _Ctx(session), call_next
+    )
+    await settle()
+    assert [n.method for n in session.sent] == [TASK_STATUS_NOTIFICATION]
+    assert session.sent[0].params.task_id == answer.task.task_id
+    assert session.sent[0].params.status == "completed"
+
+
+@pytest.mark.asyncio
+async def test_a_failed_task_is_announced_as_failed(extension):
+    session = _Session()
+
+    async def call_next(ctx):
+        raise ValueError("the kernel is dead")
+
+    await extension.intercept_tool_call(call(task=TaskMetadata()), _Ctx(session), call_next)
+    await settle()
+    assert session.sent[0].params.status == "failed"
+
+
+@pytest.mark.asyncio
+async def test_a_cancelled_task_is_announced(extension, store):
+    session = _Session()
+
+    async def call_next(ctx):
+        await asyncio.Event().wait()
+
+    answer = await extension.intercept_tool_call(
+        call(task=TaskMetadata()), _Ctx(session), call_next
+    )
+    await settle()
+    await extension._handle_cancel(_Params(answer.task.task_id), _Ctx(session))
+    await settle()
+    assert any(n.params.status == "cancelled" for n in session.sent)
+
+
+@pytest.mark.asyncio
+async def test_a_notification_that_cannot_be_sent_does_not_fail_the_task(extension, store):
+    """The protocol makes polling the way a client learns a task's state —
+    that is what `poll_interval` is for. Failing the work because the news
+    about the work would not go out would be trading one for the other."""
+    session = _Session(explode=True)
+
+    async def call_next(ctx):
+        return {"content": "done"}
+
+    answer = await extension.intercept_tool_call(
+        call(task=TaskMetadata()), _Ctx(session), call_next
+    )
+    await settle()
+    assert (await store.get(answer.task.task_id)).status == "completed"
+
+
+@pytest.mark.asyncio
+async def test_no_session_is_not_an_error(extension, store):
+    async def call_next(ctx):
+        return {"content": "done"}
+
+    answer = await extension.intercept_tool_call(call(task=TaskMetadata()), object(), call_next)
+    await settle()
+    assert (await store.get(answer.task.task_id)).status == "completed"
+
+
+@pytest.mark.asyncio
+async def test_the_announcement_carries_no_result(extension):
+    """It is a status notification, and a result can be a megabyte of output
+    that the client may not even want."""
+    session = _Session()
+
+    async def call_next(ctx):
+        return {"content": [{"type": "text", "text": "x" * 1000}]}
+
+    await extension.intercept_tool_call(call(task=TaskMetadata()), _Ctx(session), call_next)
+    await settle()
+    assert "result" not in session.sent[0].params.model_dump()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -25,6 +25,8 @@ from mcp.types import CallToolRequestParams, CreateTaskResult, TaskMetadata
 
 from jupyter_mcp_server.tasks import (
     DEFAULT_TTL_MS,
+    current_task,
+    register_interrupt,
     IDEMPOTENCY_KEY_META,
     TASK_STATUS_NOTIFICATION,
     MAX_TTL_MS,
@@ -592,6 +594,115 @@ async def test_the_announcement_carries_no_result(extension):
     await extension.intercept_tool_call(call(task=TaskMetadata()), _Ctx(session), call_next)
     await settle()
     assert "result" not in session.sent[0].params.model_dump()
+
+
+# ---------------------------------------------------------------------------
+# Cancelling stops the work, not just the wait for it
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_cancelling_interrupts_the_work_before_it_stops_waiting(extension, store):
+    """The distinction this exists for.
+
+    Cancelling the handle cancels the coroutine *waiting* for a cell. The
+    kernel keeps running it, keeps holding the sandbox and keeps costing
+    money, while the task says `cancelled` and everybody believes it stopped.
+    """
+    interrupted = []
+
+    async def call_next(ctx):
+        await register_interrupt(lambda: interrupted.append(1))
+        await asyncio.Event().wait()
+
+    answer = await extension.intercept_tool_call(call(task=TaskMetadata()), object(), call_next)
+    await settle()
+    await extension._handle_cancel(_Params(answer.task.task_id), object())
+    assert interrupted == [1]
+
+
+@pytest.mark.asyncio
+async def test_an_interrupt_that_fails_does_not_stop_the_cancellation(extension, store):
+    """Half of what the client asked for is better than none of it — and the
+    log says a kernel is still running so somebody can go and look."""
+
+    async def call_next(ctx):
+        await register_interrupt(_explode)
+        await asyncio.Event().wait()
+
+    answer = await extension.intercept_tool_call(call(task=TaskMetadata()), object(), call_next)
+    await settle()
+    cancelled = await extension._handle_cancel(_Params(answer.task.task_id), object())
+    assert cancelled.status == "cancelled"
+
+
+def _explode():
+    raise RuntimeError("the kernel is not answering")
+
+
+@pytest.mark.asyncio
+async def test_an_async_interrupt_is_awaited(extension):
+    interrupted = []
+
+    async def stop():
+        interrupted.append(1)
+
+    async def call_next(ctx):
+        await register_interrupt(stop)
+        await asyncio.Event().wait()
+
+    answer = await extension.intercept_tool_call(call(task=TaskMetadata()), object(), call_next)
+    await settle()
+    await extension._handle_cancel(_Params(answer.task.task_id), object())
+    assert interrupted == [1]
+
+
+@pytest.mark.asyncio
+async def test_a_task_with_no_interrupt_still_cancels(extension):
+    """Most tools cannot stop their work, and that must not make cancel fail."""
+
+    async def call_next(ctx):
+        await asyncio.Event().wait()
+
+    answer = await extension.intercept_tool_call(call(task=TaskMetadata()), object(), call_next)
+    await settle()
+    cancelled = await extension._handle_cancel(_Params(answer.task.task_id), object())
+    assert cancelled.status == "cancelled"
+
+
+@pytest.mark.asyncio
+async def test_a_synchronous_call_has_no_task_to_register_against(extension, store):
+    """The client is still on the other end of the connection and can drop
+    it, so there is nothing here to interrupt on its behalf."""
+    registered = []
+
+    async def call_next(ctx):
+        registered.append(await register_interrupt(lambda: None))
+        return {"content": "done"}
+
+    await extension.intercept_tool_call(call(), object(), call_next)
+    assert registered == [False]
+
+
+@pytest.mark.asyncio
+async def test_a_finished_task_is_not_interrupted(extension, store):
+    """Interrupting work that already finished would reach into a kernel
+    that has moved on to somebody else's cell."""
+    interrupted = []
+
+    async def call_next(ctx):
+        await register_interrupt(lambda: interrupted.append(1))
+        return {"content": "done"}
+
+    answer = await extension.intercept_tool_call(call(task=TaskMetadata()), object(), call_next)
+    await settle()
+    await extension._handle_cancel(_Params(answer.task.task_id), object())
+    assert interrupted == []
+
+
+@pytest.mark.asyncio
+async def test_the_current_task_is_empty_outside_a_task(extension):
+    assert current_task() == ""
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_transport_session.py
+++ b/tests/test_transport_session.py
@@ -1,3 +1,7 @@
+# Copyright (c) 2024- Datalayer, Inc.
+#
+# BSD 3-Clause License
+
 # Copyright (c) 2023-2026 Datalayer, Inc.
 # BSD 3-Clause License
 

--- a/tests/test_transport_session.py
+++ b/tests/test_transport_session.py
@@ -1,0 +1,79 @@
+# Copyright (c) 2023-2026 Datalayer, Inc.
+# BSD 3-Clause License
+
+"""Whether the Streamable HTTP transport issues a session id.
+
+Stateless is right for a server many people reach: each request runs in its
+own context, so `IdentityMiddleware` sees the caller of *that* request rather
+than whoever opened the session.
+
+It is the wrong default for a worker the Datalayer gateway starts, where
+there is one process per user — every request on it is the same caller by
+construction, so the reason does not apply, and the cost is real: a stateless
+server issues no `Mcp-Session-Id`, and a client that expects one from a
+Streamable HTTP server gets nothing.
+
+Launch the tests:
+```
+$ pytest tests/test_transport_session.py -v
+```
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from jupyter_mcp_server.utils import _env_flag
+
+
+class TestTheFlag:
+    def test_not_set_is_neither_on_nor_off(self, monkeypatch):
+        """"Not set" means *use the default for this way of running*.
+
+        Collapsing it into `False` would make an unset variable
+        indistinguishable from one somebody set to `false` on purpose, and
+        the two want different things: one takes the default, the other
+        overrides it.
+        """
+        monkeypatch.delenv("JUPYTER_MCP_STATEFUL", raising=False)
+        assert _env_flag("JUPYTER_MCP_STATEFUL") is None
+
+    @pytest.mark.parametrize("value", ["1", "true", "TRUE", "yes", "on"])
+    def test_the_spellings_that_mean_yes(self, monkeypatch, value):
+        monkeypatch.setenv("JUPYTER_MCP_STATEFUL", value)
+        assert _env_flag("JUPYTER_MCP_STATEFUL") is True
+
+    @pytest.mark.parametrize("value", ["0", "false", "no", "off", "nonsense"])
+    def test_everything_else_means_no(self, monkeypatch, value):
+        monkeypatch.setenv("JUPYTER_MCP_STATEFUL", value)
+        assert _env_flag("JUPYTER_MCP_STATEFUL") is False
+
+
+class TestWhatTheTransportDoes:
+    def test_the_default_is_stateless(self, monkeypatch):
+        """Unchanged for anybody running this server directly."""
+        monkeypatch.delenv("JUPYTER_MCP_STATEFUL", raising=False)
+        assert (_env_flag("JUPYTER_MCP_STATEFUL") is not True) is True
+
+    def test_only_an_explicit_yes_turns_sessions_on(self, monkeypatch):
+        """`is not True` rather than `not ...`, so an unset flag and an
+        explicit `false` both stay stateless — and only somebody who meant it
+        gets sessions."""
+        for value, stateless in (("true", False), ("false", True), (None, True)):
+            if value is None:
+                monkeypatch.delenv("JUPYTER_MCP_STATEFUL", raising=False)
+            else:
+                monkeypatch.setenv("JUPYTER_MCP_STATEFUL", value)
+            assert (_env_flag("JUPYTER_MCP_STATEFUL") is not True) is stateless
+
+    def test_the_app_is_built_with_the_choice(self, monkeypatch):
+        """The signature this passes through has to keep accepting it: a
+        rename upstream would otherwise leave the flag silently inert, which
+        is the failure it exists to fix."""
+        import inspect
+
+        from jupyter_mcp_server.server import MCPServerWithCORS
+
+        parameters = inspect.signature(MCPServerWithCORS.streamable_http_app).parameters
+        assert "stateless_http" in parameters
+        assert parameters["stateless_http"].default is True

--- a/tests/test_use_notebook_remote_rtc_version.py
+++ b/tests/test_use_notebook_remote_rtc_version.py
@@ -69,7 +69,7 @@ class FakeServerClient:
         self.http_client = FakeHTTPClient(extensions=extensions, error=error)
 
     def get_status(self):
-        return {"version": "2.1.0"}
+        return {"version": "2.1.1"}
 
 
 class FakeKernel:

--- a/tests/test_use_notebook_split_servers.py
+++ b/tests/test_use_notebook_split_servers.py
@@ -62,7 +62,7 @@ class FakeServerClient:
         self.http_client = SimpleNamespace(session=SimpleNamespace(headers={}))
 
     def get_status(self):
-        return {"version": "2.1.0"}
+        return {"version": "2.1.1"}
 
 
 class FakeKernel:

--- a/tests/test_use_notebook_ui_open.py
+++ b/tests/test_use_notebook_ui_open.py
@@ -42,7 +42,7 @@ class FakeServerClient:
         self.contents = FakeContents(names)
 
     def get_status(self):
-        return {"version": "2.1.0"}
+        return {"version": "2.1.1"}
 
 
 class FakeMCPToolsClient:


### PR DESCRIPTION
This PR advances the server toward “MCP 2 next” by adding protocol extensions for long-running tasks and cache revalidation (ETags), wiring them into the Streamable HTTP server, and bumping the package/versioned artifacts to 2.1.1.

Changes:

Add a tasks/* extension (task creation, polling, cancellation, idempotency keys) plus comprehensive tests and documentation.
Add ETag stamping on read tools and a revalidation extension that returns “not modified” responses when a client’s cached ETag matches.
Make Streamable HTTP session behavior configurable (stateless default; opt-in stateful via env var), and bump versions/deps to 2.1.1.