### PR TITLE
fix(capabilities): apply the environment before publishing the registry

### DIFF
--- a/jupyter_mcp_server/capabilities.py
+++ b/jupyter_mcp_server/capabilities.py
@@ -229,11 +229,17 @@ _registry: CapabilityRegistry | None = None
 
 
 def get_capabilities() -> CapabilityRegistry:
-    """The registry of this process, built on first use."""
+    """The registry of this process, built on first use.
+
+    Published only once the environment has been applied. Assigning first
+    leaves a registry the bad entry stopped halfway through, and every call
+    after the one that raised reads it back as though it were configured.
+    """
     global _registry
     if _registry is None:
-        _registry = CapabilityRegistry()
-        _registry.apply(from_environment(), source="config")
+        registry = CapabilityRegistry()
+        registry.apply(from_environment(), source="config")
+        _registry = registry
     return _registry
 
 

--- a/tests/test_capabilities.py
+++ b/tests/test_capabilities.py
@@ -32,6 +32,7 @@ from jupyter_mcp_server.capabilities import (
     Capability,
     CapabilityRegistry,
     UnknownCapability,
+    enabled,
     get_capabilities,
     parse_setting,
     reset_capabilities,
@@ -114,6 +115,26 @@ class TestSettings:
         monkeypatch.setenv(CAPABILITIES_ENV, f"{KERNEL_AUTO_RESTART}=off")
         reset_capabilities()
         assert get_capabilities().enabled(KERNEL_AUTO_RESTART) is False
+
+    def test_a_misspelt_name_in_the_environment_is_refused_on_every_call(self, monkeypatch):
+        """Refused once and then cached is the drop this refuses. The caller
+        after the one that raised reads back a registry the bad entry stopped
+        halfway through, with nothing anywhere saying so."""
+        monkeypatch.setenv(CAPABILITIES_ENV, f"kernel.autorestart,{KERNEL_AUTO_RESTART}")
+        with pytest.raises(UnknownCapability):
+            reset_capabilities()
+        with pytest.raises(UnknownCapability):
+            get_capabilities()
+        with pytest.raises(UnknownCapability):
+            enabled(KERNEL_AUTO_RESTART)
+
+    def test_the_environment_is_never_applied_in_part(self, monkeypatch):
+        """Which settings survive must not depend on where the bad name sits."""
+        monkeypatch.setenv(CAPABILITIES_ENV, f"{KERNEL_AUTO_RESTART},kernel.autorestart")
+        with pytest.raises(UnknownCapability):
+            reset_capabilities()
+        with pytest.raises(UnknownCapability):
+            enabled(KERNEL_AUTO_RESTART)
 
 
 class TestWhereAValueCameFrom:


### PR DESCRIPTION
`get_capabilities()` assigned `_registry` before it applied `JUPYTER_MCP_CAPABILITIES`, so when `apply` raised `UnknownCapability` the half-applied registry was already cached. The first caller saw the error and every caller after it read that registry back with no error at all, which turns a refused name into a dropped one. Which settings survived depended on where the bad name sat in the list.

The fix builds the registry in a local and assigns the global only after `apply` returns, so a name nobody declared is refused on every call. That is what `--capability` already does through `serve.py`, and what `UnknownCapability` was written for.

Verified in a clean `python:3.11-slim` container on 5e2e775:

- `tests/test_capabilities.py::TestSettings::test_a_misspelt_name_in_the_environment_is_refused_on_every_call` and `::test_the_environment_is_never_applied_in_part` fail before the change and pass after. The second covers the order dependence, since a bad name placed after a good one used to leave the good one applied.
- `pytest tests/test_capabilities.py` goes from 32 passed to 34 passed.
- Whole suite, `-m "not integration"`: 693 passed before, 695 after, with the same 2 failures and 129 errors on both sides. Those are the live JupyterLab fixture failing to start in the container, not this change.
- `ruff check` on both touched files reports only the pre-existing `N818` on the `UnknownCapability` class name.

Not checked: whether raising on every call rather than once is the behaviour you want on the request path. The alternative is to apply the names that are valid and log the bad one, which reads more forgiving but goes against what the class docstring and the `serve.py` comment both say. Happy to switch it if you prefer that.

Fixes #420
