### PR TITLE
fix(outputs): keep an error output that has no traceback

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -25,7 +25,7 @@
     "@docusaurus/theme-mermaid": "^3.5.2",
     "@mdx-js/react": "^3.0.1",
     "@primer/react-brand": "^0.58.0",
-    "clsx": "^2.1.2",
+    "clsx": "^2.1.1",
     "docusaurus-lunr-search": "^3.5.0",
     "react": "18.3.1",
     "react-calendly": "^4.1.0",

--- a/jupyter_mcp_server/utils.py
+++ b/jupyter_mcp_server/utils.py
@@ -514,11 +514,25 @@ def extract_output(output: dict | Any) -> str | ImageContent:
                 if hasattr(line, "source"):
                     line = str(line.source)
                 clean_traceback.append(strip_ansi_codes(str(line)))
-            return "\n".join(clean_traceback)
+            rendered = "\n".join(clean_traceback)
         else:
             if hasattr(traceback, "source"):
                 traceback = str(traceback.source)
-            return strip_ansi_codes(str(traceback))
+            rendered = strip_ansi_codes(str(traceback))
+        if rendered.strip():
+            return rendered
+        # An error with no traceback still carries a name and a message, and
+        # safe_extract_outputs drops an empty rendering, so returning "" makes
+        # the cell read back as though it had never failed.
+        parts = []
+        for field in ("ename", "evalue"):
+            value = output.get(field)
+            if hasattr(value, "source"):
+                value = value.source
+            value = strip_ansi_codes(str(value or "")).strip()
+            if value:
+                parts.append(value)
+        return ": ".join(parts) or "[Error output with no details]"
 
     else:
         return f"[Unknown output type: {output_type}]"

--- a/tests/test_error_output_without_traceback.py
+++ b/tests/test_error_output_without_traceback.py
@@ -1,0 +1,68 @@
+# Copyright (c) 2024- Datalayer, Inc.
+#
+# BSD 3-Clause License
+
+"""Unit tests for reading back an error output that carries no traceback.
+
+A kernel may report an error with an empty traceback, and
+execute_via_execution_stack builds exactly that shape when ExecutionStack
+reports a request-level failure. extract_output rendered such an output as the
+empty string, safe_extract_outputs drops an empty rendering, and the cell then
+read back with no sign that it had failed at all.
+"""
+
+from jupyter_mcp_server.models import Cell
+from jupyter_mcp_server.utils import extract_output, safe_extract_outputs
+
+NO_TRACEBACK_OUTPUT = {
+    "output_type": "error",
+    "ename": "ExecutionError",
+    "evalue": "Kernel 5f1c not found",
+    "traceback": [],
+}
+
+WITH_TRACEBACK_OUTPUT = {
+    "output_type": "error",
+    "ename": "ZeroDivisionError",
+    "evalue": "division by zero",
+    "traceback": [
+        "Traceback (most recent call last):",
+        "ZeroDivisionError: division by zero",
+    ],
+}
+
+STREAM_OUTPUT = {"output_type": "stream", "name": "stdout", "text": "starting\n"}
+
+
+def test_error_without_traceback_reports_name_and_message():
+    assert extract_output(NO_TRACEBACK_OUTPUT) == "ExecutionError: Kernel 5f1c not found"
+
+
+def test_error_without_traceback_survives_safe_extract_outputs():
+    assert safe_extract_outputs([NO_TRACEBACK_OUTPUT]) == [
+        "ExecutionError: Kernel 5f1c not found"
+    ]
+
+
+def test_a_cell_that_printed_then_failed_still_shows_the_failure():
+    cell = Cell(
+        cell_type="code",
+        source="run()",
+        execution_count=1,
+        outputs=[STREAM_OUTPUT, NO_TRACEBACK_OUTPUT],
+        metadata={},
+    )
+    assert cell.get_outputs("readable") == [
+        "starting\n",
+        "ExecutionError: Kernel 5f1c not found",
+    ]
+
+
+def test_error_with_a_traceback_is_unchanged():
+    assert extract_output(WITH_TRACEBACK_OUTPUT) == (
+        "Traceback (most recent call last):\nZeroDivisionError: division by zero"
+    )
+
+
+def test_an_error_with_nothing_at_all_is_still_reported():
+    assert extract_output({"output_type": "error"}) == "[Error output with no details]"


### PR DESCRIPTION
### Root cause

`extract_output` builds the text of an `error` output from its traceback and nothing else (`jupyter_mcp_server/utils.py:509`). An error whose traceback is empty therefore renders as `""`, and `safe_extract_outputs` keeps only a rendering that is truthy, so the output is dropped. Everything reading through `Cell.get_outputs("readable")`, which is `read_cell` and `read_notebook`, then shows a failed cell as one that did not fail.

The server builds that shape itself: `execute_via_execution_stack` wraps a request-level ExecutionStack failure as `{"ename": "ExecutionError", "evalue": <reason>, "traceback": []}` (`utils.py:1188-1194`) and `execute_cell` writes it into the cell. A kernel that sends an `error` message with no traceback arrives the same way through `utils.py:1559-1562`.

### The fix

The error branch renders the traceback exactly as before when there is one. When the rendering comes back empty it falls back to `ename: evalue`, both of which nbformat requires on an error output, and to a short marker if even those are missing.

### Verified

- New `tests/test_error_output_without_traceback.py`: 4 of its 5 tests fail on `3a07ac6` and pass with this change; the fifth pins that an error with a traceback renders exactly as it did before.
- 163 tests pass across the suites around this change (`test_extract_output_fidelity`, `test_execute_cell_output_fidelity`, `test_execute_via_execution_stack`, `test_results`, `test_cell_ids`, `test_execute_cell_stream`, `test_execute_code_timeout`, `test_clear_cell_output`, `test_common`, `test_delete_cell`, `test_move_cell`), Python 3.12.14 in a clean container.
- The 28 setup errors in `test_delete_cell.py` and `test_move_cell.py` in that container happen identically on `3a07ac6` without this change, so they are the container and not the diff. The full matrix is left to CI here.
- Not checked: a live kernel emitting an error with no traceback. The shape used throughout is the one the server constructs at `utils.py:1188-1194`.

Fixes #415


### Also in this diff

`docs/package.json` restores `clsx` to `^2.1.1`, at the maintainer's request in the thread below. The release bump `8b7504c` swapped 2.1.1 for 2.1.2 across nine files and caught that dependency too, and clsx has no 2.1.2, so `npm install` in `docs/` fails with `ETARGET` on this branch and on `main` alike. Verified by running `npm install` on node 22 with the corrected file.
