### PR TITLE
fix(hooks): fire AFTER_EXECUTE when a local execution is cancelled

### DIFF
--- a/jupyter_mcp_server/utils.py
+++ b/jupyter_mcp_server/utils.py
@@ -1602,6 +1602,22 @@ async def execute_code_local(
         )
         return result
 
+    except asyncio.CancelledError as interrupt_err:
+        # CancelledError is not an Exception, so the handler below never sees
+        # it — the AFTER this exit owes has to be fired here.
+        logger.warning(f"Code execution on kernel {kernel_id} was cancelled")
+        if hook_ctx is not None:
+            await HookRegistry.get_instance().fire(
+                HookEvent.AFTER_EXECUTE,
+                code=code,
+                kernel_id=kernel_id,
+                metadata={},
+                outputs=[],
+                error=interrupt_err,
+                context=hook_ctx,
+            )
+        raise
+
     except Exception as e:
         logger.error(f"Error executing code locally: {e}")
         if hook_ctx is not None:

--- a/tests/test_execute_hook_pairing.py
+++ b/tests/test_execute_hook_pairing.py
@@ -362,6 +362,33 @@ async def test_local_unexpected_error_fires_after_execute(handler):
         context.term()
 
 
+@pytest.mark.asyncio
+async def test_local_user_cancellation_fires_after_execute(handler):
+    """An MCP user-cancel unwinds out of the poll, on this path too."""
+    context = zmq.asyncio.Context()
+    client = _KernelClient(context)
+    try:
+        task = asyncio.create_task(
+            execute_code_local(
+                serverapp=_ServerApp(kernel_manager=_KernelManager(_Kernel(client))),
+                notebook_path="notebook.ipynb",
+                code="while True: pass",
+                kernel_id="kernel-1",
+                timeout=300,
+            )
+        )
+        await asyncio.sleep(0.1)
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+
+        after = assert_paired(handler)
+        assert isinstance(after["error"], asyncio.CancelledError)
+    finally:
+        client.close()
+        context.term()
+
+
 # --------------------------------------------------------------------------
 # What an unpaired BEFORE_EXECUTE costs a real handler
 # --------------------------------------------------------------------------


### PR DESCRIPTION
`execute_code_local` fires BEFORE_EXECUTE and then lets a `CancelledError` walk straight past its `except Exception` handler, so an execution the client cancelled never gets its AFTER_EXECUTE. A handler that stashed per-execution state in the context never gets it back: `OTelHookHandler` ends its span only in the AFTER branch and `SimpleSpanProcessor` exports on end, so a cancelled `execute_code` is missing from the span file altogether, and an audit sink pairing on the context leaks the entry.

#361 went after exactly this and its message names cancellation and both functions, but only `execute_via_execution_stack` got the branch — `execute_code_local` got the "every exit past that point owes exactly one AFTER_EXECUTE" comment and no handling to match. Added the same branch there. It's guarded on `hook_ctx` because a cancel can also land on the channel-startup sleep, before BEFORE_EXECUTE has fired, and that exit owes nothing. No `after_execute_fired` flag needed here, unlike the sibling, since `CancelledError` can't fall through into `except Exception`.

The test mirrors `test_user_cancellation_fires_after_execute` from the stack path and reuses the zmq fakes already in that file; on main it fails with `expected 1 AFTER_EXECUTE, got 0`.

One thing I left alone on purpose: this path never interrupts the kernel the way the stack path calls `execution_stack.cancel()`, so the code keeps running after the client has given up. Felt like a separate change rather than something to bundle in here.
