### PR TITLE
Fix typo in installation command for MCP server

### DIFF
--- a/docs/docs/mcp-transports/streamable-http-extension/index.mdx
+++ b/docs/docs/mcp-transports/streamable-http-extension/index.mdx
@@ -108,7 +108,7 @@ Some clients (Cursor, Claude Desktop on Windows) have a bug where spaces inside 
 ### Common Issues
 
 **Extension not loading:**
-- Verify `jupyter-mcp-server` is installed: `pip list | grep jupyter-mcp-server`
+- Verify `jupyter-mcp-server` is installed: `pip list | grep jupyter_mcp_server`
 - Check JupyterLab logs for extension errors
 
 **MCP endpoint not accessible:**


### PR DESCRIPTION
**Installation command:**

`pip install "jupyter-mcp-server" "jupyterlab" "jupyter-collaboration" "ipykernel"`

Thought the above installation alias name is "jupyter-mcp-server", the actual installed pip module name is jupyter-mcp-server

The `pip list | grep jupyter-mcp-server` returns nothing as the actual name of the module in the pip list output is 

`jupyter_mcp_server                 x.x.x`