### PR TITLE
enh: tasks cancellation + resources (notebook, cells, outputs)

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -48,7 +48,7 @@ jobs:
         run: |
           git add -AN docs/sourcey
           git diff --exit-code -- docs/sourcey \
-            || (echo "::error::docs/sourcey is stale; re-run the generation (docs/sourcey/README.md) and commit the result" && exit 1)
+            || (echo "::error::docs/sourcey is stale; run 'make sync-sourcey' and commit the result (see docs/sourcey/README.md)" && exit 1)
 
       - name: Build the docs
         working-directory: docs

--- a/Makefile
+++ b/Makefile
@@ -180,6 +180,10 @@ test-conformance: ## Run the MCP specification's own conformance suite
 
 SOURCEY_SNAPSHOT_TIMEOUT ?= 180
 
+# The extension entry-point names this repo publishes, read out of its own
+# pyproject files: the root package and everything under extensions/.
+SOURCEY_REPO_EXTENSIONS = python -c 'import glob,tomllib;fs=["pyproject.toml"]+sorted(glob.glob("extensions/*/pyproject.toml"));print(",".join(sorted({n for f in fs for n in ((tomllib.load(open(f,"rb")).get("project") or {}).get("entry-points") or {}).get("jupyter_mcp_server.extensions",{}) or {}})))'
+
 sync-sourcey: ## regenerate the generated MCP reference under docs/sourcey
 	@# The four steps of the Docs workflow's "Regenerate the MCP reference",
 	@# plus the `npm install` it runs first: docs/ has its own package.json and
@@ -189,17 +193,6 @@ sync-sourcey: ## regenerate the generated MCP reference under docs/sourcey
 	  echo "jupyter-mcp-server is not on PATH."; \
 	  echo "Run 'make dev' and 'pip install ./extensions/sandboxes' first."; \
 	  exit 1; }
-	@# The snapshot is whatever the *installed* server advertises, and any
-	@# package registering a jupyter_mcp_server.extensions entry point changes
-	@# that. CI installs only . and ./extensions/sandboxes, so an environment
-	@# carrying more than "sandboxes" produces a snapshot CI can never
-	@# reproduce -- datalayer_jupyter_mcp_server's "spaces" adds tools and its
-	@# tool_policy hides others. Refuse rather than overwrite the checked-in
-	@# reference with it; set SOURCEY_ALLOW_EXTRA_EXTENSIONS=1 to override.
-	@python -c 'import os,sys;\
-	from importlib.metadata import entry_points;\
-	extra=sorted(e.name for e in entry_points().select(group="jupyter_mcp_server.extensions") if e.name != "sandboxes");\
-	sys.exit(0) if not extra or os.environ.get("SOURCEY_ALLOW_EXTRA_EXTENSIONS") else sys.exit("refusing to snapshot: this environment registers MCP extensions CI does not have: %s\n  pip uninstall them, or use a clean venv with just this package and ./extensions/sandboxes.\n  Set SOURCEY_ALLOW_EXTRA_EXTENSIONS=1 to snapshot anyway." % ", ".join(extra))'
 	cd docs && npm install --no-audit --no-fund
 	@# Step 1 spawns the server over stdio. It used to sit there for two
 	@# minutes after writing mcp.json -- mcp-parser leaves a per-request timer
@@ -208,12 +201,22 @@ sync-sourcey: ## regenerate the generated MCP reference under docs/sourcey
 	@# answers at all, and stdin is closed so the child cannot read the
 	@# terminal. Whatever the exit status, the snapshot has to be usable, so
 	@# the artifact is checked before the three steps that consume it.
+	@# The snapshot is whatever the installed server advertises, so an
+	@# environment carrying an extension beyond the ones this repo ships
+	@# answers differently and the reference stops matching CI, which installs
+	@# only . and ./extensions/sandboxes. JUPYTER_MCP_EXTENSIONS pins discovery
+	@# to the entry-point names declared by this repo's own pyproject files --
+	@# read from them rather than written down here, so adding an extension
+	@# needs no edit.
+	exts=$$($(SOURCEY_REPO_EXTENSIONS)) ; \
+	echo "snapshotting with extensions: $$exts" ; \
 	cd docs/sourcey && \
 	  if command -v timeout >/dev/null 2>&1 ; then \
-	    timeout --foreground -k 5 $(SOURCEY_SNAPSHOT_TIMEOUT) \
+	    JUPYTER_MCP_EXTENSIONS="$$exts" timeout --foreground -k 5 $(SOURCEY_SNAPSHOT_TIMEOUT) \
 	      node snapshot.mjs jupyter-mcp-server mcp.json </dev/null ; \
 	  else \
-	    node snapshot.mjs jupyter-mcp-server mcp.json </dev/null ; \
+	    JUPYTER_MCP_EXTENSIONS="$$exts" \
+	      node snapshot.mjs jupyter-mcp-server mcp.json </dev/null ; \
 	  fi ; \
 	  status=$$? ; \
 	  if [ $$status -eq 124 ] ; then \

--- a/Makefile
+++ b/Makefile
@@ -175,3 +175,59 @@ test-conformance: ## Run the MCP specification's own conformance suite
 	@exec echo "Installing @modelcontextprotocol/conformance (npm, not saved)"
 	npm install --no-save @modelcontextprotocol/conformance
 	pytest tests/test_conformance.py -v
+
+.PHONY: sync-sourcey
+
+SOURCEY_SNAPSHOT_TIMEOUT ?= 180
+
+sync-sourcey: ## regenerate the generated MCP reference under docs/sourcey
+	@# The four steps of the Docs workflow's "Regenerate the MCP reference",
+	@# plus the `npm install` it runs first: docs/ has its own package.json and
+	@# is not one of the monorepo workspaces, so a root `npm i` never installs
+	@# mcp-parser for it and step 1 dies with ERR_MODULE_NOT_FOUND.
+	@command -v jupyter-mcp-server >/dev/null 2>&1 || { \
+	  echo "jupyter-mcp-server is not on PATH."; \
+	  echo "Run 'make dev' and 'pip install ./extensions/sandboxes' first."; \
+	  exit 1; }
+	@# The snapshot is whatever the *installed* server advertises, and any
+	@# package registering a jupyter_mcp_server.extensions entry point changes
+	@# that. CI installs only . and ./extensions/sandboxes, so an environment
+	@# carrying more than "sandboxes" produces a snapshot CI can never
+	@# reproduce -- datalayer_jupyter_mcp_server's "spaces" adds tools and its
+	@# tool_policy hides others. Refuse rather than overwrite the checked-in
+	@# reference with it; set SOURCEY_ALLOW_EXTRA_EXTENSIONS=1 to override.
+	@python -c 'import os,sys;\
+	from importlib.metadata import entry_points;\
+	extra=sorted(e.name for e in entry_points().select(group="jupyter_mcp_server.extensions") if e.name != "sandboxes");\
+	sys.exit(0) if not extra or os.environ.get("SOURCEY_ALLOW_EXTRA_EXTENSIONS") else sys.exit("refusing to snapshot: this environment registers MCP extensions CI does not have: %s\n  pip uninstall them, or use a clean venv with just this package and ./extensions/sandboxes.\n  Set SOURCEY_ALLOW_EXTRA_EXTENSIONS=1 to snapshot anyway." % ", ".join(extra))'
+	cd docs && npm install --no-audit --no-fund
+	@# Step 1 spawns the server over stdio. It used to sit there for two
+	@# minutes after writing mcp.json -- mcp-parser leaves a per-request timer
+	@# armed -- which snapshot.mjs now ends explicitly; see the comment at the
+	@# foot of that file. `timeout` stays as a backstop for a server that never
+	@# answers at all, and stdin is closed so the child cannot read the
+	@# terminal. Whatever the exit status, the snapshot has to be usable, so
+	@# the artifact is checked before the three steps that consume it.
+	cd docs/sourcey && \
+	  if command -v timeout >/dev/null 2>&1 ; then \
+	    timeout --foreground -k 5 $(SOURCEY_SNAPSHOT_TIMEOUT) \
+	      node snapshot.mjs jupyter-mcp-server mcp.json </dev/null ; \
+	  else \
+	    node snapshot.mjs jupyter-mcp-server mcp.json </dev/null ; \
+	  fi ; \
+	  status=$$? ; \
+	  if [ $$status -eq 124 ] ; then \
+	    echo "snapshot.mjs did not finish within $(SOURCEY_SNAPSHOT_TIMEOUT)s - is a Jupyter server reachable?" ; \
+	    exit 1 ; \
+	  elif [ $$status -ne 0 ] ; then \
+	    exit $$status ; \
+	  fi ; \
+	  python -m json.tool mcp.json >/dev/null 2>&1 || { \
+	    echo "mcp.json is not valid JSON - the snapshot did not complete" ; exit 1 ; } ; \
+	  python -c 'import json,sys; d=json.load(open("mcp.json")); t=len(d.get("tools") or []); p=len(d.get("prompts") or []); print("snapshot ok: %d tools, %d prompt(s)" % (t,p)) if t else sys.exit("mcp.json carries no tools - the snapshot did not complete")'
+	cd docs/sourcey && \
+	  python gen_sourcemap.py ../.. sourcemap.json && \
+	  python dump_config.py config-fields.json && \
+	  node build_pages.mjs
+	@exec echo
+	@exec echo "docs/sourcey regenerated - commit whatever changed, that is what CI checks."

--- a/Makefile
+++ b/Makefile
@@ -57,6 +57,20 @@ test-jupyter-server: ## run the unit tests for jupyter server
 test-integration: ## run the integration tests
 	hatch test
 
+.PHONY: bump bump-patch bump-minor bump-major
+
+bump: ## bump the version, asking which part
+	python dev/bump_version.py
+
+bump-patch: ## bump the patch version (2.1.3 -> 2.1.4)
+	python dev/bump_version.py patch
+
+bump-minor: ## bump the minor version (2.1.3 -> 2.2.0)
+	python dev/bump_version.py minor
+
+bump-major: ## bump the major version (2.1.3 -> 3.0.0)
+	python dev/bump_version.py major
+
 build:
 	pip install build
 	python -m build .

--- a/README.md
+++ b/README.md
@@ -26,14 +26,14 @@
 
 📖 [Documentation](https://jupyter-mcp-server.datalayer.tech) &nbsp;·&nbsp; 🔧 [Tools](https://jupyter-mcp-server.datalayer.tech/mcp) &nbsp;·&nbsp; 💬 [Community](https://jupyter-mcp-server.datalayer.tech/community)
 
-[![HOT NEWS](https://img.shields.io/badge/%F0%9F%94%A5%20HOT%20NEWS-Hosted%20MCP%20is%20live-E74C3C?style=for-the-badge&labelColor=922B21)](https://jupyter-mcp-server.datalayer.tech/hosted)
+[![HOT NEWS](https://img.shields.io/badge/%F0%9F%94%A5%20HOT%20NEWS-Hosted%20MCP%20is%20live-E74C3C?style=for-the-badge&labelColor=922B21)](https://datalayer.ai)
 
 **No process to run.** Datalayer now hosts this server for you at
 **`https://mcp.datalayer.run/mcp`** — one endpoint for every agent and every notebook.
 Sign in from your browser, approve what the agent may do, and your work keeps running
 on the server after the agent disconnects.
 
-→ [**Hosted Jupyter MCP Server**](https://jupyter-mcp-server.datalayer.tech/hosted)
+→ [**Hosted Jupyter MCP Server**](https://datalayer.ai)
 
 [![Jupyter MCP Server 2](https://images.datalayer.io/products/jupyter-mcp-server/jupyter-mcp-server-2.png)](https://datalayer.ai)
 
@@ -149,7 +149,7 @@ names when convenient — the old ones are deprecated, not removed.
 - [Key Features](#-key-features)
 - [MCP Overview](#-mcp-overview)
 - [Getting Started](#-getting-started)
-- [Sandbox Variants](#-execution-engines)
+- [Sandbox Variants](#-sandbox-variants)
 - [Best Practices](#-best-practices)
 - [Contributing](#-contributing)
 - [Resources](#-resources)
@@ -173,80 +173,42 @@ come with GPUs and the execution survives a disconnect.
 
 ### 🔧 Tools Overview
 
-The server provides a rich set of tools for interacting with Jupyter notebooks, categorized as follows.
-For more details on each tool, their parameters, and return values, please refer to the [official Tools documentation](https://jupyter-mcp-server.datalayer.tech/mcp).
+Every tool, with its parameters, schema and return value, is generated from a live
+snapshot of the running server and published at
+[**jupyter-mcp-server.datalayer.tech/mcp**](https://jupyter-mcp-server.datalayer.tech/mcp) — so it is never out of step with the
+code, which a table copied into this file would be.
 
-#### Server and Code Sandbox Management Tools
+They fall into four groups:
 
-| Name                 | Description                                                                                                                                                                                                                                                                                     |
-| :------------------- | :---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `list_files`         | List files and directories in the Jupyter server's file system.                                                                                                                                                                                                                                 |
-| `list_kernels`       | List all available and running kernel sessions on the Jupyter server.                                                                                                                                                                                                                           |
-| `launch_sandbox`     | Launch a code sandbox (eval/docker/jupyter-server/datalayer/daytona/e2b/coreweave/cloudflare/kaggle/google-colab/monty/modal) as an alternative execution backend for `execute_code`. Supports variant-specific options including GPU flavor for supported backends. Requires the `jupyter_mcp_sandboxes` extension. |
-| `list_sandboxes`     | List launched code sandboxes and their state (active flag, variant, status, and selected code sandbox options). Requires the `jupyter_mcp_sandboxes` extension.                                                                                                                                 |
-| `use_sandbox`        | Select or clear the active sandbox used by `execute_code`, enabling dynamic routing between kernel-backed and sandbox-backed execution. Requires the `jupyter_mcp_sandboxes` extension.                                                                                                         |
-| `terminate_sandbox`  | Stop and unregister a launched code sandbox. Requires the `jupyter_mcp_sandboxes` extension.                                                                                                                                                                                                    |
-| `connect_to_jupyter` | Connect to a Jupyter server dynamically without restarting the MCP server. *Not available when running as Jupyter extension. Useful for switching servers dynamically or avoiding hardcoded configuration.*                                                                                     |
+- **Server and code sandbox** — browse the Jupyter file system, list kernels, connect to
+  a server at runtime, and launch, select and terminate code sandboxes.
+- **Notebooks** — open, create and switch between notebooks, list them, read one, restart
+  its kernel, release it.
+- **Cells** — read, insert, delete, move, reorder and edit cells, surgically or wholesale,
+  and clear their outputs.
+- **Execution** — run a cell or arbitrary code on the active backend, with multimodal
+  output and streaming where the sandbox supports it.
 
-#### Multi-Notebook Management Tools
-
-| Name               | Description                                                                |
-| :----------------- | :------------------------------------------------------------------------- |
-| `use_notebook`     | Connect to a notebook file, create a new one, or switch between notebooks. |
-| `list_notebooks`   | List all notebooks available on the Jupyter server and their status        |
-| `restart_notebook` | Restart the kernel for a specific managed notebook.                        |
-| `unuse_notebook`   | Disconnect from a specific notebook and release its resources.             |
-| `read_notebook`    | Read notebook cells source content with brief or detailed format options.  |
-
-#### Cell Operations and Execution Tools
-
-| Name                       | Description                                                                                                                                                                                                                                                    |
-| :------------------------- | :------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `read_cell`                | Read the full content (Metadata, Source and Outputs) of a single cell.                                                                                                                                                                                         |
-| `insert_cell`              | Insert a new code or markdown cell at a specified position.                                                                                                                                                                                                    |
-| `delete_cell`              | Delete a cell at a specified index.                                                                                                                                                                                                                            |
-| `move_cell`                | Move a cell from one position to another within a notebook.                                                                                                                                                                                                    |
-| `clear_cell_output`        | Clear the outputs and execution count of a single code cell.                                                                                                                                                                                                   |
-| `overwrite_cell_source`    | Overwrite the source code of an existing cell.                                                                                                                                                                                                                 |
-| `edit_cell_source`         | Apply surgical find-and-replace edits to a cell's source without full rewrite.                                                                                                                                                                                 |
-| `execute_cell`             | Execute a cell with timeout, supports multimodal output including images.                                                                                                                                                                                      |
-| `insert_execute_code_cell` | Insert a new code cell and execute it in one step.                                                                                                                                                                                                             |
-| `execute_code`             | Execute code directly in the active backend (kernel by default, or active sandbox if selected), supports magic commands and shell commands. When the selected sandbox supports streaming execution, progress/output events are consumed and returned in order. |
+Sandbox tools need the optional `jupyter_mcp_sandboxes` extension; see
+[Sandbox Variants](#-sandbox-variants).
 
 #### JupyterLab Integration
 
 *Available only when JupyterLab mode is enabled. It is enabled by default.*
 
-When running in JupyterLab mode, Jupyter MCP Server integrates with [jupyter-mcp-tools](https://github.com/datalayer/jupyter-mcp-tools) to expose additional JupyterLab commands as MCP tools. By default, the following tools are enabled:
-
-| Name                         | Description                                            |
-| :--------------------------- | :----------------------------------------------------- |
-| `notebook_run-all-cells`     | Execute all cells in the current notebook sequentially |
-| `notebook_get-selected-cell` | Get information about the currently selected cell      |
-
-<details>
-<summary><strong>📚 Learn how to customize additional tools</strong></summary>
-
-You can now customize which tools from `jupyter-mcp-tools` are available using the `allowed_jupyter_mcp_tools` configuration parameter. This allows you to enable additional notebook operations, console commands, file management tools, and more.
-
-```bash
-# Example: Enable additional tools via command-line
-jupyter lab --port 4040 --IdentityProvider.token MY_TOKEN --JupyterMCPServerExtensionApp.allowed_jupyter_mcp_tools="notebook_run-all-cells,notebook_get-selected-cell,notebook_append-execute,console_create"
-```
-
-For the complete list of available tools and detailed configuration instructions, please refer to the [Additional Tools documentation](https://jupyter-mcp-server.datalayer.tech/features/tools-jupyterlab).
-
-</details>
+In JupyterLab mode the server also exposes JupyterLab commands as MCP tools through
+[jupyter-mcp-tools](https://github.com/datalayer/jupyter-mcp-tools) —
+`notebook_run-all-cells` and `notebook_get-selected-cell` by default, with more
+selectable through `allowed_jupyter_mcp_tools`. The full list and how to configure it are
+in the [Additional Tools documentation](https://jupyter-mcp-server.datalayer.tech/operations/tools-jupyterlab).
 
 ### 📝 Prompt Overview
 
-The server also supports [prompt feature](https://modelcontextprotocol.io/specification/2025-06-18/server/prompts) of MCP, providing a easy way for user to interact with Jupyter notebooks.
-
-| Name           | Description                                                                 |
-| :------------- | :-------------------------------------------------------------------------- |
-| `jupyter-cite` | Cite specific cells from specified notebook (like `@` in Coding IDE or CLI) |
-
-For more details on each prompt, their input parameters, and return content, please refer to the [official Prompt documentation](https://jupyter-mcp-server.datalayer.tech/features/prompts).
+The server implements the MCP
+[prompts feature](https://modelcontextprotocol.io/specification/2025-06-18/server/prompts).
+`jupyter-cite` cites specific cells from a notebook, the way `@` does in a coding IDE or
+CLI. Input parameters and returned content are in the
+[Prompts documentation](https://jupyter-mcp-server.datalayer.tech/operations/prompts).
 
 ## 🏁 Getting Started
 
@@ -394,7 +356,7 @@ Then, configure your client:
 
 ---
 
-For detailed instructions on configuring various MCP clients—including [Claude Desktop](https://jupyter-mcp-server.datalayer.tech/clients/claude_desktop), [VS Code](https://jupyter-mcp-server.datalayer.tech/clients/vscode), [Cursor](https://jupyter-mcp-server.datalayer.tech/clients/cursor), [Cline](https://jupyter-mcp-server.datalayer.tech/clients/cline), and [Windsurf](https://jupyter-mcp-server.datalayer.tech/clients/windsurf) — see the [Clients documentation](https://jupyter-mcp-server.datalayer.tech/clients).
+For detailed instructions on configuring various MCP clients—including [Claude Desktop](https://datalayer.ai/docs/mcp-clients/claude-desktop), [VS Code](https://datalayer.ai/docs/mcp-clients/vscode), [Cursor](https://datalayer.ai/docs/mcp-clients/cursor), [Cline](https://datalayer.ai/docs/mcp-clients/cline), and [Windsurf](https://datalayer.ai/docs/mcp-clients/windsurf) — see [MCP Client Configuration](https://jupyter-mcp-server.datalayer.tech/getting_started#mcp-client-configuration).
 
 ## 🧩 Sandbox Variants
 
@@ -412,313 +374,23 @@ To expose sandbox lifecycle tools (`launch_sandbox`, `list_sandboxes`,
 `use_sandbox`, `terminate_sandbox`) or run any non-`jupyter-server` sandbox variant,
 install it with `pip install jupyter_mcp_sandboxes`.
 
-| Engine                   | `SANDBOX_VARIANT` | Extra install                    | Key variables                                                                                                                                                                                                             |
-| ------------------------ | ----------------- | -------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Jupyter Server (default) | `jupyter-server`  | —                                | `JUPYTER_URL`, `JUPYTER_TOKEN`                                                                                                                                                                                            |
-| JupyterHub               | `jupyter-server`  | —                                | `CODE_SANDBOX_URL`, `CODE_SANDBOX_TOKEN`                                                                                                                                                                                  |
-| Datalayer                | `datalayer`       | `jupyter-mcp-server[datalayer]`  | `CODE_SANDBOX_URL`, `CODE_SANDBOX_TOKEN`, `SANDBOX_ENVIRONMENT`                                                                                                                                                           |
-| Kaggle                   | `kaggle`          | `jupyter-mcp-server[kaggle]`     | Default batch mode: Kaggle credentials (`KAGGLE_API_TOKEN` or `kaggle.json`). Interactive mode: `CODE_SANDBOX_URL` + (`KAGGLE_API_TOKEN`/`CODE_SANDBOX_TOKEN` or `CODE_SANDBOX_ID`). Optional accelerator: `SANDBOX_GPU`. |
-| Google Colab             | `google-colab`    | `jupyter-mcp-server`             | `CODE_SANDBOX_URL`, `CODE_SANDBOX_ID`, `CODE_SANDBOX_PROXY_TOKEN`                                                                                                                                                         |
-| Monty                    | `monty`           | `jupyter-mcp-server[monty]`      | —                                                                                                                                                                                                                         |
-| Modal                    | `modal`           | `jupyter-mcp-server[modal]`      | Modal credentials                                                                                                                                                                                                         |
-| Daytona                  | `daytona`         | `jupyter-mcp-server[daytona]`    | `DAYTONA_API_KEY`, or `DAYTONA_JWT_TOKEN` + `DAYTONA_ORGANIZATION_ID`. Optional accelerator: `SANDBOX_GPU`.                                                                                                               |
-| E2B                      | `e2b`             | `jupyter-mcp-server[e2b]`        | `E2B_API_KEY`. Optional: `E2B_DOMAIN`.                                                                                                                                                                                    |
-| CoreWeave                | `coreweave`       | `jupyter-mcp-server[coreweave]`  | `CWSANDBOX_API_KEY`. Optional: `CWSANDBOX_BASE_URL`, accelerator `SANDBOX_GPU`.                                                                                                                                           |
-| Cloudflare               | `cloudflare`      | `jupyter-mcp-server[cloudflare]` | `CLOUDFLARE_SANDBOX_API_URL`, `CLOUDFLARE_SANDBOX_API_KEY`                                                                                                                                                                |
-
-### 1. Jupyter Server
-
-The default engine. Point the server at a running Jupyter Server:
-
-```bash
-pip install jupyter-mcp-server
-```
-
-```json
-"env": {
-  "JUPYTER_URL": "http://localhost:8888",
-  "JUPYTER_TOKEN": "MY_TOKEN"
-}
-```
-
-### 2. JupyterHub
-
-JupyterHub uses the same `jupyter-server` engine, targeting a user's single-user server.
-Authenticate with a JupyterHub API token that has the `access:servers` scope:
-
-```json
-"env": {
-  "CODE_SANDBOX_URL": "https://your-jupyterhub.domain/user/<username>",
-  "CODE_SANDBOX_TOKEN": "your-jupyterhub-api-token",
-  "DOCUMENT_URL": "https://your-jupyterhub.domain/user/<username>",
-  "DOCUMENT_TOKEN": "your-jupyterhub-api-token"
-}
-```
-
-See the [JupyterHub setup guide](https://jupyter-mcp-server.datalayer.tech/code-sandboxes/jupyterhub) for full details.
-
-### 3. Datalayer
-
-Execute on the [Datalayer](https://datalayer.ai) cloud code sandbox with GPU support
-and persistence:
-
-```bash
-pip install "jupyter-mcp-server[datalayer]"
-```
-
-```json
-"env": {
-  "SANDBOX_VARIANT": "datalayer",
-  "CODE_SANDBOX_URL": "https://prod1.datalayer.run",
-  "CODE_SANDBOX_TOKEN": "your-datalayer-token",
-  "SANDBOX_ENVIRONMENT": "python-cpu-env"
-}
-```
-
-### 4. Kaggle
-
-Execute against Kaggle. By default, when no code sandbox URL/channels are provided,
-the server uses the transparent Kaggle **batch** path from `code-sandboxes`.
-If code sandbox values are provided, it uses Kaggle interactive kernel mode.
-
-```bash
-pip install "jupyter-mcp-server[kaggle]"
-```
-
-```json
-"env": {
-  "SANDBOX_VARIANT": "kaggle",
-  "KAGGLE_API_TOKEN": "...",
-  "SANDBOX_GPU": "T4"
-}
-```
-
-To force interactive code sandbox mode, provide `CODE_SANDBOX_URL` and either:
-
-- `KAGGLE_API_TOKEN` / `CODE_SANDBOX_TOKEN` (create kernel), or
-- `CODE_SANDBOX_ID` / `CODE_SANDBOX_CHANNELS_URL` (connect existing kernel).
-
-Supported Kaggle accelerator values include:
-`NvidiaTeslaP100`, `NvidiaTeslaT4`, `NvidiaTeslaT4Highmem`, `NvidiaL4`,
-`NvidiaL4X1`, `NvidiaTeslaA100`, `NvidiaH100`, and `NvidiaRtxPro6000`.
-Aliases such as `P100` and `T4` are accepted.
-
-> Note: Kaggle free-tier availability usually includes `P100` and `T4`. Other
-> accelerators are commonly restricted to specific competitions or internal
-> Kaggle workloads.
-
-### 5. Google Colab
-
-Execute against a Google Colab code sandbox. Install Jupyter MCP Server and provide the
-values from an active Colab notebook session:
-
-```bash
-pip install jupyter-mcp-server
-```
-
-```json
-"env": {
-  "SANDBOX_VARIANT": "google-colab",
-  "CODE_SANDBOX_URL": "https://8080-m-s-kkb-...-d.us-east1-0.prod.colab.dev",
-  "CODE_SANDBOX_ID": "a1b2c3d4-....",
-  "CODE_SANDBOX_PROXY_TOKEN": "ya29...."
-}
-```
-
-> The proxy token (`colab-runtime-proxy-token`) is short-lived; refresh it when it
-> expires.
-
-You can also pass `CODE_SANDBOX_CHANNELS_URL` with the Colab channels WebSocket URL
-and let the server derive `CODE_SANDBOX_URL` and `CODE_SANDBOX_ID`.
-
-### 6. Monty
-
-Execute in [Monty](https://github.com/pydantic/monty), a secure in-process Python
-interpreter — ideal for short, safe LLM snippets. No credentials required.
-
-```bash
-pip install "jupyter-mcp-server[monty]"
-```
-
-```json
-"env": {
-  "SANDBOX_VARIANT": "monty"
-}
-```
-
-> Monty supports only a subset of Python; third-party libraries and rich display
-> outputs are not available.
-
-### 7. Modal
-
-Execute in a [Modal](https://modal.com/docs/guide) cloud sandbox. Install the
-extra and configure Modal credentials:
-
-```bash
-pip install "jupyter-mcp-server[modal]"
-modal token new
-```
-
-For local development, `modal token new` is usually enough because the Modal SDK
-loads credentials from `~/.modal.toml`.
-
-If you run in CI/CD, containers, or hosted runners, set both environment
-variables below.
-
-```json
-"env": {
-  "SANDBOX_VARIANT": "modal",
-  "MODAL_TOKEN_ID": "ak-...",
-  "MODAL_TOKEN_SECRET": "as-..."
-}
-```
-
-Why both variables? Modal uses a token pair for environment-based auth:
-
-- `MODAL_TOKEN_ID`: public token identifier.
-- `MODAL_TOKEN_SECRET`: secret half paired with that id.
-
-Providing only one is insufficient for authentication.
-
-If needed, export both values from your local Modal config:
-
-```bash
-python - <<'PY'
-import pathlib
-import tomllib
-
-cfg = tomllib.loads(pathlib.Path("~/.modal.toml").expanduser().read_text())
-profile = cfg.get("default", cfg)
-token_id = profile.get("token_id")
-token_secret = profile.get("token_secret")
-if token_id and token_secret:
-    print(f"export MODAL_TOKEN_ID={token_id}")
-    print(f"export MODAL_TOKEN_SECRET={token_secret}")
-else:
-    raise SystemExit("Could not find token_id/token_secret in ~/.modal.toml")
-PY
-```
-
-### 8. Daytona
-
-Execute in a [Daytona](https://www.daytona.io/docs/) cloud sandbox. Install the
-extra and provide a Daytona API key:
-
-```bash
-pip install "jupyter-mcp-server[daytona]"
-```
-
-```json
-"env": {
-  "SANDBOX_VARIANT": "daytona",
-  "DAYTONA_API_KEY": "your-daytona-api-key"
-}
-```
-
-Instead of an API key you can authenticate with a JWT token, which Daytona reads
-together with the organization it belongs to:
-
-```json
-"env": {
-  "SANDBOX_VARIANT": "daytona",
-  "DAYTONA_JWT_TOKEN": "your-daytona-jwt-token",
-  "DAYTONA_ORGANIZATION_ID": "your-daytona-organization-id"
-}
-```
-
-Ask for a GPU with `SANDBOX_GPU` (for example `H100`, `H200`, `RTX-4090`).
-Daytona also sells preemptible ("spot") GPU capacity, which is chosen through the
-`code-sandboxes` API rather than a `SANDBOX_*` variable.
-
-> Daytona's code interpreter holds a namespace, so variables set in one call are
-> still there in the next. Rich display data (figures, HTML) is not returned.
-
-### 9. E2B
-
-Execute in an [E2B](https://docs.e2b.dev/client) sandbox. Install the extra and
-provide an E2B API key:
-
-```bash
-pip install "jupyter-mcp-server[e2b]"
-```
-
-```json
-"env": {
-  "SANDBOX_VARIANT": "e2b",
-  "E2B_API_KEY": "your-e2b-api-key"
-}
-```
-
-Set `E2B_DOMAIN` to reach an E2B deployment other than the default `e2b.dev`.
-
-The sandbox is created from E2B's `code-interpreter-v1` template, which is the one
-carrying the Jupyter kernel the code interpreter talks to.
-
-> Each execution context is a Jupyter kernel, so state persists across calls, and
-> rich outputs — figures, HTML — come back as results.
-
-### 10. CoreWeave
-
-Execute in a [CoreWeave Sandbox](https://docs.coreweave.com/products/sandboxes),
-a container on CoreWeave's GPU cloud. Install the extra and provide a CoreWeave
-Sandboxes API key:
-
-```bash
-pip install "jupyter-mcp-server[coreweave]"
-```
-
-```json
-"env": {
-  "SANDBOX_VARIANT": "coreweave",
-  "CWSANDBOX_API_KEY": "your-coreweave-api-key",
-  "SANDBOX_GPU": "H100"
-}
-```
-
-`SANDBOX_GPU` is optional; without it the sandbox is a plain container. Set
-`CWSANDBOX_BASE_URL` to reach an endpoint other than the default
-`https://api.cwsandbox.com`.
-
-> State is kept by a session process the variant holds open on stdin. If that
-> process cannot start, each snippet runs in a process of its own and variables do
-> not carry over. Rich display data is not returned.
-
-### 11. Cloudflare
-
-Execute in a [Cloudflare Sandbox](https://developers.cloudflare.com/sandbox/).
-Cloudflare's own SDK is a TypeScript Workers binding, which a Python process
-cannot hold, so this variant drives the **sandbox bridge** — a reference Worker
-Cloudflare publishes that exposes the SDK over HTTP. Deploy it once:
-
-```bash
-npm create cloudflare -- sandbox-bridge \
-  --template=cloudflare/sandbox-sdk/bridge/worker
-```
-
-The deployment returns the bridge's `workers.dev` URL and generates the key it
-accepts. Both are required:
-
-```bash
-pip install "jupyter-mcp-server[cloudflare]"
-```
-
-```json
-"env": {
-  "SANDBOX_VARIANT": "cloudflare",
-  "CLOUDFLARE_SANDBOX_API_URL": "https://sandbox-bridge.your-subdomain.workers.dev",
-  "CLOUDFLARE_SANDBOX_API_KEY": "your-bridge-api-key"
-}
-```
-
-See the [sandbox bridge documentation](https://developers.cloudflare.com/sandbox/bridge/)
-for the Worker itself.
-
-> Each snippet runs in a process of its own, so `x = 1` is gone by the next call.
-> Combine statements into a single cell, or keep state in a file — the filesystem
-> persists. Rich display data is not returned.
-
-> You can also select the engine on the command line with
-> `--sandbox-variant`, `--code-sandbox-proxy-token`, and `--sandbox-environment`.
+| Engine | `SANDBOX_VARIANT` | Extra install | Key variables | Docs |
+| ------ | ----------------- | ------------- | ------------- | ---- |
+| Jupyter Server (default) | `jupyter-server` | — | `JUPYTER_URL`, `JUPYTER_TOKEN` | [Setup](https://jupyter-mcp-server.datalayer.tech/code-sandboxes/jupyter-server) |
+| JupyterHub | `jupyter-server` | — | `CODE_SANDBOX_URL`, `CODE_SANDBOX_TOKEN` | [Setup](https://jupyter-mcp-server.datalayer.tech/code-sandboxes/jupyterhub) |
+| Datalayer | `datalayer` | `jupyter-mcp-server[datalayer]` | `CODE_SANDBOX_URL`, `CODE_SANDBOX_TOKEN`, `SANDBOX_ENVIRONMENT` | [Setup](https://jupyter-mcp-server.datalayer.tech/code-sandboxes/datalayer) |
+| Kaggle | `kaggle` | `jupyter-mcp-server[kaggle]` | Kaggle credentials, or `CODE_SANDBOX_URL` for interactive mode | [Setup](https://jupyter-mcp-server.datalayer.tech/code-sandboxes/kaggle) |
+| Google Colab | `google-colab` | `jupyter-mcp-server` | `CODE_SANDBOX_URL`, `CODE_SANDBOX_ID`, `CODE_SANDBOX_PROXY_TOKEN` | [Setup](https://jupyter-mcp-server.datalayer.tech/code-sandboxes/google-colab) |
+| Monty | `monty` | `jupyter-mcp-server[monty]` | — | [Setup](https://jupyter-mcp-server.datalayer.tech/code-sandboxes/monty) |
+| Modal | `modal` | `jupyter-mcp-server[modal]` | Modal credentials | [Setup](https://jupyter-mcp-server.datalayer.tech/code-sandboxes/modal) |
+| Daytona | `daytona` | `jupyter-mcp-server[daytona]` | `DAYTONA_API_KEY`, or `DAYTONA_JWT_TOKEN` + `DAYTONA_ORGANIZATION_ID` | [Setup](https://jupyter-mcp-server.datalayer.tech/code-sandboxes/daytona) |
+| E2B | `e2b` | `jupyter-mcp-server[e2b]` | `E2B_API_KEY` | [Setup](https://jupyter-mcp-server.datalayer.tech/code-sandboxes/e2b) |
+| CoreWeave | `coreweave` | `jupyter-mcp-server[coreweave]` | `CWSANDBOX_API_KEY` | [Setup](https://jupyter-mcp-server.datalayer.tech/code-sandboxes/coreweave) |
+| Cloudflare | `cloudflare` | `jupyter-mcp-server[cloudflare]` | `CLOUDFLARE_SANDBOX_API_URL`, `CLOUDFLARE_SANDBOX_API_KEY` | [Setup](https://jupyter-mcp-server.datalayer.tech/code-sandboxes/cloudflare) |
+
+Each engine has its own page with the credentials it needs, the accelerator options it
+accepts and a worked client configuration — start from
+[**jupyter-mcp-server.datalayer.tech/code-sandboxes**](https://jupyter-mcp-server.datalayer.tech/code-sandboxes).
 
 ## 🧪 Testing
 

--- a/dev/bump_version.py
+++ b/dev/bump_version.py
@@ -1,0 +1,199 @@
+#!/usr/bin/env python3
+# Copyright (c) 2024- Datalayer, Inc.
+#
+# BSD 3-Clause License
+
+"""Bump the version, in every file that carries a copy of it.
+
+The version lives in four places. `pyproject.toml` does **not** carry a
+fifth: hatch reads it from `__version__.py`, which is why that file is the
+one this script treats as the source of truth — the others are copies, and a
+copy that gets missed ships a package whose manifest disagrees with the
+module it installs.
+
+    python dev/bump_version.py patch     # 2.1.3 -> 2.1.4
+    python dev/bump_version.py minor     # 2.1.3 -> 2.2.0
+    python dev/bump_version.py major     # 2.1.3 -> 3.0.0
+    python dev/bump_version.py           # asks
+
+Nothing is written unless **every** file can be updated. A run that bumped
+two of four and then hit a file whose format had changed would leave the tree
+in a state where the next `make build` produces a package that is wrong in a
+way nobody looks at. Either all of them move or none do.
+
+@module dev.bump_version
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+
+#: The file the version is read *from*. Hatch reads it too
+#: (`[tool.hatch.version] path`), which is what makes it the source rather
+#: than a fourth copy.
+SOURCE = ROOT / "jupyter_mcp_server" / "__version__.py"
+
+PARTS = ("major", "minor", "patch")
+
+
+class Unbumpable(Exception):
+    """A file this script cannot update, named with what it expected.
+
+    Raised before anything is written. The alternative — updating what it
+    can and reporting the rest — is how a release goes out with a manifest
+    that disagrees with the module.
+    """
+
+
+def read_version() -> str:
+    text = SOURCE.read_text()
+    match = re.search(r'__version__\s*=\s*"([^"]+)"', text)
+    if match is None:
+        raise Unbumpable(f"{SOURCE.relative_to(ROOT)} has no __version__ = \"...\"")
+    return match.group(1)
+
+
+def bump(version: str, part: str) -> str:
+    """The next version, or a refusal naming what it could not read.
+
+    Only `major.minor.patch`. A pre-release or a build tag would need rules
+    about what bumping means for it — does `2.2.0rc1` patch to `2.2.0rc2` or
+    to `2.2.1`? — and guessing one is worse than saying so.
+    """
+    match = re.fullmatch(r"(\d+)\.(\d+)\.(\d+)", version)
+    if match is None:
+        raise Unbumpable(
+            f"{version!r} is not major.minor.patch; bump it by hand and say "
+            "here what the next one should be"
+        )
+    major, minor, patch = (int(value) for value in match.groups())
+    if part == "major":
+        return f"{major + 1}.0.0"
+    if part == "minor":
+        return f"{major}.{minor + 1}.0"
+    return f"{major}.{minor}.{patch + 1}"
+
+
+def _replace_once(path: Path, pattern: str, replacement: str, current: str) -> str:
+    """One substitution, refusing zero and refusing more than one.
+
+    Zero means the file's format changed and this script is now editing
+    nothing while reporting success. More than one means the pattern is
+    matching something else as well — a dependency's version, say — and
+    rewriting it would be a silent, wrong edit in a file nobody diffs.
+    """
+    text = path.read_text()
+    # Multiline: the TOML pattern anchors `version =` to the start of a line,
+    # which is what keeps it off `python-version` and off a dependency's pin.
+    found = re.findall(pattern, text, flags=re.M)
+    if len(found) != 1:
+        raise Unbumpable(
+            f"{path.relative_to(ROOT)}: expected exactly one "
+            f"{current!r} matching {pattern!r}, found {len(found)}"
+        )
+    return re.sub(pattern, replacement, text, count=1, flags=re.M)
+
+
+def planned_edits(current: str, new: str) -> dict[Path, str]:
+    """Every file's new content, or an exception. Nothing is written here."""
+    escaped = re.escape(current)
+    edits: dict[Path, str] = {}
+
+    edits[SOURCE] = _replace_once(
+        SOURCE,
+        rf'(__version__\s*=\s*")({escaped})(")',
+        rf"\g<1>{new}\g<3>",
+        current,
+    )
+
+    manifest = ROOT / "extensions" / "mcpb" / "manifest.json"
+    edits[manifest] = _replace_once(
+        manifest,
+        rf'("version"\s*:\s*")({escaped})(")',
+        rf"\g<1>{new}\g<3>",
+        current,
+    )
+
+    mcpb_pyproject = ROOT / "extensions" / "mcpb" / "pyproject.toml"
+    edits[mcpb_pyproject] = _replace_once(
+        mcpb_pyproject,
+        rf'(^version\s*=\s*")({escaped})(")',
+        rf"\g<1>{new}\g<3>",
+        current,
+    )
+
+    # The published server card. Its `version` is the *server's*, nested
+    # under `server`; the file also carries `mcpSpec` and `mcpVersion`, which
+    # are the protocol's and must not move with a release of ours.
+    sourcey = ROOT / "docs" / "sourcey" / "mcp.json"
+    edits[sourcey] = _replace_once(
+        sourcey,
+        rf'("version"\s*:\s*")({escaped})(")',
+        rf"\g<1>{new}\g<3>",
+        current,
+    )
+
+    return edits
+
+
+def check_json(edits: dict[Path, str]) -> None:
+    """Every JSON file still parses. A regex that produced valid-looking but
+    broken JSON would be found by whoever installs the extension."""
+    for path, text in edits.items():
+        if path.suffix == ".json":
+            try:
+                json.loads(text)
+            except ValueError as error:
+                raise Unbumpable(f"{path.relative_to(ROOT)} would not parse: {error}")
+
+
+def ask() -> str:
+    print(f"Current version: {read_version()}")
+    for index, part in enumerate(PARTS, start=1):
+        print(f"  {index}) {part:5s} -> {bump(read_version(), part)}")
+    while True:
+        answer = input("Which? [major/minor/patch] ").strip().lower()
+        if answer in PARTS:
+            return answer
+        if answer in ("1", "2", "3"):
+            return PARTS[int(answer) - 1]
+        print(f"Say one of: {', '.join(PARTS)}")
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument("part", nargs="?", choices=PARTS, help="what to bump")
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="say what would change and write nothing",
+    )
+    arguments = parser.parse_args(argv)
+
+    try:
+        current = read_version()
+        part = arguments.part or ask()
+        new = bump(current, part)
+        edits = planned_edits(current, new)
+        check_json(edits)
+    except Unbumpable as error:
+        print(f"Refused: {error}", file=sys.stderr)
+        print("Nothing was written.", file=sys.stderr)
+        return 1
+
+    for path, text in sorted(edits.items()):
+        if not arguments.dry_run:
+            path.write_text(text)
+        print(f"{'would bump' if arguments.dry_run else 'bumped'} {path.relative_to(ROOT)}")
+    print(f"{current} -> {new}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/docs/docs/architecture/resources/_category_.yaml
+++ b/docs/docs/architecture/resources/_category_.yaml
@@ -1,0 +1,2 @@
+label: Resources
+position: 3

--- a/docs/docs/architecture/resources/index.mdx
+++ b/docs/docs/architecture/resources/index.mdx
@@ -1,0 +1,79 @@
+# Resources
+
+Tools **push**. Everything a call produces comes back whether the agent wanted
+it or not, so a cell that printed a megabyte spends a megabyte of the client's
+context every time anybody reads it.
+
+Resources **pull**. The agent is told what exists and reads the one thing it
+needs.
+
+That is what these three are for.
+
+| Resource | What it is |
+|---|---|
+| `notebook://{name}` | A notebook in use, as nbformat JSON |
+| `notebook://{name}/cells/{cell_id}` | One cell, with its outputs *listed* |
+| `notebook://{name}/cells/{cell_id}/outputs/{index}` | One output, on its own |
+
+## Addressed by name and cell id
+
+A notebook path contains slashes. It cannot sit in one URI template segment
+without being encoded into something nobody can read, and the **name** is what
+every tool here already takes — the one `use_notebook` registered.
+
+A cell is addressed by its nbformat 4.5 **id**, not its index. An index is a
+position in a document somebody else is editing: between reading a notebook
+and reading "cell 4", cell 4 may be a different cell. The id is not.
+
+:::note The scheme is provider-neutral
+
+This server talks to a Jupyter server. A `datalayer://` URI here would be a
+hosted platform's identifier on a resource that has nothing to do with it.
+:::
+
+## A cell lists its outputs and inlines none of them
+
+```json
+{
+  "id": "c1",
+  "index": 0,
+  "cell_type": "code",
+  "source": ["print('hello')"],
+  "outputs": [
+    {"index": 0, "mimeType": "text/plain", "uri": "notebook://work/cells/c1/outputs/0"},
+    {"index": 1, "mimeType": "image/png", "uri": "notebook://work/cells/c1/outputs/1"}
+  ]
+}
+```
+
+Reading the cell tells an agent what the cell produced, what type each output
+is and where to get it — for the cost of that table. An agent that only needed
+to know the cell succeeded stops there.
+
+The output resource's audience is the **assistant** alone. A person reads
+outputs in their notebook, where they are rendered, not through a URI.
+
+:::warning The MIME type is on the list, not on the read
+
+A templated resource's type is fixed when it is registered, so an output
+cannot answer with its own type on the read. It is on the cell's output list
+instead — which is where an agent that needs to know what an output *is*
+before spending context on it actually looks.
+
+The richest type wins there: `text/plain` is the fallback every kernel
+attaches beside the real thing, and preferring it would read every figure as
+the words `<Figure>` with nothing saying so.
+:::
+
+## Caching
+
+All three are `cacheScope: private`. A notebook is one caller's, and a proxy
+that shared the answer would hand somebody else's work to whoever asked next.
+
+The notebook and cell are held for 5 seconds — long enough that reading a
+notebook and then three of its cells does not fetch the document four times,
+short enough that an agent watching a cell run sees it change.
+
+An **output** is held for a minute, because it does not change. A re-run
+*replaces* a cell's outputs rather than editing one, and the new ones are at
+new positions under a cell whose id is the same.

--- a/docs/docs/architecture/resources/index.mdx
+++ b/docs/docs/architecture/resources/index.mdx
@@ -100,6 +100,31 @@ handler. `get_capabilities` derives the capability from whether
 and at 2025-11-25 it is not.
 :::
 
+## Both eras
+
+At 2025-11-25 a client asks with `resources/subscribe` instead, and this
+server serves it — which is also what makes `resources.subscribe` true in
+that handshake, since the SDK derives the capability from whether the handler
+exists.
+
+Both halves are told on every change. A client on each era is two clients,
+and sending only on the wire the last subscriber used would leave the other
+silent — a bug that appears only when two are connected.
+
+:::note Sessions are held weakly
+
+A session that goes away takes its subscriptions with it. The alternative is
+an unsubscribe hook that has to fire on every way a connection can end,
+including the ones that run no code, and a subscription nobody can reach is a
+notification sent for ever to nobody.
+
+A send that fails drops the session rather than retrying it for ever.
+:::
+
+Unsubscribing from something never subscribed is **not** an error. The
+client's intent — *stop telling me about this* — is satisfied either way, and
+refusing it teaches a client to retry something that is already true.
+
 The event is published **after** the tool has done its work and returned. A
 subscriber told a cell changed before it did refetches the old document and
 caches it as new.

--- a/docs/docs/architecture/resources/index.mdx
+++ b/docs/docs/architecture/resources/index.mdx
@@ -141,3 +141,63 @@ no live document to observe. That needs a persistent connection per
 subscribed notebook, with its own lifecycle, and it is a different kind of
 thing from this.
 :::
+
+## Seams for a deployment
+
+This package is scaffolding. What a *deployment* does with these mechanisms is
+its own, and it says so the way it already does for the audit sink, the token
+verifier and the task store: an environment variable naming a class.
+
+| Variable | What it replaces |
+|---|---|
+| `JUPYTER_MCP_PUBLISHER_CLASS` | Where `resources/updated` is published |
+| `JUPYTER_MCP_RESOURCE_GATE_CLASS` | Which of these resources are served |
+
+Both default to the behaviour that makes this server work unconfigured. A
+server that needs configuration before it will serve a resource is a server
+that does not work out of the box.
+
+### Why a publisher seam
+
+The SDK's bus reaches clients attached to **this process**. That is the whole
+story for a server somebody runs on their laptop, and no story at all behind
+several replicas: a client attached to one replica never hears an edit made
+through another.
+
+A deployment that configures a publisher replaces the bus rather than adding
+to it — it is a deployment where this process is not where the subscribers
+are, so publishing to both would send half the event twice.
+
+```python
+class MyPublisher:
+    async def publish(self, uri: str) -> bool:
+        ...
+```
+
+### Why a gate
+
+A deployment that addresses notebooks by its own identifiers serves its own
+resources and does not want these. `notebook://{name}` is the name a *worker*
+knows, and such a deployment's clients have never seen one.
+
+```python
+class MyGate:
+    def serves(self, uri_template: str) -> bool:
+        ...
+```
+
+A withheld resource raises `ResourceWithheld`, not `ResourceNotFound`. *We do
+not answer this here* and *there is no such cell* are different answers, and a
+client told the second when the first is true goes looking for a cell it will
+never find.
+
+:::note A misconfigured seam is fatal; a broken one is not
+
+A class that cannot be imported or built stops the server, for the reason the
+audit sink gives: a deployment that configured delivery and got a server
+running without it believes subscribers are being told, and they are not.
+
+A gate that *raises when asked* serves the resource instead. That is the safe
+direction for a scaffold — the alternative is a server that silently answers
+nothing and looks like a server with no resources.
+:::

--- a/docs/docs/architecture/resources/index.mdx
+++ b/docs/docs/architecture/resources/index.mdx
@@ -77,3 +77,42 @@ short enough that an agent watching a cell run sees it change.
 An **output** is held for a minute, because it does not change. A re-run
 *replaces* a cell's outputs rather than editing one, and the new ones are at
 new positions under a cell whose id is the same.
+
+## Change notifications
+
+A client that opens `subscriptions/listen` and names `notebook://{name}` in
+its `resource_subscriptions` is told when that notebook changes.
+
+One worker serves one user, and that user may have several agents — so the
+case this is for is ordinary rather than exotic: agent A edits a cell, agent B
+is subscribed, and B finds out through the same process with no polling.
+
+:::note The channel is the SDK's
+
+At 2026-07-28 the SDK serves `subscriptions/listen`, acknowledges the subset
+of the filter it will honour, and streams matching events. It even ships the
+bus. What was missing was anybody publishing onto it.
+
+Worth knowing, because the obvious reading of "implement subscriptions" is to
+write `resources/subscribe` — and on the modern wire the SDK **ignores** that
+handler. `get_capabilities` derives the capability from whether
+`subscriptions/listen` is served, so at 2026-07-28 subscription is available
+and at 2025-11-25 it is not.
+:::
+
+The event is published **after** the tool has done its work and returned. A
+subscriber told a cell changed before it did refetches the old document and
+caches it as new.
+
+It never fails the edit. Failing an edit because the news about the edit would
+not go out trades the work for the story about the work — the same call the
+tasks extension makes about its status notifications.
+
+:::warning A change by somebody else is not covered
+
+This announces what *this worker* changed. A person typing in JupyterLab is
+not seen: notebook connections here are per call, so between calls there is
+no live document to observe. That needs a persistent connection per
+subscribed notebook, with its own lifecycle, and it is a different kind of
+thing from this.
+:::

--- a/docs/docs/architecture/tasks/index.mdx
+++ b/docs/docs/architecture/tasks/index.mdx
@@ -130,8 +130,15 @@ Outside a task this answers `False` and does nothing, which is right: a
 synchronous call has the client on the other end of the connection, and the
 client can drop it.
 
-The cell execution loop registers the kernel's interrupt, so cancelling a
-task that is running a cell stops the cell.
+**Every** loop that waits for a cell registers it — `execute_cell` in both
+its streaming and non-streaming forms, and `execute_code` — so cancelling a
+task that is running a cell stops the cell whichever tool started it.
+
+That is worth stating because it was not true. `execute_cell(stream=True)`
+runs a monitor loop of its own, and it is the documented mode for
+long-running cells, so it is the one most likely to be cancelled: it had
+neither hook while the other loop had both. A test now finds the loops by
+shape rather than by name, so a fourth is covered on the day it is written.
 
 ## A cancelled task keeps what it produced
 

--- a/docs/docs/architecture/tasks/index.mdx
+++ b/docs/docs/architecture/tasks/index.mdx
@@ -130,6 +130,44 @@ Outside a task this answers `False` and does nothing, which is right: a
 synchronous call has the client on the other end of the connection, and the
 client can drop it.
 
+The cell execution loop registers the kernel's interrupt, so cancelling a
+task that is running a cell stops the cell.
+
+## A cancelled task keeps what it produced
+
+`result` arrives whole when the tool returns. That is the right shape for a
+call that finishes and no shape at all for one that does not: cancel a
+ten-minute cell at minute nine and the task is `cancelled` with no result,
+though the cell printed five hundred lines — and those lines are exactly what
+the person who cancelled it wanted to read.
+
+So a tool that produces output as it goes says so:
+
+```python
+from jupyter_mcp_server.tasks import record_output
+
+await record_output(outputs_so_far)
+```
+
+It **replaces** rather than appends: the caller holds the whole list of
+outputs so far, and appending would make every reader deduplicate what it
+reads. Outside a task it answers `False` and does nothing, for the same
+reason `register_interrupt` does.
+
+On cancellation the partial output becomes the result — the task is terminal,
+so `tasks/result` serves it. A task that produced nothing keeps no result:
+an empty list there would read as a measured zero rather than as nothing to
+measure, which is the distinction the two refusals above exist for.
+
+A tool's own result always wins. If the call returned while the cancellation
+was landing, the complete answer is not replaced by the half that was visible
+a moment earlier.
+
+A **failed** task keeps its partial output too, though `tasks/result` raises
+for it: a cell that printed for nine minutes and then raised has the output
+somebody needs in order to see *why*, and discarding it at the moment of
+failure discards the diagnosis.
+
 An interrupt that fails does not stop the cancellation. Half of what the
 client asked for is better than none of it, and the failure is logged at
 error — a kernel that could not be interrupted is a sandbox somebody has to

--- a/docs/docs/code-sandboxes/datalayer/index.mdx
+++ b/docs/docs/code-sandboxes/datalayer/index.mdx
@@ -48,6 +48,25 @@ SANDBOX_VARIANT=datalayer
 DATALAYER_API_KEY=your-datalayer-token
 ```
 
+The engine reads `DATALAYER_API_KEY` itself. The server also accepts the
+sandbox-neutral spelling, which is what `--code-sandbox-url` and
+`--code-sandbox-token` set and what the other sandboxes use:
+
+| Environment variable | Description |
+|----------------------|-------------|
+| `CODE_SANDBOX_URL` | Datalayer service URL, e.g. `https://prod1.datalayer.run` |
+| `CODE_SANDBOX_TOKEN` | Datalayer API token |
+| `SANDBOX_ENVIRONMENT` | Environment to launch, e.g. `python-cpu-env` |
+
+```json
+"env": {
+  "SANDBOX_VARIANT": "datalayer",
+  "CODE_SANDBOX_URL": "https://prod1.datalayer.run",
+  "CODE_SANDBOX_TOKEN": "your-datalayer-token",
+  "SANDBOX_ENVIRONMENT": "python-cpu-env"
+}
+```
+
 MCP client configuration:
 
 ```json

--- a/docs/docs/code-sandboxes/jupyterhub/index.mdx
+++ b/docs/docs/code-sandboxes/jupyterhub/index.mdx
@@ -93,6 +93,26 @@ http://localhost:8000/user/<username>/mcp
 ```
 :::
 
+### 5. Alternative: a local server pointed at JupyterHub
+
+Everything above runs the MCP server *inside* the single-user server. The other
+way round works too: run `jupyter-mcp-server` locally over STDIO and point it at a
+user's single-user server. It uses the same `jupyter-server` engine, and the same
+API token with the `access:servers` scope:
+
+```json
+"env": {
+  "CODE_SANDBOX_URL": "https://your-jupyterhub.domain/user/<username>",
+  "CODE_SANDBOX_TOKEN": "your-jupyterhub-api-token",
+  "DOCUMENT_URL": "https://your-jupyterhub.domain/user/<username>",
+  "DOCUMENT_TOKEN": "your-jupyterhub-api-token"
+}
+```
+
+`CODE_SANDBOX_*` reaches the kernel, `DOCUMENT_*` reaches the notebook documents;
+they are separate so the two can live behind different URLs, and for JupyterHub
+they are the same.
+
 ## Production Considerations
 
 ### Security

--- a/docs/sourcey/README.md
+++ b/docs/sourcey/README.md
@@ -40,14 +40,14 @@ That runs `npm install` in `docs/` — which a monorepo-wide install does not co
 `docs/` is not one of the workspaces — then the four steps below, checking that step 1
 produced a usable `mcp.json` before the steps that read it.
 
-It also refuses to run in an environment that registers `jupyter_mcp_server.extensions`
-entry points beyond `sandboxes`. The snapshot is whatever the *installed* server
-advertises, so an extra extension silently changes it —
-`datalayer_jupyter_mcp_server`'s `spaces` adds `find_notebook` and `list_spaces` and its
-tool policy hides `connect_to_jupyter`, `list_files` and `list_kernels` — and the result
-is a reference CI can never reproduce, since it installs only this package and
-`extensions/sandboxes`. Use a clean environment, or set
-`SOURCEY_ALLOW_EXTRA_EXTENSIONS=1` if you know what you are doing.
+It also pins which extensions load. The snapshot is whatever the *installed* server
+advertises, so an unrelated extension installed beside it silently changes the reference:
+`datalayer_jupyter_mcp_server`'s `spaces` adds `find_notebook` and `list_spaces`, and its
+tool policy hides `connect_to_jupyter`, `list_files` and `list_kernels` — 21 tools where
+CI, which installs only this package and `extensions/sandboxes`, sees 22. The target sets
+`JUPYTER_MCP_EXTENSIONS` to the entry-point names this repo's own `pyproject.toml` files
+declare, so it reproduces CI's surface from any development environment, and adding an
+extension to `extensions/` needs no change here.
 
 The steps it runs, if you would rather drive them by hand:
 

--- a/docs/sourcey/README.md
+++ b/docs/sourcey/README.md
@@ -30,8 +30,26 @@ the code.
 
 ## Regenerating after the MCP surface changes
 
-From a checkout with the package (and `extensions/sandboxes`) installed, and `npm install`
-already run in `docs/`:
+From the repository root, with the package (and `extensions/sandboxes`) installed:
+
+```bash
+make sync-sourcey
+```
+
+That runs `npm install` in `docs/` — which a monorepo-wide install does not cover, since
+`docs/` is not one of the workspaces — then the four steps below, checking that step 1
+produced a usable `mcp.json` before the steps that read it.
+
+It also refuses to run in an environment that registers `jupyter_mcp_server.extensions`
+entry points beyond `sandboxes`. The snapshot is whatever the *installed* server
+advertises, so an extra extension silently changes it —
+`datalayer_jupyter_mcp_server`'s `spaces` adds `find_notebook` and `list_spaces` and its
+tool policy hides `connect_to_jupyter`, `list_files` and `list_kernels` — and the result
+is a reference CI can never reproduce, since it installs only this package and
+`extensions/sandboxes`. Use a clean environment, or set
+`SOURCEY_ALLOW_EXTRA_EXTENSIONS=1` if you know what you are doing.
+
+The steps it runs, if you would rather drive them by hand:
 
 ```bash
 cd docs/sourcey

--- a/docs/sourcey/mcp.json
+++ b/docs/sourcey/mcp.json
@@ -7,12 +7,13 @@
   },
   "capabilities": {
     "experimental": {},
+    "logging": {},
     "prompts": {
       "listChanged": false
     },
     "resources": {
       "listChanged": false,
-      "subscribe": false
+      "subscribe": true
     },
     "tools": {
       "listChanged": false
@@ -1757,6 +1758,61 @@
       "mimeType": "text/plain",
       "name": "capabilities_resource",
       "uri": "capabilities://"
+    }
+  ],
+  "resourceTemplates": [
+    {
+      "_meta": {
+        "io.modelcontextprotocol/cache": {
+          "ttlMs": 5000,
+          "cacheScope": "private"
+        }
+      },
+      "annotations": {
+        "audience": [
+          "assistant",
+          "user"
+        ]
+      },
+      "description": "A notebook in use, as nbformat JSON. Cells and outputs are resources of their own.",
+      "mimeType": "application/x-ipynb+json",
+      "name": "notebook",
+      "uriTemplate": "notebook://{name}"
+    },
+    {
+      "_meta": {
+        "io.modelcontextprotocol/cache": {
+          "ttlMs": 5000,
+          "cacheScope": "private"
+        }
+      },
+      "annotations": {
+        "audience": [
+          "assistant",
+          "user"
+        ]
+      },
+      "description": "One cell by its nbformat id, with its outputs listed rather than inlined.",
+      "mimeType": "application/json",
+      "name": "notebook-cell",
+      "uriTemplate": "notebook://{name}/cells/{cell_id}"
+    },
+    {
+      "_meta": {
+        "io.modelcontextprotocol/cache": {
+          "ttlMs": 60000,
+          "cacheScope": "private"
+        }
+      },
+      "annotations": {
+        "audience": [
+          "assistant"
+        ]
+      },
+      "description": "One output of one cell, with its own MIME type. Read it only if you need the bytes.",
+      "mimeType": "text/plain",
+      "name": "notebook-cell-output",
+      "uriTemplate": "notebook://{name}/cells/{cell_id}/outputs/{index}"
     }
   ],
   "prompts": [

--- a/docs/sourcey/snapshot.mjs
+++ b/docs/sourcey/snapshot.mjs
@@ -78,14 +78,26 @@ for (const d of result.diagnostics ?? []) {
   console.error(`${d.severity}: ${d.path} - ${d.message}`);
 }
 await writeFile(out, JSON.stringify(spec, null, 2) + "\n");
-console.log(
-  JSON.stringify({
-    valid: result.valid,
-    server: spec.server,
-    mcpVersion: spec.mcpVersion,
-    tools: spec.tools?.length ?? 0,
-    resources: spec.resources?.length ?? 0,
-    resourceTemplates: spec.resourceTemplates?.length ?? 0,
-    prompts: spec.prompts?.length ?? 0,
-  }),
-);
+const summary = JSON.stringify({
+  valid: result.valid,
+  server: spec.server,
+  mcpVersion: spec.mcpVersion,
+  tools: spec.tools?.length ?? 0,
+  resources: spec.resources?.length ?? 0,
+  resourceTemplates: spec.resourceTemplates?.length ?? 0,
+  prompts: spec.prompts?.length ?? 0,
+});
+
+// Leave instead of waiting for the event loop to drain.
+//
+// mcp-parser 0.4.1 arms a `setTimeout(..., timeout)` for every request it sends
+// and never clears it once the reply lands (`connectStdio`'s `send`, in
+// dist/snapshot.js). Its `close()` kills the server process but not those
+// timers, so the loop stays alive for a further `timeout` after the snapshot is
+// complete and written — two minutes with the value above, which reads as a
+// hang because everything this script had to say is already on stdout.
+//
+// Flush before exiting: process.exit() truncates a pending write when stdout is
+// a pipe rather than a terminal, which is exactly how CI reads it.
+await new Promise((resolve) => process.stdout.write(summary + "\n", resolve));
+process.exit(0);

--- a/jupyter_mcp_server/client_logging.py
+++ b/jupyter_mcp_server/client_logging.py
@@ -1,0 +1,104 @@
+# Copyright (c) 2024- Datalayer, Inc.
+#
+# BSD 3-Clause License
+
+"""How much this server tells a client through `notifications/message`.
+
+A client sets a floor with `logging/setLevel` and gets everything at or above
+it. Without the method served, a client that sends it is refused `-32601` and
+has no way to turn the volume down — which matters because the alternative to
+turning it down is turning the connection off.
+
+**A level is per session, not per server.** Two agents of the same user share
+a worker; one debugging a notebook and one running a pipeline want different
+amounts, and a single global level would have the quiet one shouting or the
+loud one silent.
+
+**The default is `info`, and the default is a decision.** `debug` would send
+every client a stream it did not ask for and mostly cannot use, and the spec
+lets a server pick; `warning` would hide the progress notes a long cell
+sends, which are the ones somebody watching a ten-minute execution actually
+wants.
+
+@module jupyter_mcp_server.client_logging
+"""
+
+from __future__ import annotations
+
+import logging
+import weakref
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+#: The spec's levels, least to most severe. Order is the whole point: a floor
+#: is only meaningful against a sequence, and this is the sequence RFC 5424
+#: gives and the protocol adopts.
+LEVELS = (
+    "debug",
+    "info",
+    "notice",
+    "warning",
+    "error",
+    "critical",
+    "alert",
+    "emergency",
+)
+
+#: What a session gets before it asks.
+DEFAULT_LEVEL = "info"
+
+#: One floor per session, dropped when the session is.
+_LEVELS: "weakref.WeakKeyDictionary[Any, str]" = weakref.WeakKeyDictionary()
+
+
+def set_level(session: Any, level: str) -> bool:
+    """Remember this session's floor. Answers whether it was understood.
+
+    An unknown level is *not* stored and not raised on either: refusing the
+    call would be refusing a client for asking about a level a later
+    specification added, and storing it would silently mute the session,
+    because nothing would ever compare greater than a name with no position.
+    """
+    if session is None or level not in LEVELS:
+        if level not in LEVELS:
+            logger.debug("Ignoring an unknown logging level %r", level)
+        return False
+    _LEVELS[session] = level
+    return True
+
+
+def level_of(session: Any) -> str:
+    """This session's floor, or the default."""
+    if session is None:
+        return DEFAULT_LEVEL
+    return _LEVELS.get(session, DEFAULT_LEVEL)
+
+
+def should_send(session: Any, level: str) -> bool:
+    """Whether a message at this level clears the session's floor.
+
+    A message at an unknown level is sent rather than dropped. The failure
+    modes are not symmetric: sending something nobody wanted is noise, and
+    dropping something somebody needed is an outage they cannot see.
+    """
+    if level not in LEVELS:
+        return True
+    return LEVELS.index(level) >= LEVELS.index(level_of(session))
+
+
+async def log_to_client(session: Any, level: str, data: Any, *, source: str = "") -> bool:
+    """Send one message, if the session asked for that much.
+
+    Never raises. This is a note *about* work, sent from paths that are doing
+    the work — failing a cell because the note about the cell would not go
+    out trades the work for the story about the work.
+    """
+    if session is None or not should_send(session, level):
+        return False
+    try:
+        await session.send_log_message(level=level, data=data, logger=source or None)
+    except Exception as error:  # noqa: BLE001 - never in the way of the work
+        logger.debug("A log message could not be sent to the client: %s", error)
+        return False
+    return True

--- a/jupyter_mcp_server/extensions.py
+++ b/jupyter_mcp_server/extensions.py
@@ -23,6 +23,7 @@ which contributes the sandbox lifecycle tools and sandbox-backed execution.
 from __future__ import annotations
 
 import logging
+import os
 from importlib import metadata
 from typing import TYPE_CHECKING, Any, Optional
 
@@ -33,6 +34,11 @@ logger = logging.getLogger(__name__)
 
 #: Entry-point group used to discover installed extensions.
 ENTRY_POINT_GROUP = "jupyter_mcp_server.extensions"
+
+#: Comma-separated entry-point names to load, to the exclusion of everything
+#: else on the group. Unset or empty means every installed extension, which is
+#: what a server should normally do.
+EXTENSIONS_ENV = "JUPYTER_MCP_EXTENSIONS"
 
 
 class JupyterMCPExtension:
@@ -146,15 +152,34 @@ class ExtensionManager:
         may *replace* a tool another registered, and the SDK keeps the
         original when a name is registered twice. Sorting by name gives such
         an extension something it can rely on.
+
+        ``JUPYTER_MCP_EXTENSIONS`` narrows discovery to the entry-point names
+        it lists. What it is for: the tool surface a client sees is whatever
+        happens to be installed beside the server, so an environment carrying
+        an extra extension answers differently from a bare one — which is a
+        problem when the answer has to be reproducible, as it does for the
+        generated reference in ``docs/sourcey``. Unset, every installed
+        extension loads, which is what a server should normally do.
         """
         if self._discovered:
             return
         self._discovered = True
+        allowed = {
+            part.strip()
+            for part in (os.environ.get(EXTENSIONS_ENV) or "").split(",")
+            if part.strip()
+        }
         try:
             entry_points = metadata.entry_points(group=ENTRY_POINT_GROUP)
         except TypeError:  # pragma: no cover - Python < 3.10 compatibility
             entry_points = metadata.entry_points().get(ENTRY_POINT_GROUP, [])
         for entry_point in sorted(entry_points, key=lambda point: point.name):
+            if allowed and entry_point.name not in allowed:
+                logger.info(
+                    "Skipping Jupyter MCP extension '%s': %s selects %s",
+                    entry_point.name, EXTENSIONS_ENV, ", ".join(sorted(allowed)),
+                )
+                continue
             try:
                 factory = entry_point.load()
                 extension = factory() if callable(factory) else factory

--- a/jupyter_mcp_server/notifications.py
+++ b/jupyter_mcp_server/notifications.py
@@ -1,0 +1,119 @@
+# Copyright (c) 2024- Datalayer, Inc.
+#
+# BSD 3-Clause License
+
+"""Telling a subscribed client that a notebook changed.
+
+One worker serves one user, and that user may have several agents. So the
+case this exists for is ordinary rather than exotic: agent A edits a cell,
+agent B is subscribed to the notebook, and B finds out — through the same
+process, with no polling and no second connection.
+
+**The channel is the SDK's, not ours.** At 2026-07-28 a client opens
+`subscriptions/listen`, naming the notification types it wants and the
+resource URIs it cares about; the SDK acknowledges the subset it will honour
+and streams matching events. It even ships the bus. What is missing is
+somebody publishing onto it, which is all this module does.
+
+That matters because the obvious reading of "implement subscriptions" is to
+write `resources/subscribe`, and on the modern wire the SDK *ignores* that
+handler — `get_capabilities` derives the capability from whether
+`subscriptions/listen` is served, and the legacy method cannot be dispatched
+there at all.
+
+**What is not here**: a change made by somebody *else* — a person typing in
+JupyterLab. This server's notebook connections are per call, so between calls
+there is no live document to observe. That needs a persistent connection per
+subscribed notebook, with its own lifecycle, and it is a different kind of
+thing from this.
+
+@module jupyter_mcp_server.notifications
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+#: The result kinds that mean the document changed.
+#:
+#: Declared as the set that *mutates* rather than as "not the readers",
+#: because a new reading tool added to the negative version would start
+#: publishing spurious updates and nothing would say so. A new *writing* tool
+#: missing from this one publishes nothing, which is the harmless direction —
+#: and the test next door holds this against every kind the server declares,
+#: so neither stays wrong for long.
+MUTATING_KINDS = frozenset(
+    {
+        "cell.insert",
+        "cell.insert_execute",
+        "cell.edit",
+        "cell.overwrite",
+        "cell.delete",
+        "cell.move",
+        "cell.execute",
+        "cell.clear_output",
+    }
+)
+
+
+def notebook_uri(name: str) -> str:
+    """The resource URI of a notebook, as a client subscribed to it."""
+    return f"notebook://{name}"
+
+
+def target_notebook(keywords: dict[str, Any], current: Any) -> str:
+    """Which notebook a tool call changed.
+
+    The tool's own `notebook_name` when it named one, and the currently
+    activated notebook otherwise — the same resolution the tools use, because
+    a subscriber told the wrong notebook changed is worse than one told
+    nothing: it refetches the wrong document and believes it is current.
+    """
+    named = str(keywords.get("notebook_name") or "").strip()
+    if named:
+        return named
+    try:
+        return str(current() or "")
+    except Exception:  # noqa: BLE001 - no current notebook is not an error
+        return ""
+
+
+def _bus(server: Any) -> Any | None:
+    """The SDK's subscription bus, if this server has one.
+
+    Reached through the registered `subscriptions/listen` handler rather than
+    constructed: there is exactly one bus and the handler owns it, so making
+    a second one here would publish into a channel nobody is listening on.
+    """
+    try:
+        lowlevel = getattr(server, "_lowlevel_server", None)
+        entry = lowlevel._request_handlers.get("subscriptions/listen")
+        return getattr(entry.handler, "_bus", None) if entry else None
+    except Exception:  # noqa: BLE001 - an SDK without the stream is not an error
+        return None
+
+
+async def publish_notebook_updated(server: Any, name: str) -> bool:
+    """Say that this notebook changed. Answers whether anything was told.
+
+    Never raises. It runs after a tool has already done its work and
+    returned: failing the edit because the *news about* the edit would not go
+    out would trade the work for the story about the work, which is the same
+    call `tasks.py` makes about its status notifications.
+    """
+    if not name:
+        return False
+    bus = _bus(server)
+    if bus is None:
+        return False
+    try:
+        from mcp.server.subscriptions import ResourceUpdated  # noqa: PLC0415
+
+        await bus.publish(ResourceUpdated(uri=notebook_uri(name)))
+    except Exception as error:  # noqa: BLE001 - never in the way of the edit
+        logger.debug("A notebook update could not be published: %s", error)
+        return False
+    return True

--- a/jupyter_mcp_server/notifications.py
+++ b/jupyter_mcp_server/notifications.py
@@ -27,12 +27,23 @@ there is no live document to observe. That needs a persistent connection per
 subscribed notebook, with its own lifecycle, and it is a different kind of
 thing from this.
 
+**A seam, because the in-process bus is not always the right destination.**
+The SDK's bus reaches clients attached to *this* process, which is the whole
+story for a server somebody runs on their laptop and not the story at all for
+a deployment behind several replicas: a client attached to one replica never
+hears an edit made through another. `JUPYTER_MCP_PUBLISHER_CLASS` names a
+class that takes the event instead — the same shape as the audit-sink and
+token-verifier seams next door. Unset, the default here is used, so the
+open source server needs no configuration to work.
+
 @module jupyter_mcp_server.notifications
 """
 
 from __future__ import annotations
 
+import importlib
 import logging
+import os
 import weakref
 from typing import Any
 
@@ -117,6 +128,65 @@ def target_notebook(keywords: dict[str, Any], current: Any) -> str:
         return ""
 
 
+#: Names a class with ``async publish(uri) -> bool``, used instead of the
+#: in-process bus. See ``resolve_publisher``.
+PUBLISHER_CLASS_ENV = "JUPYTER_MCP_PUBLISHER_CLASS"
+
+_publisher: Any | None = None
+_publisher_resolved = False
+
+
+def resolve_publisher() -> Any | None:
+    """Build the configured publisher, or ``None`` for the in-process bus.
+
+    A named class that cannot be imported or built is **fatal**, for the
+    reason the audit sink gives: an operator who configured delivery and got
+    a server running without it has the worst of both — they believe
+    subscribers are being told, and they are not.
+
+    Resolved once. A class named per publish would be an import on the path
+    of every cell edit.
+    """
+    global _publisher, _publisher_resolved
+    if _publisher_resolved:
+        return _publisher
+    _publisher_resolved = True
+    path = (os.environ.get(PUBLISHER_CLASS_ENV) or "").strip()
+    if not path:
+        return None
+    module_name, _, attribute = path.rpartition(".")
+    if not module_name:
+        raise RuntimeError(
+            f"{PUBLISHER_CLASS_ENV} is {path!r}, which is not a module.Class path"
+        )
+    try:
+        module = importlib.import_module(module_name)
+        publisher_class = getattr(module, attribute)
+    except Exception as error:
+        raise RuntimeError(
+            f"{PUBLISHER_CLASS_ENV} names {path!r}, which could not be imported: {error}"
+        ) from error
+    try:
+        publisher = publisher_class()
+    except Exception as error:
+        raise RuntimeError(
+            f"{PUBLISHER_CLASS_ENV} names {path!r}, which could not be constructed: {error}"
+        ) from error
+    if not callable(getattr(publisher, "publish", None)):
+        raise RuntimeError(
+            f"{PUBLISHER_CLASS_ENV} names {path!r}, which has no publish(uri) method"
+        )
+    _publisher = publisher
+    return _publisher
+
+
+def use_publisher(replacement: Any | None) -> None:
+    """Swap the publisher — for the tests, and at startup."""
+    global _publisher, _publisher_resolved
+    _publisher = replacement
+    _publisher_resolved = replacement is not None
+
+
 def _bus(server: Any) -> Any | None:
     """The SDK's subscription bus, if this server has one.
 
@@ -142,6 +212,17 @@ async def publish_notebook_updated(server: Any, name: str) -> bool:
     """
     if not name:
         return False
+    # A configured publisher replaces the in-process bus entirely: a
+    # deployment that has one is a deployment where this process is not where
+    # the subscribers are, so publishing to both would be publishing half the
+    # event twice.
+    publisher = resolve_publisher()
+    if publisher is not None:
+        try:
+            return bool(await publisher.publish(notebook_uri(name)))
+        except Exception as error:  # noqa: BLE001 - never in the way of the edit
+            logger.debug("A notebook update could not be published: %s", error)
+            return False
     bus = _bus(server)
     if bus is None:
         return False

--- a/jupyter_mcp_server/notifications.py
+++ b/jupyter_mcp_server/notifications.py
@@ -33,6 +33,7 @@ thing from this.
 from __future__ import annotations
 
 import logging
+import weakref
 from typing import Any
 
 logger = logging.getLogger(__name__)
@@ -57,6 +58,41 @@ MUTATING_KINDS = frozenset(
         "cell.clear_output",
     }
 )
+
+
+#: Sessions that asked for a resource through the **legacy** method, and the
+#: URIs each asked about.
+#:
+#: A weak-keyed map, so a session that goes away takes its subscriptions with
+#: it. The alternative is an unsubscribe hook that has to fire on every way a
+#: connection can end — including the ones that do not run any code — and a
+#: subscription nobody can reach is a notification sent for ever to nobody.
+_LEGACY: "weakref.WeakKeyDictionary[Any, set[str]]" = weakref.WeakKeyDictionary()
+
+
+def legacy_subscribe(session: Any, uri: str) -> None:
+    """Remember that this session asked about this URI (2025-11-25)."""
+    if session is None or not uri:
+        return
+    _LEGACY.setdefault(session, set()).add(uri)
+
+
+def legacy_unsubscribe(session: Any, uri: str) -> None:
+    """Forget it. Unsubscribing from something never subscribed is not an
+    error: the client's intent — *do not tell me about this* — is satisfied
+    either way, and refusing it invites a client to retry."""
+    if session is None:
+        return
+    subscribed = _LEGACY.get(session)
+    if subscribed is not None:
+        subscribed.discard(uri)
+
+
+def legacy_subscribers(uri: str) -> list[Any]:
+    """The sessions to tell about this URI."""
+    return [
+        session for session, uris in list(_LEGACY.items()) if uri in uris
+    ]
 
 
 def notebook_uri(name: str) -> str:
@@ -109,11 +145,31 @@ async def publish_notebook_updated(server: Any, name: str) -> bool:
     bus = _bus(server)
     if bus is None:
         return False
+    told = False
     try:
         from mcp.server.subscriptions import ResourceUpdated  # noqa: PLC0415
 
         await bus.publish(ResourceUpdated(uri=notebook_uri(name)))
+        told = True
     except Exception as error:  # noqa: BLE001 - never in the way of the edit
         logger.debug("A notebook update could not be published: %s", error)
-        return False
-    return True
+    return await _tell_legacy_subscribers(notebook_uri(name)) or told
+
+
+async def _tell_legacy_subscribers(uri: str) -> bool:
+    """The 2025-11-25 half: one notification per subscribed session.
+
+    Both halves run, because both eras can be connected at once — this server
+    answers 2026-07-28 and 2025-11-25, and a client on each is two clients.
+    Sending only on the wire the *last* subscriber used would leave the other
+    silent, which is a bug that only appears when two clients are connected.
+    """
+    told = False
+    for session in legacy_subscribers(uri):
+        try:
+            await session.send_resource_updated(uri)
+            told = True
+        except Exception as error:  # noqa: BLE001 - a gone session is not an error
+            logger.debug("A subscriber could not be told about %s: %s", uri, error)
+            _LEGACY.pop(session, None)
+    return told

--- a/jupyter_mcp_server/resources.py
+++ b/jupyter_mcp_server/resources.py
@@ -31,8 +31,10 @@ platform's identifier on a resource that has nothing to do with it.
 
 from __future__ import annotations
 
+import importlib
 import json
 import logging
+import os
 from typing import Any
 
 from jupyter_mcp_server.models import Notebook
@@ -57,6 +59,90 @@ OUTPUT_TTL_MS = 60_000
 
 #: The MIME type of a whole notebook.
 NOTEBOOK_MIME = "application/x-ipynb+json"
+
+
+#: Names a class deciding which of these resources this deployment serves.
+#: See ``resolve_gate``.
+RESOURCE_GATE_CLASS_ENV = "JUPYTER_MCP_RESOURCE_GATE_CLASS"
+
+_gate: Any | None = None
+_gate_resolved = False
+
+
+def resolve_gate() -> Any | None:
+    """The configured gate, or ``None`` when every resource is served.
+
+    A deployment that addresses notebooks by its own identifiers serves its
+    own `…://` resources and does not want these: `notebook://{name}` is the
+    name a *worker* knows, and a hosted platform's client has never seen one.
+    Rather than have that platform delete resources after the fact — the
+    `_remove` dance the tools need — it names a gate here and this module
+    asks before answering.
+
+    Same shape and same strictness as the audit-sink seam: a class that
+    cannot be imported or built is fatal, because a deployment that
+    configured a gate and got one without it is serving resources it meant to
+    withhold.
+    """
+    global _gate, _gate_resolved
+    if _gate_resolved:
+        return _gate
+    _gate_resolved = True
+    path = (os.environ.get(RESOURCE_GATE_CLASS_ENV) or "").strip()
+    if not path:
+        return None
+    module_name, _, attribute = path.rpartition(".")
+    if not module_name:
+        raise RuntimeError(
+            f"{RESOURCE_GATE_CLASS_ENV} is {path!r}, which is not a module.Class path"
+        )
+    try:
+        module = importlib.import_module(module_name)
+        gate = getattr(module, attribute)()
+    except Exception as error:
+        raise RuntimeError(
+            f"{RESOURCE_GATE_CLASS_ENV} names {path!r}, which could not be used: {error}"
+        ) from error
+    if not callable(getattr(gate, "serves", None)):
+        raise RuntimeError(
+            f"{RESOURCE_GATE_CLASS_ENV} names {path!r}, which has no serves(uri) method"
+        )
+    _gate = gate
+    return _gate
+
+
+def use_gate(replacement: Any | None) -> None:
+    """Swap the gate — for the tests, and at startup."""
+    global _gate, _gate_resolved
+    _gate = replacement
+    _gate_resolved = replacement is not None
+
+
+def serves(uri_template: str) -> bool:
+    """Whether this deployment answers this resource.
+
+    Asked at *read* time rather than at registration, so the answer can
+    depend on configuration that arrives after the module is imported —
+    which is when extensions are registered here.
+    """
+    gate = resolve_gate()
+    if gate is None:
+        return True
+    try:
+        return bool(gate.serves(uri_template))
+    except Exception as error:  # noqa: BLE001 - a gate that cannot decide serves
+        logger.debug("The resource gate could not decide about %s: %s", uri_template, error)
+        return True
+
+
+class ResourceWithheld(ValueError):
+    """This deployment does not serve this resource.
+
+    Distinct from `ResourceNotFound`, which means the thing asked for is not
+    there. "We do not answer this here" and "there is no such cell" are
+    different answers, and a client told the second when the first is true
+    goes looking for a cell it will never find.
+    """
 
 
 class ResourceNotFound(ValueError):

--- a/jupyter_mcp_server/resources.py
+++ b/jupyter_mcp_server/resources.py
@@ -1,0 +1,181 @@
+# Copyright (c) 2024- Datalayer, Inc.
+#
+# BSD 3-Clause License
+
+"""The notebook, its cells and their outputs, as resources a client may read.
+
+Tools *push*: everything a call produces comes back whether the agent wanted
+it or not, so a cell that printed a megabyte spends a megabyte of the
+client's context on every read. Resources *pull*: the agent is told what
+exists, and reads the one thing it needs.
+
+That is the whole point of the output resource. A tool result says an output
+is there, how big it is and what type it is; an agent that needs the bytes
+asks for them, and an agent that only needed to know the cell succeeded does
+not pay for them.
+
+**Addressed by name and cell id, not by path and index.** A notebook path
+contains slashes and cannot sit in one URI template segment without being
+encoded into something nobody can read; the *name* is what every tool here
+already takes and what `use_notebook` registered. And an index is a position
+in a document somebody else is editing — between reading a notebook and
+reading cell 4 of it, cell 4 may be a different cell. The nbformat 4.5 id is
+not.
+
+The scheme is `notebook://`, deliberately provider-neutral: this server talks
+to a Jupyter server, and a `datalayer://` URI here would be a hosted
+platform's identifier on a resource that has nothing to do with it.
+
+@module jupyter_mcp_server.resources
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from typing import Any
+
+from jupyter_mcp_server.models import Notebook
+
+logger = logging.getLogger(__name__)
+
+#: The three resources, as URI templates.
+NOTEBOOK_RESOURCE = "notebook://{name}"
+CELL_RESOURCE = "notebook://{name}/cells/{cell_id}"
+OUTPUT_RESOURCE = "notebook://{name}/cells/{cell_id}/outputs/{index}"
+
+#: A notebook someone is editing is worth holding for seconds, not minutes.
+#: Long enough that reading a notebook and then three of its cells does not
+#: fetch the document four times; short enough that an agent watching a cell
+#: run sees it change.
+NOTEBOOK_TTL_MS = 5_000
+
+#: An output that exists does not change: a cell re-run replaces its outputs
+#: rather than editing one, and the new ones are at new indices under a cell
+#: whose id is the same. So this is the one thing here worth holding.
+OUTPUT_TTL_MS = 60_000
+
+#: The MIME type of a whole notebook.
+NOTEBOOK_MIME = "application/x-ipynb+json"
+
+
+class ResourceNotFound(ValueError):
+    """Named rather than a bare `ValueError`, so a caller can tell "no such
+    cell" from "the notebook could not be read" — one is the agent asking for
+    something that is not there, the other is this server failing."""
+
+
+async def read_notebook(notebook_manager: Any, name: str) -> Notebook:
+    """The notebook behind a resource URI.
+
+    Through the same connection the tools use, so a resource read right after
+    a write sees the write: the collaborative document is the truth, and
+    reading the file from disk would answer with whatever was last saved.
+    """
+    from jupyter_mcp_server.utils import resolve_notebook_connection  # noqa: PLC0415
+
+    if name not in notebook_manager:
+        raise ResourceNotFound(
+            f"No notebook named {name!r} is in use. Open one with use_notebook, "
+            "and list what is open with list_notebooks."
+        )
+    async with resolve_notebook_connection(notebook_manager, name) as content:
+        return Notebook(**content.as_dict())
+
+
+def find_cell(notebook: Notebook, cell_id: str) -> tuple[int, Any]:
+    """The cell with this id, and where it currently sits.
+
+    The index comes back with it because a caller almost always wants to say
+    *which* cell in a message, and looking it up twice invites the two
+    answers to disagree after an edit lands between them.
+    """
+    for index, cell in enumerate(notebook.cells):
+        if str(getattr(cell, "id", "")) == cell_id:
+            return index, cell
+    raise ResourceNotFound(
+        f"No cell with id {cell_id!r} in this notebook. Cell ids are on every "
+        "cell result; an index is not an id."
+    )
+
+
+def output_mime(output: Any) -> str:
+    """The output's own MIME type, not `text/plain` for everything.
+
+    An image read as text is a screenful of base64 in the agent's context,
+    and the agent cannot tell that is what happened. The type is what lets a
+    client decide whether to render it, save it or leave it alone.
+    """
+    if not isinstance(output, dict):
+        return "text/plain"
+    kind = output.get("output_type")
+    if kind == "stream":
+        return "text/plain"
+    if kind == "error":
+        return "text/plain"
+    data = output.get("data")
+    if isinstance(data, dict) and data:
+        # The richest representation the cell produced. `text/plain` is the
+        # fallback every kernel attaches, so preferring it would throw away
+        # the image in every image output.
+        for candidate in data:
+            if candidate != "text/plain":
+                return str(candidate)
+        return "text/plain"
+    return "text/plain"
+
+
+def output_text(output: Any) -> str:
+    """One output as text, in whatever form it actually has."""
+    if not isinstance(output, dict):
+        return str(output)
+    kind = output.get("output_type")
+    if kind == "stream":
+        text = output.get("text", "")
+        return "".join(text) if isinstance(text, list) else str(text)
+    if kind == "error":
+        traceback = output.get("traceback") or []
+        if traceback:
+            return "\n".join(str(line) for line in traceback)
+        return f"{output.get('ename', 'Error')}: {output.get('evalue', '')}"
+    data = output.get("data")
+    if isinstance(data, dict):
+        chosen = output_mime(output)
+        value = data.get(chosen, data.get("text/plain", ""))
+        return "".join(value) if isinstance(value, list) else str(value)
+    return json.dumps(output)
+
+
+def cell_document(name: str, index: int, cell: Any) -> str:
+    """One cell, as JSON rather than as the tools' readable text.
+
+    A resource is read by a program. The tools' `=====Cell 3 | type: code=====`
+    banner is for a person reading a transcript, and an agent parsing it back
+    into fields is an agent that will get it wrong on the first cell whose
+    source contains the word "Cell".
+    """
+    return json.dumps(
+        {
+            "id": str(getattr(cell, "id", "")),
+            "index": index,
+            "cell_type": cell.cell_type,
+            "source": cell.get_source("raw"),
+            "execution_count": getattr(cell, "execution_count", None),
+            # The outputs are *listed*, not inlined: their URIs and their
+            # types, so an agent can decide which to read. Inlining them here
+            # would make reading a cell cost whatever the cell printed, which
+            # is the thing these resources exist to avoid.
+            "outputs": [
+                {
+                    "index": position,
+                    "mimeType": output_mime(output),
+                    "uri": (
+                        f"notebook://{name}/cells/"
+                        f"{getattr(cell, 'id', '')}/outputs/{position}"
+                    ),
+                }
+                for position, output in enumerate(getattr(cell, "outputs", []) or [])
+            ],
+        },
+        indent=2,
+    )

--- a/jupyter_mcp_server/results.py
+++ b/jupyter_mcp_server/results.py
@@ -374,6 +374,32 @@ def structured(
             finally:
                 _pending.reset(token)
 
-        return wrapper
+        @wraps(function)
+        async def announcing(*arguments: Any, **keywords: Any) -> CallToolResult:
+            """The same wrapper, plus a word to anybody subscribed.
+
+            Here rather than in each writing tool because there are eight of
+            them and they already share this decorator, and because the thing
+            that decides whether a call *changed* the notebook is the `kind`
+            it declares — which is exactly what this sees.
+
+            After the call, never before: a subscriber told a cell changed
+            before it did refetches the old document and caches it as new.
+            """
+            result = await wrapper(*arguments, **keywords)
+            from jupyter_mcp_server import notifications  # noqa: PLC0415
+
+            if kind in notifications.MUTATING_KINDS:
+                from jupyter_mcp_server.server import mcp, notebook_manager  # noqa: PLC0415
+
+                await notifications.publish_notebook_updated(
+                    mcp,
+                    notifications.target_notebook(
+                        keywords, notebook_manager.get_current_notebook
+                    ),
+                )
+            return result
+
+        return announcing
 
     return decorate

--- a/jupyter_mcp_server/results.py
+++ b/jupyter_mcp_server/results.py
@@ -61,6 +61,18 @@ SCOPE_PRIVATE = "private"
 META_NAMESPACE = "io.jupyter-mcp"
 
 
+def audience_annotations(*audiences: str) -> Annotations:
+    """Content annotations saying who something is for.
+
+    Here rather than at the call site for the reason the whole module is: if
+    the Working Group deprecates annotations, one function stops returning
+    them. A resource declares its audience the same way a tool result does,
+    and building `Annotations(...)` in a second place would make that two
+    edits — which is exactly what the invariant test next door refuses.
+    """
+    return Annotations(audience=list(audiences))
+
+
 def meta_key(name: str) -> str:
     """A `_meta` key of this server's, namespaced."""
     return f"{META_NAMESPACE}/{name}"

--- a/jupyter_mcp_server/server.py
+++ b/jupyter_mcp_server/server.py
@@ -35,9 +35,14 @@ from jupyter_mcp_server.config import get_config, set_config
 from jupyter_mcp_server.enroll import auto_enroll_document
 from jupyter_mcp_server.extensions import get_extension_manager
 from jupyter_mcp_server.revalidation import revalidation_extension
-from mcp.types import EmptyResult, SubscribeRequestParams, UnsubscribeRequestParams
+from mcp.types import (
+    EmptyResult,
+    SetLevelRequestParams,
+    SubscribeRequestParams,
+    UnsubscribeRequestParams,
+)
 
-from jupyter_mcp_server import notifications, resources
+from jupyter_mcp_server import client_logging, notifications, resources
 from jupyter_mcp_server.results import (
     AUDIENCE_ASSISTANT,
     AUDIENCE_USER,
@@ -385,6 +390,23 @@ async def _on_unsubscribe_resource(ctx, params) -> EmptyResult:
     """
     notifications.legacy_unsubscribe(getattr(ctx, "session", None), str(params.uri))
     return EmptyResult()
+
+
+async def _on_set_logging_level(ctx, params) -> EmptyResult:
+    """`logging/setLevel`: how much this client wants to be told.
+
+    Served because a client that cannot turn the volume down turns the
+    connection off instead. The floor is remembered per session — two agents
+    of the same user share this worker, and one debugging a notebook wants
+    more than one running a pipeline.
+    """
+    client_logging.set_level(getattr(ctx, "session", None), str(params.level))
+    return EmptyResult()
+
+
+mcp._lowlevel_server.add_request_handler(
+    "logging/setLevel", SetLevelRequestParams, _on_set_logging_level
+)
 
 
 mcp._lowlevel_server.add_request_handler(

--- a/jupyter_mcp_server/server.py
+++ b/jupyter_mcp_server/server.py
@@ -35,7 +35,9 @@ from jupyter_mcp_server.config import get_config, set_config
 from jupyter_mcp_server.enroll import auto_enroll_document
 from jupyter_mcp_server.extensions import get_extension_manager
 from jupyter_mcp_server.revalidation import revalidation_extension
-from jupyter_mcp_server import resources
+from mcp.types import EmptyResult, SubscribeRequestParams, UnsubscribeRequestParams
+
+from jupyter_mcp_server import notifications, resources
 from jupyter_mcp_server.results import (
     AUDIENCE_ASSISTANT,
     AUDIENCE_USER,
@@ -356,6 +358,41 @@ mcp = MCPServerWithCORS(
 notebook_manager = NotebookManager()
 server_context = ServerContext.get_instance()
 extension_manager = get_extension_manager()
+
+
+async def _on_subscribe_resource(ctx, params) -> EmptyResult:
+    """`resources/subscribe`, the 2025-11-25 way to ask.
+
+    Registered even though the modern wire cannot dispatch it, because this
+    server answers both eras and most clients today are on the older one. At
+    2026-07-28 the same intent arrives as a `subscriptions/listen` filter and
+    the SDK handles it; here it is a method call this has to remember.
+
+    Registering it is also what makes `resources.subscribe` true in the
+    2025-11-25 handshake — the SDK derives that capability from whether this
+    handler exists.
+    """
+    notifications.legacy_subscribe(getattr(ctx, "session", None), str(params.uri))
+    return EmptyResult()
+
+
+async def _on_unsubscribe_resource(ctx, params) -> EmptyResult:
+    """`resources/unsubscribe`. Never refuses.
+
+    Unsubscribing from something never subscribed is not an error: the
+    client's intent — *stop telling me about this* — is satisfied either way,
+    and refusing it teaches a client to retry something already true.
+    """
+    notifications.legacy_unsubscribe(getattr(ctx, "session", None), str(params.uri))
+    return EmptyResult()
+
+
+mcp._lowlevel_server.add_request_handler(
+    "resources/subscribe", SubscribeRequestParams, _on_subscribe_resource
+)
+mcp._lowlevel_server.add_request_handler(
+    "resources/unsubscribe", UnsubscribeRequestParams, _on_unsubscribe_resource
+)
 
 
 @mcp.resource(

--- a/jupyter_mcp_server/server.py
+++ b/jupyter_mcp_server/server.py
@@ -432,6 +432,10 @@ async def notebook_resource(name: str) -> str:
     proxy that shared this answer would hand somebody else's work to whoever
     asked next.
     """
+    if not resources.serves(resources.NOTEBOOK_RESOURCE):
+        raise resources.ResourceWithheld(
+            "This deployment does not serve {}".format(resources.NOTEBOOK_RESOURCE)
+        )
     notebook = await resources.read_notebook(notebook_manager, name)
     return notebook.model_dump_json(indent=2)
 
@@ -451,6 +455,10 @@ async def cell_resource(name: str, cell_id: str) -> str:
     reading the notebook and reading "cell 4", cell 4 may be a different
     cell. The nbformat 4.5 id is not.
     """
+    if not resources.serves(resources.CELL_RESOURCE):
+        raise resources.ResourceWithheld(
+            "This deployment does not serve {}".format(resources.CELL_RESOURCE)
+        )
     notebook = await resources.read_notebook(notebook_manager, name)
     index, cell = resources.find_cell(notebook, cell_id)
     return resources.cell_document(name, index, cell)
@@ -479,6 +487,10 @@ async def cell_output_resource(name: str, cell_id: str, index: str) -> str:
     re-run *replaces* a cell's outputs rather than editing one, and the new
     ones are at new positions.
     """
+    if not resources.serves(resources.OUTPUT_RESOURCE):
+        raise resources.ResourceWithheld(
+            "This deployment does not serve {}".format(resources.OUTPUT_RESOURCE)
+        )
     notebook = await resources.read_notebook(notebook_manager, name)
     _, cell = resources.find_cell(notebook, cell_id)
     outputs = list(getattr(cell, "outputs", []) or [])

--- a/jupyter_mcp_server/server.py
+++ b/jupyter_mcp_server/server.py
@@ -35,6 +35,14 @@ from jupyter_mcp_server.config import get_config, set_config
 from jupyter_mcp_server.enroll import auto_enroll_document
 from jupyter_mcp_server.extensions import get_extension_manager
 from jupyter_mcp_server.revalidation import revalidation_extension
+from jupyter_mcp_server import resources
+from jupyter_mcp_server.results import (
+    AUDIENCE_ASSISTANT,
+    AUDIENCE_USER,
+    CACHE_META_KEY,
+    SCOPE_PRIVATE,
+    audience_annotations,
+)
 from jupyter_mcp_server.tasks import tasks_extension
 from jupyter_mcp_server.hooks import HookEvent, HookRegistry, with_hooks
 from jupyter_mcp_server.jupyter_extension.context import get_server_context
@@ -348,6 +356,82 @@ mcp = MCPServerWithCORS(
 notebook_manager = NotebookManager()
 server_context = ServerContext.get_instance()
 extension_manager = get_extension_manager()
+
+
+@mcp.resource(
+    resources.NOTEBOOK_RESOURCE,
+    name="notebook",
+    description="A notebook in use, as nbformat JSON. Cells and outputs are resources of their own.",
+    mime_type=resources.NOTEBOOK_MIME,
+    annotations=audience_annotations(AUDIENCE_ASSISTANT, AUDIENCE_USER),
+    meta={CACHE_META_KEY: {"ttlMs": resources.NOTEBOOK_TTL_MS, "cacheScope": SCOPE_PRIVATE}},
+)
+async def notebook_resource(name: str) -> str:
+    """The whole notebook, for an agent that wants the document.
+
+    `private` rather than `session`: the notebook is one caller's, and a
+    proxy that shared this answer would hand somebody else's work to whoever
+    asked next.
+    """
+    notebook = await resources.read_notebook(notebook_manager, name)
+    return notebook.model_dump_json(indent=2)
+
+
+@mcp.resource(
+    resources.CELL_RESOURCE,
+    name="notebook-cell",
+    description="One cell by its nbformat id, with its outputs listed rather than inlined.",
+    mime_type="application/json",
+    annotations=audience_annotations(AUDIENCE_ASSISTANT, AUDIENCE_USER),
+    meta={CACHE_META_KEY: {"ttlMs": resources.NOTEBOOK_TTL_MS, "cacheScope": SCOPE_PRIVATE}},
+)
+async def cell_resource(name: str, cell_id: str) -> str:
+    """One cell, addressed by id rather than by index.
+
+    An index is a position in a document somebody else is editing: between
+    reading the notebook and reading "cell 4", cell 4 may be a different
+    cell. The nbformat 4.5 id is not.
+    """
+    notebook = await resources.read_notebook(notebook_manager, name)
+    index, cell = resources.find_cell(notebook, cell_id)
+    return resources.cell_document(name, index, cell)
+
+
+@mcp.resource(
+    resources.OUTPUT_RESOURCE,
+    name="notebook-cell-output",
+    description="One output of one cell, with its own MIME type. Read it only if you need the bytes.",
+    annotations=audience_annotations(AUDIENCE_ASSISTANT),
+    meta={CACHE_META_KEY: {"ttlMs": resources.OUTPUT_TTL_MS, "cacheScope": SCOPE_PRIVATE}},
+)
+async def cell_output_resource(name: str, cell_id: str, index: str) -> str:
+    """One output, which is the point of all three.
+
+    A tool result says an output exists, how big it is and what type it is.
+    An agent that needs the bytes asks for them here; an agent that only
+    needed to know the cell succeeded does not pay for them. A cell that
+    printed a megabyte otherwise spends a megabyte of context every time
+    anybody reads it.
+
+    The audience is the assistant alone: a person reads outputs in their
+    notebook, where they are rendered, not through a URI.
+
+    Held longer than the notebook because an output does not change — a
+    re-run *replaces* a cell's outputs rather than editing one, and the new
+    ones are at new positions.
+    """
+    notebook = await resources.read_notebook(notebook_manager, name)
+    _, cell = resources.find_cell(notebook, cell_id)
+    outputs = list(getattr(cell, "outputs", []) or [])
+    try:
+        position = int(index)
+    except ValueError:
+        raise resources.ResourceNotFound(f"{index!r} is not an output index")
+    if position < 0 or position >= len(outputs):
+        raise resources.ResourceNotFound(
+            f"Cell {cell_id} has {len(outputs)} output(s); there is no {position}"
+        )
+    return resources.output_text(outputs[position])
 
 
 @mcp.resource(CAPABILITIES_RESOURCE)

--- a/jupyter_mcp_server/tasks.py
+++ b/jupyter_mcp_server/tasks.py
@@ -150,6 +150,13 @@ class TaskRecord:
     #: A digest of the call the key was used for. A key reused for a
     #: *different* call is a mistake, not a replay — see `intercept_tool_call`.
     request_hash: str = ""
+    #: What the work has produced *so far*. See `record_output`.
+    #:
+    #: Separate from `result`, which is what the tool returned. A task that
+    #: never returns — cancelled at minute nine of ten — has no result and
+    #: may still have printed five hundred lines, and those lines are the
+    #: only thing the person who cancelled it wanted.
+    partial: list[Any] = field(default_factory=list, repr=False)
 
     def public(self) -> Task:
         """The protocol's view. Never the result, never the handle."""
@@ -338,6 +345,34 @@ async def register_interrupt(stop: Callable[[], Any], *, store: TaskStore | None
         return False
     where = store or get_task_store()
     return await where.update(task_id, interrupt=stop) is not None
+
+
+async def record_output(outputs: Any, *, store: TaskStore | None = None) -> bool:
+    """Put what the work has produced so far where a reader can see it.
+
+    A task's `result` arrives whole when the tool returns. That is the right
+    shape for a call that finishes, and no shape at all for one that does
+    not: cancel a ten-minute cell at minute nine and the task is `cancelled`
+    with `result: None`, though the cell printed five hundred lines and those
+    lines are exactly what the person who cancelled it wanted to read.
+
+    So a tool that produces output as it goes says so here, and the record
+    keeps it. On cancellation the partial output *becomes* the result — the
+    task is terminal, so `tasks/result` will serve it — and on a normal
+    return the tool's own result wins, because it is the complete one.
+
+    Replaces rather than appends: the caller holds the whole list of outputs
+    so far, and appending would have every reader deduplicate what it reads.
+
+    Answers whether it was recorded — `False` for a synchronous call, which
+    has no task to attach to and needs none, since the client is still on the
+    other end of the connection.
+    """
+    task_id = current_task()
+    if not task_id:
+        return False
+    where = store or get_task_store()
+    return await where.update(task_id, partial=list(outputs)) is not None
 
 
 def _idempotency_key(params: Any) -> str:
@@ -668,6 +703,12 @@ class TasksExtension(Extension):
                     status="failed",
                     error=f"{type(error).__name__}: {error}",
                     status_message=str(error)[:200],
+                    # `tasks/result` raises for a failed task, so this is not
+                    # served — it is kept because a cell that printed for
+                    # nine minutes and then raised has the output somebody
+                    # needs to see *why*, and throwing it away at the moment
+                    # of failure is throwing away the diagnosis.
+                    **({"result": partial} if (partial := await self._partial(task_id)) else {}),
                 ),
             )
             return
@@ -675,10 +716,22 @@ class TasksExtension(Extension):
             ctx, await self.store.update(task_id, status="completed", result=result)
         )
 
+    async def _partial(self, task_id: str) -> Any:
+        """What the task produced so far, or `None`."""
+        record = await self.store.get(task_id)
+        return record.partial if record is not None and record.partial else None
+
     async def _mark_cancelled(self, task_id: str) -> None:
         record = await self.store.get(task_id)
         if record is not None and not record.is_terminal:
-            await self.store.update(task_id, status="cancelled")
+            # What it produced before it was stopped, promoted to the result.
+            # The task is terminal now, so `tasks/result` will serve it, and
+            # a cancelled cell that printed five hundred lines hands them
+            # over instead of answering with nothing.
+            changes: dict[str, Any] = {"status": "cancelled"}
+            if record.partial and record.result is None:
+                changes["result"] = record.partial
+            await self.store.update(task_id, **changes)
 
 
 def tasks_extension(store: TaskStore | None = None) -> TasksExtension:

--- a/jupyter_mcp_server/tasks.py
+++ b/jupyter_mcp_server/tasks.py
@@ -722,15 +722,41 @@ class TasksExtension(Extension):
         return record.partial if record is not None and record.partial else None
 
     async def _mark_cancelled(self, task_id: str) -> None:
+        """The cancelled task's last word: what it produced before it stopped.
+
+        **This cannot ask whether the task is still working.** By the time it
+        runs, `tasks/cancel` has already written `cancelled` — it writes the
+        status, interrupts the work and cancels the handle, and only then does
+        the coroutine unwind into here. A guard for "not terminal" therefore
+        skips the promotion on the path every cancellation actually takes,
+        which is how the first version of this shipped a feature that never
+        once ran and a test that stayed green: the test called this directly
+        on a still-working record, a state the real flow never reaches.
+
+        It runs here rather than in `_handle_cancel` because it runs *later*:
+        the work may have produced more between the cancel arriving and the
+        coroutine unwinding, and this is the last moment anything can see it.
+        """
         record = await self.store.get(task_id)
-        if record is not None and not record.is_terminal:
-            # What it produced before it was stopped, promoted to the result.
-            # The task is terminal now, so `tasks/result` will serve it, and
-            # a cancelled cell that printed five hundred lines hands them
-            # over instead of answering with nothing.
-            changes: dict[str, Any] = {"status": "cancelled"}
-            if record.partial and record.result is None:
-                changes["result"] = record.partial
+        if record is None:
+            return
+        changes: dict[str, Any] = {}
+        if not record.is_terminal:
+            # Cancelled from somewhere other than `tasks/cancel` — the handle
+            # itself was cancelled, so nothing has written the status yet.
+            changes["status"] = "cancelled"
+        elif record.status != "cancelled":
+            # It completed or failed first. That is the race the client lost,
+            # and its own answer stands: replacing a finished result with the
+            # half that was visible a moment earlier loses the complete one.
+            return
+        # What it produced before it was stopped, promoted to the result. The
+        # task is terminal, so `tasks/result` serves it — a cancelled cell
+        # that printed five hundred lines hands them over instead of
+        # answering with nothing.
+        if record.partial and record.result is None:
+            changes["result"] = record.partial
+        if changes:
             await self.store.update(task_id, **changes)
 
 

--- a/jupyter_mcp_server/tools/execute_cell_tool.py
+++ b/jupyter_mcp_server/tools/execute_cell_tool.py
@@ -488,6 +488,18 @@ class ExecuteCellTool(BaseTool):
                     last_progress_emit = 0.0
                     timed_out = False
 
+                    # How to stop the cell, as opposed to stopping the wait
+                    # for it. This is the *streaming* loop — the documented
+                    # mode for long-running cells, and so the one most likely
+                    # to be cancelled — and it had neither hook while the
+                    # non-streaming loop in `utils` had both.
+                    try:
+                        from jupyter_mcp_server.tasks import register_interrupt
+
+                        await register_interrupt(kernel.interrupt)
+                    except Exception as error:  # noqa: BLE001 - never in the way
+                        logger.debug("The interrupt could not be registered: %s", error)
+
                     # Monitor progress
                     while not execution_task.done():
                         elapsed = time.perf_counter() - start_time
@@ -517,6 +529,20 @@ class ExecuteCellTool(BaseTool):
                                     f"[{elapsed:.1f}s] {new_count} new output(s), "
                                     f"{last_output_count} total"
                                 )
+                                # Into the task, where a reader can see them.
+                                # A cell cancelled at minute nine of ten has
+                                # no result and may have printed five hundred
+                                # lines.
+                                try:
+                                    from jupyter_mcp_server.tasks import record_output
+
+                                    await record_output(
+                                        safe_extract_outputs(current_outputs)
+                                    )
+                                except Exception as error:  # noqa: BLE001
+                                    logger.debug(
+                                        "Progress could not be recorded: %s", error
+                                    )
 
                         except Exception as e:
                             timeline.append(f"[{elapsed:.1f}s] Error checking outputs: {e}")

--- a/jupyter_mcp_server/tools/execute_code_tool.py
+++ b/jupyter_mcp_server/tools/execute_code_tool.py
@@ -207,6 +207,18 @@ class ExecuteCodeTool(BaseTool):
             start_time = asyncio.get_event_loop().time()
             last_progress_emit = 0.0
 
+            # How to stop the code, as opposed to stopping the wait for it.
+            # This loop has no outputs to stream — `execute` returns them
+            # whole — but it can interrupt, and a task cancelled here would
+            # otherwise leave the sandbox running.
+            if code_sandbox_client is not None and hasattr(code_sandbox_client, "interrupt"):
+                try:
+                    from jupyter_mcp_server.tasks import register_interrupt
+
+                    await register_interrupt(code_sandbox_client.interrupt)
+                except Exception as error:  # noqa: BLE001 - never in the way
+                    logger.debug("The interrupt could not be registered: %s", error)
+
             # Wait for execution with timeout, emitting MCP keepalive progress
             # so clients do not idle-timeout on long-running cells.
             # Use >= so timeout=0 is an immediate timeout even if elapsed is 0.

--- a/jupyter_mcp_server/utils.py
+++ b/jupyter_mcp_server/utils.py
@@ -907,6 +907,19 @@ async def execute_cell_with_forced_sync(
     last_output_count = 0
     last_progress_emit = 0.0
 
+    # How to stop the cell, as opposed to stopping the wait for it. Cancelling
+    # the task cancels this loop; the kernel would keep running the cell, keep
+    # holding the sandbox and keep costing money while the task said
+    # `cancelled`. Registered here because this is the frame that holds the
+    # kernel — a no-op for a synchronous call, which has no task.
+    if hasattr(kernel, "interrupt"):
+        try:
+            from jupyter_mcp_server.tasks import register_interrupt
+
+            await register_interrupt(kernel.interrupt)
+        except Exception as error:  # noqa: BLE001 - never in the way of the cell
+            logger.debug("The interrupt could not be registered: %s", error)
+
     while not execution_future.done():
         elapsed = time.perf_counter() - start_time
 
@@ -933,6 +946,16 @@ async def execute_cell_with_forced_sync(
                 logger.info(
                     f"Cell {cell_index} progress: {len(current_outputs)} outputs after {elapsed:.1f}s"
                 )
+                # Into the task, where a reader can see them. A cell cancelled
+                # at minute nine of ten has no result and may have printed
+                # five hundred lines; without this the task answers with
+                # nothing, which reads as "it produced nothing".
+                try:
+                    from jupyter_mcp_server.tasks import record_output
+
+                    await record_output(safe_extract_outputs(current_outputs))
+                except Exception as error:  # noqa: BLE001 - never in the way
+                    logger.debug("Progress could not be recorded: %s", error)
 
                 # Try different sync methods
                 try:

--- a/tests/conformance-baseline.yaml
+++ b/tests/conformance-baseline.yaml
@@ -28,7 +28,6 @@ server:
   - completion-complete
   - elicitation-sep1034-defaults
   - elicitation-sep1330-enums
-  - logging-set-level
   - prompts-get-embedded-resource
   - prompts-get-simple
   - prompts-get-with-args
@@ -38,10 +37,10 @@ server:
   - resources-templates-read
   - server-sse-multiple-streams
   - tools-call-audio
+  - tools-call-with-logging
   - tools-call-elicitation
   - tools-call-embedded-resource
   - tools-call-image
   - tools-call-mixed-content
   - tools-call-sampling
-  - tools-call-with-logging
   - tools-call-with-progress

--- a/tests/conformance-baseline.yaml
+++ b/tests/conformance-baseline.yaml
@@ -35,9 +35,7 @@ server:
   - prompts-get-with-image
   - resources-read-binary
   - resources-read-text
-  - resources-subscribe
   - resources-templates-read
-  - resources-unsubscribe
   - server-sse-multiple-streams
   - tools-call-audio
   - tools-call-elicitation

--- a/tests/test_client_logging.py
+++ b/tests/test_client_logging.py
@@ -1,0 +1,162 @@
+# Copyright (c) 2024- Datalayer, Inc.
+#
+# BSD 3-Clause License
+
+"""How much this server tells a client, and who decides.
+
+A client sets a floor with `logging/setLevel` and gets everything at or above
+it. Without the method served it was refused `-32601`, so a client had no way
+to turn the volume down — and the alternative to turning it down is turning
+the connection off.
+
+`logging-set-level` left the conformance baseline because of this. Verified
+the only way that means anything: by removing the handler and watching the
+specification's own suite fail.
+
+Launch the tests:
+```
+$ pytest tests/test_client_logging.py -v
+```
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from jupyter_mcp_server import client_logging
+
+
+class _Session:
+    def __init__(self, explode: bool = False) -> None:
+        self.sent: list[tuple[str, object, str | None]] = []
+        self._explode = explode
+
+    async def send_log_message(self, level, data, logger=None) -> None:
+        if self._explode:
+            raise RuntimeError("the connection is gone")
+        self.sent.append((level, data, logger))
+
+
+class TestTheFloor:
+    def test_a_session_gets_info_before_it_asks(self):
+        """`debug` would send every client a stream it did not ask for and
+        mostly cannot use; `warning` would hide the progress notes a long
+        cell sends, which are what somebody watching a ten-minute execution
+        actually wants."""
+        assert client_logging.level_of(_Session()) == "info"
+
+    def test_setting_a_level_is_remembered(self):
+        session = _Session()
+        assert client_logging.set_level(session, "warning") is True
+        assert client_logging.level_of(session) == "warning"
+
+    def test_each_session_has_its_own(self):
+        """Two agents of the same user share this worker. One debugging a
+        notebook and one running a pipeline want different amounts, and a
+        single global level would have the quiet one shouting or the loud one
+        silent."""
+        loud, quiet = _Session(), _Session()
+        client_logging.set_level(loud, "debug")
+        client_logging.set_level(quiet, "error")
+        assert client_logging.level_of(loud) == "debug"
+        assert client_logging.level_of(quiet) == "error"
+
+    def test_an_unknown_level_is_neither_stored_nor_raised(self):
+        """Refusing would refuse a client for asking about a level a later
+        specification added. Storing it would silently mute the session,
+        because nothing compares greater than a name with no position."""
+        session = _Session()
+        client_logging.set_level(session, "warning")
+        assert client_logging.set_level(session, "chatty") is False
+        assert client_logging.level_of(session) == "warning"
+
+    def test_a_session_that_goes_away_takes_its_level_with_it(self):
+        import gc
+
+        session = _Session()
+        client_logging.set_level(session, "error")
+        held = client_logging.level_of(session)
+        del session
+        gc.collect()
+        assert held == "error"
+
+
+class TestWhatClearsIt:
+    def test_the_same_level_clears_its_own_floor(self):
+        session = _Session()
+        client_logging.set_level(session, "warning")
+        assert client_logging.should_send(session, "warning") is True
+
+    def test_something_more_severe_clears_it(self):
+        session = _Session()
+        client_logging.set_level(session, "warning")
+        assert client_logging.should_send(session, "error") is True
+
+    def test_something_less_severe_does_not(self):
+        session = _Session()
+        client_logging.set_level(session, "warning")
+        assert client_logging.should_send(session, "info") is False
+
+    def test_the_order_is_the_specification_s(self):
+        """A floor is only meaningful against a sequence, and getting the
+        sequence wrong inverts every comparison silently."""
+        assert client_logging.LEVELS.index("debug") < client_logging.LEVELS.index("info")
+        assert client_logging.LEVELS.index("info") < client_logging.LEVELS.index("warning")
+        assert client_logging.LEVELS.index("warning") < client_logging.LEVELS.index("error")
+        assert client_logging.LEVELS.index("error") < client_logging.LEVELS.index("emergency")
+
+    def test_an_unknown_level_is_sent_rather_than_dropped(self):
+        """The failure modes are not symmetric: sending something nobody
+        wanted is noise, and dropping something somebody needed is an outage
+        they cannot see."""
+        session = _Session()
+        client_logging.set_level(session, "emergency")
+        assert client_logging.should_send(session, "from-the-future") is True
+
+
+@pytest.mark.asyncio
+class TestSending:
+    async def test_a_message_above_the_floor_goes(self):
+        session = _Session()
+        client_logging.set_level(session, "info")
+        assert await client_logging.log_to_client(session, "warning", "careful") is True
+        assert session.sent == [("warning", "careful", None)]
+
+    async def test_a_message_below_the_floor_does_not(self):
+        session = _Session()
+        client_logging.set_level(session, "error")
+        assert await client_logging.log_to_client(session, "info", "fyi") is False
+        assert session.sent == []
+
+    async def test_the_source_is_carried_when_given(self):
+        session = _Session()
+        await client_logging.log_to_client(session, "info", "x", source="cells")
+        assert session.sent[0][2] == "cells"
+
+    async def test_a_broken_connection_never_fails_the_work(self):
+        """A note *about* work, sent from a path that is doing the work.
+        Failing a cell because the note about the cell would not go out
+        trades the work for the story about the work."""
+        assert await client_logging.log_to_client(_Session(explode=True), "error", "x") is False
+
+    async def test_no_session_is_not_an_error(self):
+        assert await client_logging.log_to_client(None, "error", "x") is False
+
+
+class TestTheMethodIsServed:
+    def test_the_handler_is_registered(self):
+        """A client that cannot turn the volume down turns the connection off
+        instead."""
+        from jupyter_mcp_server.server import mcp
+
+        assert "logging/setLevel" in mcp._lowlevel_server._request_handlers
+
+    def test_it_is_not_in_the_conformance_baseline_any_more(self):
+        """It came off because it started passing, which is the only reason
+        an entry should ever come off."""
+        import pathlib
+
+        baseline = pathlib.Path(__file__).resolve().parent / "conformance-baseline.yaml"
+        if not baseline.exists():
+            pytest.skip("no baseline here")
+        assert "logging-set-level" not in baseline.read_text()

--- a/tests/test_documented_features.py
+++ b/tests/test_documented_features.py
@@ -107,6 +107,40 @@ class TestTheTasksPage:
         assert "register_interrupt" in page
         assert hasattr(tasks, "register_interrupt")
 
+    def test_the_output_helper_it_shows_is_the_one_that_exists(self, page):
+        """Same reason as the interrupt above: a page showing a call that
+        raises `ImportError` reads to whoever typed it as their own
+        mistake."""
+        from jupyter_mcp_server import tasks
+
+        assert "record_output" in page
+        assert hasattr(tasks, "record_output")
+
+    def test_the_page_says_replaces_and_the_code_replaces(self, page):
+        """The one thing a caller has to know, and the one that would break
+        silently: appending would have every reader deduplicate what it
+        reads, and the page telling them otherwise is worse than saying
+        nothing."""
+        import inspect
+
+        from jupyter_mcp_server import tasks
+
+        assert "**replaces** rather than appends" in page
+        source = inspect.getsource(tasks.record_output)
+        assert "partial=list(outputs)" in source
+        assert "+=" not in source and "extend" not in source
+
+    def test_the_page_says_a_result_that_arrived_wins_and_it_does(self, page):
+        """A claim about a race, which is the kind nobody re-reads."""
+        import inspect
+
+        from jupyter_mcp_server import tasks
+
+        assert "A tool's own result always wins" in page
+        assert "record.result is None" in inspect.getsource(
+            tasks.TasksExtension._mark_cancelled
+        )
+
     def test_the_store_methods_it_tells_you_to_write_are_the_ones_called(self, page):
         """Both directions, and that is the half that was missing.
 

--- a/tests/test_execute_records_into_the_task.py
+++ b/tests/test_execute_records_into_the_task.py
@@ -1,0 +1,205 @@
+# Copyright (c) 2023-2026 Datalayer, Inc.
+#
+# BSD 3-Clause License
+
+"""Both execution paths put the task's interrupt and its output where they go.
+
+Reported against `b6c494a0`, and reproduced here before it was fixed:
+
+```
+non-streaming: interrupt True,  partial 2
+streaming:     interrupt False, partial 0
+```
+
+`execute_cell(stream=True)` runs its own monitor loop — the documented mode
+for long-running cells, and therefore the one most likely to be cancelled —
+and it registered no interrupt and recorded no output. Cancelling there left
+the kernel running and the task empty, which is the whole failure the two
+hooks exist to prevent.
+
+`test_tasks.py` guards this by reading the source of *every* wait loop, found
+by shape. This measures it instead: the same fake kernel, the same cell
+printing twice, both paths.
+
+Launch the tests:
+```
+$ pytest tests/test_execute_records_into_the_task.py -v
+```
+"""
+
+from __future__ import annotations
+
+import contextlib
+import time
+
+import pytest
+
+from jupyter_mcp_server.tools._base import ServerMode
+from jupyter_mcp_server.tasks import (
+    CURRENT_TASK,
+    MemoryTaskStore,
+    TaskRecord,
+    use_task_store,
+)
+from jupyter_mcp_server.tools.execute_cell_tool import ExecuteCellTool
+from jupyter_mcp_server.utils import execute_cell_with_forced_sync
+
+TWO_OUTPUTS = [
+    {"output_type": "stream", "name": "stdout", "text": "one\n"},
+    {"output_type": "stream", "name": "stdout", "text": "two\n"},
+]
+
+
+class FakeKernel:
+    def __init__(self):
+        self.interrupted = False
+
+    def interrupt(self):
+        self.interrupted = True
+
+
+class FakeNotebook:
+    """A cell that prints twice, a moment after it starts.
+
+    The delay is what makes the outputs *arrive* rather than be there from
+    the beginning: a loop that only ever sees a finished cell would record
+    the same thing either way, and prove nothing about streaming.
+    """
+
+    def __init__(self, cell):
+        self._cell = cell
+
+    def __len__(self):
+        return 1
+
+    def __getitem__(self, index):
+        return self._cell
+
+    def execute_cell(self, cell_index, kernel):
+        time.sleep(1.2)
+        self._cell["outputs"] = list(TWO_OUTPUTS)
+        time.sleep(1.2)
+
+    @property
+    def _doc(self):
+        return _Doc(self._cell)
+
+
+class _Doc:
+    def __init__(self, cell):
+        self._cell = cell
+
+    @property
+    def _ycells(self):
+        return [self._cell]
+
+
+class FakeNotebookManager:
+    def __init__(self, notebook, kernel):
+        self._notebook = notebook
+        self._kernel = kernel
+
+    def get_current_notebook(self):
+        return "default"
+
+    def get_code_sandbox_id(self, notebook_name):
+        return "kernel-1"
+
+    def get_code_sandbox(self, notebook_name):
+        return self._kernel
+
+    @contextlib.asynccontextmanager
+    async def _connection(self):
+        yield self._notebook
+
+    def get_current_connection(self):
+        return self._connection()
+
+
+@pytest.fixture
+def running_task():
+    """A task this call is running as, and the store holding it."""
+    store = MemoryTaskStore()
+    use_task_store(store)
+    token = CURRENT_TASK.set("tsk_under_test")
+    try:
+        yield store
+    finally:
+        CURRENT_TASK.reset(token)
+        use_task_store(None)
+
+
+async def _seed(store):
+    await store.create(TaskRecord(task_id="tsk_under_test"))
+
+
+@pytest.mark.asyncio
+async def test_the_streaming_path_registers_and_records(running_task):
+    """The path that was reported broken."""
+    await _seed(running_task)
+    cell = {"source": "print()", "outputs": []}
+    kernel = FakeKernel()
+
+    await ExecuteCellTool().execute(
+        mode=ServerMode.MCP_SERVER,
+        notebook_manager=FakeNotebookManager(FakeNotebook(cell), kernel),
+        cell_index=0,
+        timeout_seconds=30,
+        stream=True,
+        progress_interval=1,
+        ensure_code_sandbox_alive_fn=lambda: kernel,
+    )
+
+    record = await running_task.get("tsk_under_test")
+    # Output first: a regression in recording is otherwise masked by the
+    # interrupt assertion failing before it, and the two are separate bugs
+    # with separate fixes.
+    assert len(record.partial) == 2, record.partial
+    assert record.interrupt is not None, "no way to stop the cell"
+
+
+@pytest.mark.asyncio
+async def test_the_non_streaming_path_registers_and_records(running_task):
+    """The path that already worked, measured the same way so the two are
+    held to one standard."""
+    await _seed(running_task)
+    cell = {"source": "print()", "outputs": []}
+    kernel = FakeKernel()
+
+    await execute_cell_with_forced_sync(
+        FakeNotebook(cell),
+        0,
+        kernel,
+        timeout_seconds=30,
+        progress_interval=1,
+    )
+
+    record = await running_task.get("tsk_under_test")
+    # Output first: a regression in recording is otherwise masked by the
+    # interrupt assertion failing before it, and the two are separate bugs
+    # with separate fixes.
+    assert len(record.partial) == 2, record.partial
+    assert record.interrupt is not None, "no way to stop the cell"
+
+
+@pytest.mark.asyncio
+async def test_the_registered_interrupt_is_the_kernel_s(running_task):
+    """Registering something that is not the kernel's interrupt would satisfy
+    the check above and stop nothing."""
+    await _seed(running_task)
+    cell = {"source": "print()", "outputs": []}
+    kernel = FakeKernel()
+
+    await ExecuteCellTool().execute(
+        mode=ServerMode.MCP_SERVER,
+        notebook_manager=FakeNotebookManager(FakeNotebook(cell), kernel),
+        cell_index=0,
+        timeout_seconds=30,
+        stream=True,
+        progress_interval=1,
+        ensure_code_sandbox_alive_fn=lambda: kernel,
+    )
+
+    record = await running_task.get("tsk_under_test")
+    record.interrupt()
+    assert kernel.interrupted is True

--- a/tests/test_execute_records_into_the_task.py
+++ b/tests/test_execute_records_into_the_task.py
@@ -1,3 +1,7 @@
+# Copyright (c) 2024- Datalayer, Inc.
+#
+# BSD 3-Clause License
+
 # Copyright (c) 2023-2026 Datalayer, Inc.
 #
 # BSD 3-Clause License

--- a/tests/test_extension_seams.py
+++ b/tests/test_extension_seams.py
@@ -1,0 +1,194 @@
+# Copyright (c) 2024- Datalayer, Inc.
+#
+# BSD 3-Clause License
+
+"""Where a deployment substitutes its own behaviour for this server's.
+
+This package is the scaffolding: the protocol surface, the tools against a
+plain Jupyter server, and the mechanisms. What a *deployment* does with those
+mechanisms is its own — and the seams here are how it says so, in the shape
+this package already uses for the audit sink, the token verifier and the task
+store: an environment variable naming a class.
+
+Two exist for the subscription work, and each answers a real problem rather
+than a hypothetical one.
+
+`JUPYTER_MCP_PUBLISHER_CLASS` — the SDK's bus reaches clients attached to
+*this process*. That is the whole story for a server somebody runs on their
+laptop and no story at all behind several replicas, where a client attached
+to one never hears an edit made through another.
+
+`JUPYTER_MCP_RESOURCE_GATE_CLASS` — a deployment that addresses notebooks by
+its own identifiers serves its own resources and does not want these:
+`notebook://{name}` is the name a *worker* knows, and its clients have never
+seen one.
+
+Both default to the behaviour that makes this server work unconfigured,
+because a server that needs configuration to serve resources is a server that
+does not work out of the box.
+
+Launch the tests:
+```
+$ pytest tests/test_extension_seams.py -v
+```
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from jupyter_mcp_server import notifications, resources
+
+
+@pytest.fixture(autouse=True)
+def _clean():
+    """No seam configured, whatever a previous test did."""
+    notifications.use_publisher(None)
+    resources.use_gate(None)
+    yield
+    notifications.use_publisher(None)
+    resources.use_gate(None)
+
+
+class TestTheDefaultsNeedNoConfiguration:
+    def test_no_publisher_is_configured_by_default(self):
+        assert notifications.resolve_publisher() is None
+
+    def test_every_resource_is_served_by_default(self):
+        for template in (
+            resources.NOTEBOOK_RESOURCE,
+            resources.CELL_RESOURCE,
+            resources.OUTPUT_RESOURCE,
+        ):
+            assert resources.serves(template) is True
+
+
+@pytest.mark.asyncio
+class TestSubstitutingThePublisher:
+    async def test_a_configured_publisher_gets_the_event(self):
+        sent = []
+
+        class _Publisher:
+            async def publish(self, uri):
+                sent.append(uri)
+                return True
+
+        notifications.use_publisher(_Publisher())
+        assert await notifications.publish_notebook_updated(object(), "work") is True
+        assert sent == ["notebook://work"]
+
+    async def test_the_in_process_bus_is_not_also_used(self):
+        """A deployment that has a publisher is one where this process is not
+        where the subscribers are. Publishing to both would send half the
+        event twice."""
+        published = []
+
+        class _Bus:
+            async def publish(self, event):
+                published.append(event)
+
+        class _Server:
+            def __init__(self):
+                handler = type("H", (), {"_bus": _Bus()})()
+                entry = type("E", (), {"handler": handler})()
+                self._lowlevel_server = type(
+                    "L", (), {"_request_handlers": {"subscriptions/listen": entry}}
+                )()
+
+        class _Publisher:
+            async def publish(self, uri):
+                return True
+
+        notifications.use_publisher(_Publisher())
+        await notifications.publish_notebook_updated(_Server(), "work")
+        assert published == []
+
+    async def test_a_failing_publisher_never_fails_the_edit(self):
+        class _Publisher:
+            async def publish(self, uri):
+                raise RuntimeError("the queue is gone")
+
+        notifications.use_publisher(_Publisher())
+        assert await notifications.publish_notebook_updated(object(), "work") is False
+
+
+class TestSubstitutingTheResourceGate:
+    def test_a_gate_can_withhold_a_resource(self):
+        class _Gate:
+            def serves(self, uri):
+                return "outputs" not in uri
+
+        resources.use_gate(_Gate())
+        assert resources.serves(resources.NOTEBOOK_RESOURCE) is True
+        assert resources.serves(resources.OUTPUT_RESOURCE) is False
+
+    def test_a_gate_that_cannot_decide_serves(self):
+        """The safe direction for a *scaffold*: a broken gate leaves the
+        server answering, rather than silently serving nothing and looking
+        like a server with no resources."""
+
+        class _Gate:
+            def serves(self, uri):
+                raise RuntimeError("no idea")
+
+        resources.use_gate(_Gate())
+        assert resources.serves(resources.NOTEBOOK_RESOURCE) is True
+
+    def test_withholding_is_not_the_same_as_not_found(self):
+        """"We do not answer this here" and "there is no such cell" are
+        different answers. A client told the second when the first is true
+        goes looking for a cell it will never find."""
+        assert not issubclass(resources.ResourceWithheld, resources.ResourceNotFound)
+        assert not issubclass(resources.ResourceNotFound, resources.ResourceWithheld)
+
+
+class TestTheResourcesActuallyAsk:
+    """A gate nothing consults is a setting that does nothing."""
+
+    @staticmethod
+    def _server_source() -> str:
+        import inspect
+
+        from jupyter_mcp_server import server
+
+        return inspect.getsource(server)
+
+    @pytest.mark.parametrize(
+        "template",
+        ["NOTEBOOK_RESOURCE", "CELL_RESOURCE", "OUTPUT_RESOURCE"],
+    )
+    def test_each_resource_asks_the_gate(self, template):
+        assert f"resources.serves(resources.{template})" in self._server_source()
+
+    def test_it_asks_before_reading_the_notebook(self):
+        """Reading first would make a withheld resource cost a round trip to
+        the document server before refusing."""
+        source = self._server_source()
+        assert source.index("resources.serves(resources.NOTEBOOK_RESOURCE)") < source.index(
+            "await resources.read_notebook(notebook_manager, name)"
+        )
+
+
+class TestTheSeamsLookLikeTheOnesAlreadyHere:
+    """One shape for every hook, so a deployment learns it once."""
+
+    def test_both_are_named_by_an_environment_variable(self):
+        assert notifications.PUBLISHER_CLASS_ENV.startswith("JUPYTER_MCP_")
+        assert resources.RESOURCE_GATE_CLASS_ENV.startswith("JUPYTER_MCP_")
+
+    def test_a_class_that_cannot_be_imported_is_fatal(self, monkeypatch):
+        """The audit sink's rule, for the audit sink's reason: a deployment
+        that configured this and got a server running without it believes
+        something is happening that is not."""
+        monkeypatch.setenv(notifications.PUBLISHER_CLASS_ENV, "no.such.module.Thing")
+        notifications.use_publisher(None)
+        notifications._publisher_resolved = False
+        with pytest.raises(RuntimeError):
+            notifications.resolve_publisher()
+
+    def test_a_class_of_the_wrong_shape_is_fatal(self, monkeypatch):
+        monkeypatch.setenv(resources.RESOURCE_GATE_CLASS_ENV, "builtins.object")
+        resources.use_gate(None)
+        resources._gate_resolved = False
+        with pytest.raises(RuntimeError):
+            resources.resolve_gate()

--- a/tests/test_notebook_resources.py
+++ b/tests/test_notebook_resources.py
@@ -1,0 +1,253 @@
+# Copyright (c) 2024- Datalayer, Inc.
+#
+# BSD 3-Clause License
+
+"""Notebook, cell and output resources: what an agent may read rather than be sent.
+
+Tools push. Everything a call produces comes back whether the agent wanted it
+or not, so a cell that printed a megabyte spends a megabyte of the client's
+context every time anybody reads it. Resources pull: the agent is told what
+exists and reads the one thing it needs.
+
+That is what the output resource is for, and why a cell lists its outputs
+rather than inlining them.
+
+Launch the tests:
+```
+$ pytest tests/test_notebook_resources.py -v
+```
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from jupyter_mcp_server import resources
+from jupyter_mcp_server.models import Cell, Notebook
+
+STREAM = {"output_type": "stream", "name": "stdout", "text": "hello\n"}
+IMAGE = {"output_type": "display_data", "data": {"image/png": "AAA", "text/plain": "<Figure>"}}
+ERROR = {"output_type": "error", "ename": "ValueError", "evalue": "no", "traceback": ["a", "b"]}
+
+
+def _notebook() -> Notebook:
+    return Notebook(
+        cells=[
+            Cell(cell_type="code", source="print('hello')", id="c1", outputs=[STREAM, IMAGE]),
+            Cell(cell_type="markdown", source="# Title", id="c2"),
+        ]
+    )
+
+
+class TestFindingACell:
+    def test_a_cell_is_found_by_its_id(self):
+        index, cell = resources.find_cell(_notebook(), "c2")
+        assert index == 1 and cell.cell_type == "markdown"
+
+    def test_an_unknown_id_is_not_found_rather_than_the_first_cell(self):
+        with pytest.raises(resources.ResourceNotFound):
+            resources.find_cell(_notebook(), "nope")
+
+    def test_the_message_says_an_index_is_not_an_id(self):
+        """The mistake somebody will make, given every tool takes an index."""
+        with pytest.raises(resources.ResourceNotFound) as refused:
+            resources.find_cell(_notebook(), "0")
+        assert "index is not an id" in str(refused.value)
+
+
+class TestTheOutputsType:
+    def test_a_stream_is_text(self):
+        assert resources.output_mime(STREAM) == "text/plain"
+
+    def test_an_image_is_an_image(self):
+        """`text/plain` is the fallback every kernel attaches beside the real
+        thing. Preferring it would read every figure as the words
+        `<Figure>`, and the agent could not tell that is what happened."""
+        assert resources.output_mime(IMAGE) == "image/png"
+
+    def test_an_error_is_text(self):
+        assert resources.output_mime(ERROR) == "text/plain"
+
+    def test_something_unrecognisable_is_text_rather_than_a_guess(self):
+        assert resources.output_mime({"output_type": "future_kind"}) == "text/plain"
+        assert resources.output_mime("not a dict") == "text/plain"
+
+
+class TestReadingAnOutput:
+    def test_a_stream_is_its_text(self):
+        assert resources.output_text(STREAM) == "hello\n"
+
+    def test_a_stream_written_as_a_list_is_joined(self):
+        """Kernels send either, and a client that got `['a', 'b']` back as a
+        string would show the brackets."""
+        assert resources.output_text(
+            {"output_type": "stream", "text": ["a", "b"]}
+        ) == "ab"
+
+    def test_an_error_is_its_traceback(self):
+        assert resources.output_text(ERROR) == "a\nb"
+
+    def test_an_error_with_no_traceback_still_says_what_it_was(self):
+        assert "ValueError: no" in resources.output_text(
+            {"output_type": "error", "ename": "ValueError", "evalue": "no"}
+        )
+
+    def test_an_image_is_its_own_data_not_its_caption(self):
+        assert resources.output_text(IMAGE) == "AAA"
+
+
+class TestTheCellDocument:
+    def test_it_is_json_a_program_can_read(self):
+        """Not the tools' `=====Cell 3 | type: code=====` banner, which is for
+        a person reading a transcript — an agent parsing it back into fields
+        gets it wrong on the first cell whose source contains "Cell"."""
+        document = json.loads(resources.cell_document("work", 0, _notebook()[0]))
+        assert document["id"] == "c1"
+        assert document["cell_type"] == "code"
+
+    def test_outputs_are_listed_and_not_inlined(self):
+        """The whole point. A cell that printed a megabyte would otherwise
+        cost a megabyte to read, which is what these resources exist to
+        avoid."""
+        document = json.loads(resources.cell_document("work", 0, _notebook()[0]))
+        assert [output["index"] for output in document["outputs"]] == [0, 1]
+        assert "hello" not in json.dumps(document["outputs"])
+
+    def test_each_output_carries_its_real_type_and_where_to_read_it(self):
+        """The MIME type is here rather than on the read, because the SDK
+        fixes a template's type at registration. An agent that needs to know
+        what an output *is* before spending context on it reads it here."""
+        document = json.loads(resources.cell_document("work", 0, _notebook()[0]))
+        assert document["outputs"][1]["mimeType"] == "image/png"
+        assert document["outputs"][1]["uri"] == "notebook://work/cells/c1/outputs/1"
+
+    def test_the_uri_names_the_notebook_it_came_from(self):
+        """It carried the literal `{name}` in the first version of this, which
+        is a URI no client can resolve and every client would try."""
+        document = json.loads(resources.cell_document("other", 0, _notebook()[0]))
+        assert "{name}" not in json.dumps(document)
+        assert document["outputs"][0]["uri"].startswith("notebook://other/")
+
+
+class TestWhatIsRegistered:
+    """The templates, the audiences and the cache hints, as a client sees them."""
+
+    @pytest.fixture(scope="class")
+    def templates(self):
+        import asyncio
+
+        from jupyter_mcp_server.server import mcp
+
+        return {
+            template.uri_template: template
+            for template in asyncio.run(mcp.list_resource_templates())
+        }
+
+    def test_all_three_are_templates(self, templates):
+        assert resources.NOTEBOOK_RESOURCE in templates
+        assert resources.CELL_RESOURCE in templates
+        assert resources.OUTPUT_RESOURCE in templates
+
+    def test_the_scheme_is_provider_neutral(self, templates):
+        """This server talks to a Jupyter server. A `datalayer://` URI here
+        would be a hosted platform's identifier on a resource that has
+        nothing to do with it."""
+        for uri in templates:
+            assert not uri.startswith("datalayer://")
+
+    def test_a_notebook_is_addressed_by_name_not_by_path(self, templates):
+        """A path contains slashes and cannot sit in one template segment
+        without being encoded into something nobody can read."""
+        assert "{name}" in resources.NOTEBOOK_RESOURCE
+        assert "{path}" not in resources.NOTEBOOK_RESOURCE
+
+    def test_a_cell_is_addressed_by_id_not_by_index(self, templates):
+        """An index is a position in a document somebody else is editing."""
+        assert "{cell_id}" in resources.CELL_RESOURCE
+        assert "{cell_index}" not in resources.CELL_RESOURCE
+
+    def test_an_output_is_for_the_assistant(self, templates):
+        """A person reads outputs in their notebook, where they are rendered,
+        not through a URI."""
+        annotations = templates[resources.OUTPUT_RESOURCE].annotations
+        assert annotations.audience == ["assistant"]
+
+    def test_a_notebook_is_for_both(self, templates):
+        annotations = templates[resources.NOTEBOOK_RESOURCE].annotations
+        assert set(annotations.audience) == {"assistant", "user"}
+
+    def test_every_one_is_cached_privately(self, templates):
+        """A notebook is one caller's. A proxy that shared this answer would
+        hand somebody else's work to whoever asked next."""
+        from jupyter_mcp_server.results import CACHE_META_KEY, SCOPE_PRIVATE
+
+        for uri in (resources.NOTEBOOK_RESOURCE, resources.CELL_RESOURCE, resources.OUTPUT_RESOURCE):
+            block = (templates[uri].meta or {}).get(CACHE_META_KEY) or {}
+            assert block.get("cacheScope") == SCOPE_PRIVATE, uri
+            assert block.get("ttlMs", 0) > 0, uri
+
+    def test_an_output_is_held_longer_than_the_notebook(self, templates):
+        """It does not change: a re-run replaces a cell's outputs rather than
+        editing one, and the new ones are at new positions."""
+        assert resources.OUTPUT_TTL_MS > resources.NOTEBOOK_TTL_MS
+
+
+class TestThePageSaysWhatTheCodeDoes:
+    """The resources page makes four claims a reader would act on.
+
+    Each is held against the code, in the style `test_documented_features`
+    uses for the tasks page: a page that describes a URI scheme, a cache
+    scope or a MIME rule the code does not follow is worse than no page,
+    because somebody writes a client against it.
+    """
+
+    @pytest.fixture(scope="class")
+    def page(self):
+        import pathlib
+
+        path = (
+            pathlib.Path(__file__).resolve().parent.parent
+            / "docs"
+            / "docs"
+            / "architecture"
+            / "resources"
+            / "index.mdx"
+        )
+        if not path.is_file():
+            pytest.skip("the resources page is not here")
+        return path.read_text()
+
+    def test_the_three_uris_it_shows_are_the_three_registered(self, page):
+        for uri in (
+            resources.NOTEBOOK_RESOURCE,
+            resources.CELL_RESOURCE,
+            resources.OUTPUT_RESOURCE,
+        ):
+            assert f"`{uri}`" in page, uri
+
+    def test_the_ttls_it_quotes_are_the_ttls(self, page):
+        assert f"{resources.NOTEBOOK_TTL_MS // 1000} seconds" in page
+        assert resources.OUTPUT_TTL_MS == 60_000 and "a minute" in page
+
+    def test_it_still_says_the_output_audience_is_the_assistant(self, page):
+        """A negative-ish claim: the page tells a reader a person will not see
+        these, and nothing about widening the audience makes anybody re-read
+        the paragraph."""
+        import asyncio
+
+        from jupyter_mcp_server.server import mcp
+
+        templates = {
+            template.uri_template: template
+            for template in asyncio.run(mcp.list_resource_templates())
+        }
+        assert templates[resources.OUTPUT_RESOURCE].annotations.audience == [
+            "assistant"
+        ]
+        assert "audience is the **assistant** alone" in page
+
+    def test_the_richest_type_rule_it_explains_is_the_rule(self, page):
+        assert "preferring it would read every figure as" in page
+        assert resources.output_mime(IMAGE) == "image/png"

--- a/tests/test_notebook_update_notifications.py
+++ b/tests/test_notebook_update_notifications.py
@@ -1,0 +1,216 @@
+# Copyright (c) 2024- Datalayer, Inc.
+#
+# BSD 3-Clause License
+
+"""A subscribed client hears that a notebook changed.
+
+One worker serves one user, and that user may have several agents. So this is
+the ordinary case rather than an exotic one: agent A edits a cell, agent B is
+subscribed to the notebook, and B finds out — same process, no polling.
+
+The channel is the SDK's. At 2026-07-28 a client opens `subscriptions/listen`
+naming the URIs it cares about, and the SDK acknowledges, filters and
+streams; it even ships the bus. What was missing was anybody publishing onto
+it.
+
+Worth stating because the obvious reading of "implement subscriptions" is to
+write `resources/subscribe`, and on the modern wire the SDK *ignores* that
+handler: `get_capabilities` derives the capability from whether
+`subscriptions/listen` is served.
+
+Launch the tests:
+```
+$ pytest tests/test_notebook_update_notifications.py -v
+```
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from jupyter_mcp_server import notifications
+
+
+class _Bus:
+    """A bus that remembers, standing in for the SDK's."""
+
+    def __init__(self, explode: bool = False) -> None:
+        self.published: list = []
+        self._explode = explode
+
+    async def publish(self, event) -> None:
+        if self._explode:
+            raise RuntimeError("the stream is gone")
+        self.published.append(event)
+
+
+class _Server:
+    def __init__(self, bus=None) -> None:
+        handler = type("H", (), {"_bus": bus})()
+        entry = type("E", (), {"handler": handler})()
+        self._lowlevel_server = type(
+            "L", (), {"_request_handlers": {"subscriptions/listen": entry}}
+        )()
+
+
+class TestWhichNotebookChanged:
+    def test_the_tool_s_own_argument_wins(self):
+        assert notifications.target_notebook({"notebook_name": "other"}, lambda: "current") == "other"
+
+    def test_the_activated_notebook_otherwise(self):
+        assert notifications.target_notebook({}, lambda: "current") == "current"
+
+    def test_a_blank_argument_is_not_a_name(self):
+        """A subscriber told the *wrong* notebook changed is worse than one
+        told nothing: it refetches the wrong document and believes it is
+        current."""
+        assert notifications.target_notebook({"notebook_name": "  "}, lambda: "current") == "current"
+
+    def test_no_current_notebook_is_no_name_rather_than_a_crash(self):
+        def boom():
+            raise RuntimeError("none open")
+
+        assert notifications.target_notebook({}, boom) == ""
+
+
+@pytest.mark.asyncio
+class TestPublishing:
+    async def test_a_subscriber_is_told_the_notebook_uri(self):
+        bus = _Bus()
+        assert await notifications.publish_notebook_updated(_Server(bus), "work") is True
+        assert [event.uri for event in bus.published] == ["notebook://work"]
+
+    async def test_the_uri_is_the_one_the_resource_is_read_at(self):
+        """A subscriber matches on the URI it subscribed to. A different
+        spelling here is an event the SDK filters out, and nothing anywhere
+        says so — the client simply never hears."""
+        from jupyter_mcp_server import resources
+
+        assert notifications.notebook_uri("work") == resources.NOTEBOOK_RESOURCE.replace(
+            "{name}", "work"
+        )
+
+    async def test_nothing_is_published_for_no_notebook(self):
+        bus = _Bus()
+        assert await notifications.publish_notebook_updated(_Server(bus), "") is False
+        assert bus.published == []
+
+    async def test_a_server_with_no_stream_is_not_an_error(self):
+        """An older SDK, or a server built without the listen handler."""
+        assert await notifications.publish_notebook_updated(_Server(None), "work") is False
+
+    async def test_a_failing_bus_never_fails_the_edit(self):
+        """It runs after the tool has done its work and returned. Failing the
+        edit because the news about the edit would not go out trades the work
+        for the story about the work."""
+        assert await notifications.publish_notebook_updated(_Server(_Bus(explode=True)), "work") is False
+
+
+class TestWhichCallsAnnounce:
+    """The set is declared as what *mutates*, not as "not the readers"."""
+
+    def test_the_writing_tools_are_in_it(self):
+        for kind in ("cell.edit", "cell.insert", "cell.delete", "cell.execute"):
+            assert kind in notifications.MUTATING_KINDS
+
+    def test_the_reading_tools_are_not(self):
+        """A reader that published would wake every subscriber on every read,
+        and a subscriber that refetches on every read is a polling loop with
+        extra steps."""
+        for kind in ("cell.read", "notebook.read", "notebooks.list", "kernels.list"):
+            assert kind not in notifications.MUTATING_KINDS
+
+    def test_every_kind_named_here_is_a_kind_the_server_declares(self):
+        """A typo publishes nothing and looks like a decision. Held against
+        the `@structured` decorators rather than a second list."""
+        import pathlib
+        import re
+
+        import jupyter_mcp_server
+
+        root = pathlib.Path(jupyter_mcp_server.__file__).parent
+        declared = set()
+        for path in root.rglob("*.py"):
+            declared.update(re.findall(r'@structured\(\s*"([^"]+)"', path.read_text()))
+        assert declared, "no @structured kinds found; the search stopped working"
+        assert notifications.MUTATING_KINDS <= declared, (
+            notifications.MUTATING_KINDS - declared
+        )
+
+    def test_every_cell_writing_kind_the_server_declares_is_named(self):
+        """The direction that goes silently wrong: a new writing tool missing
+        from the set publishes nothing, and a subscriber never learns."""
+        import pathlib
+        import re
+
+        import jupyter_mcp_server
+
+        root = pathlib.Path(jupyter_mcp_server.__file__).parent
+        declared = set()
+        for path in root.rglob("*.py"):
+            declared.update(re.findall(r'@structured\(\s*"([^"]+)"', path.read_text()))
+        writing = {
+            kind
+            for kind in declared
+            if kind.startswith("cell.")
+            and not kind.endswith(".read")
+        }
+        assert writing <= notifications.MUTATING_KINDS, writing - notifications.MUTATING_KINDS
+
+
+class TestTheDecoratorActuallyAnnounces:
+    """A publisher nothing calls tells nobody anything.
+
+    The recurring shape here: `register_interrupt` was defined, tested and
+    called by nothing for as long as it existed. So the call site is asserted
+    as well as the function.
+    """
+
+    def test_the_result_wrapper_publishes(self):
+        import inspect
+
+        from jupyter_mcp_server import results
+
+        source = inspect.getsource(results.structured)
+        assert "publish_notebook_updated(" in source
+        assert "MUTATING_KINDS" in source
+
+    def test_it_publishes_after_the_call_and_not_before(self):
+        """A subscriber told a cell changed before it did refetches the old
+        document and caches it as new."""
+        import inspect
+
+        from jupyter_mcp_server import results
+
+        source = inspect.getsource(results.structured)
+        assert source.index("await wrapper(") < source.index("publish_notebook_updated(")
+
+
+class TestThePageSaysWhatHappens:
+    """Two claims a reader would act on, held against the code."""
+
+    @staticmethod
+    def _page() -> str:
+        import pathlib
+
+        path = (
+            pathlib.Path(__file__).resolve().parent.parent
+            / "docs"
+            / "docs"
+            / "architecture"
+            / "resources"
+            / "index.mdx"
+        )
+        if not path.is_file():
+            pytest.skip("the resources page is not here")
+        return path.read_text()
+
+    def test_it_says_the_event_carries_the_notebook_uri(self):
+        page = self._page()
+        assert "`notebook://{name}` in" in page
+        assert notifications.notebook_uri("x") == "notebook://x"
+
+    def test_it_still_says_another_party_is_not_covered(self):
+        """A negative claim: nothing about adding a persistent observer later
+        makes anybody re-read the paragraph explaining its absence."""
+        assert "A change by somebody else is not covered" in self._page()

--- a/tests/test_notebook_update_notifications.py
+++ b/tests/test_notebook_update_notifications.py
@@ -31,6 +31,18 @@ import pytest
 from jupyter_mcp_server import notifications
 
 
+class _FakeSession:
+    """A stand-in for a `ServerSession`.
+
+    A class rather than `object()`, because the registry holds sessions
+    weakly and a bare `object()` cannot be weakly referenced — which is not a
+    property of anything real, only of the placeholder.
+    """
+
+    async def send_resource_updated(self, uri):
+        return None
+
+
 class _Bus:
     """A bus that remembers, standing in for the SDK's."""
 
@@ -184,6 +196,146 @@ class TestTheDecoratorActuallyAnnounces:
 
         source = inspect.getsource(results.structured)
         assert source.index("await wrapper(") < source.index("publish_notebook_updated(")
+
+
+class TestTheOlderWayToAsk:
+    """`resources/subscribe`, which is how a 2025-11-25 client asks.
+
+    Registered even though the modern wire cannot dispatch it, because this
+    server answers both eras and most clients today are on the older one.
+    Registering it is also what makes `resources.subscribe` true in the
+    2025-11-25 handshake — the SDK derives that capability from whether the
+    handler exists — and it is what takes `resources-subscribe` and
+    `resources-unsubscribe` out of the conformance baseline.
+    """
+
+    def test_both_methods_are_served(self):
+        from jupyter_mcp_server.server import mcp
+
+        handlers = mcp._lowlevel_server._request_handlers
+        assert "resources/subscribe" in handlers
+        assert "resources/unsubscribe" in handlers
+
+    def test_the_older_handshake_now_offers_subscription(self):
+        from mcp.server.lowlevel.server import NotificationOptions
+
+        from jupyter_mcp_server.server import mcp
+
+        capabilities = mcp._lowlevel_server.get_capabilities(
+            NotificationOptions(), {}, protocol_version="2025-11-25"
+        )
+        assert capabilities.resources.subscribe is True
+
+    def test_a_session_hears_about_what_it_subscribed_to(self):
+        session = _FakeSession()
+        notifications.legacy_subscribe(session, "notebook://work")
+        try:
+            assert session in notifications.legacy_subscribers("notebook://work")
+        finally:
+            notifications.legacy_unsubscribe(session, "notebook://work")
+
+    def test_a_session_hears_nothing_about_anything_else(self):
+        session = _FakeSession()
+        notifications.legacy_subscribe(session, "notebook://work")
+        try:
+            assert notifications.legacy_subscribers("notebook://other") == []
+        finally:
+            notifications.legacy_unsubscribe(session, "notebook://work")
+
+    def test_unsubscribing_stops_it(self):
+        session = _FakeSession()
+        notifications.legacy_subscribe(session, "notebook://work")
+        notifications.legacy_unsubscribe(session, "notebook://work")
+        assert notifications.legacy_subscribers("notebook://work") == []
+
+    def test_unsubscribing_from_something_never_subscribed_is_not_an_error(self):
+        """The client's intent — stop telling me about this — is satisfied
+        either way, and refusing it teaches a client to retry something that
+        is already true."""
+        notifications.legacy_unsubscribe(_FakeSession(), "notebook://never")
+
+    def test_a_real_session_can_be_held_weakly(self):
+        """The registry is weak-keyed, so a session that cannot be weakly
+        referenced would make every `resources/subscribe` raise. A bare
+        `object()` cannot be — which is how this was found — and an SDK that
+        gave `ServerSession` `__slots__` without `__weakref__` would break it
+        the same way, silently, at the first subscribe."""
+        import weakref
+
+        from mcp.server.session import ServerSession
+
+        class _Unconstructed(ServerSession):
+            def __init__(self):  # noqa: D107 - the constructor is not the point
+                pass
+
+        weakref.ref(_Unconstructed())
+
+    def test_a_session_that_goes_away_takes_its_subscriptions_with_it(self):
+        """The map is weak-keyed. The alternative is an unsubscribe hook that
+        has to fire on every way a connection can end — including the ones
+        that run no code — and a subscription nobody can reach is a
+        notification sent for ever to nobody."""
+        import gc
+
+        class _Session:
+            pass
+
+        session = _Session()
+        notifications.legacy_subscribe(session, "notebook://ghost")
+        assert notifications.legacy_subscribers("notebook://ghost")
+        del session
+        gc.collect()
+        assert notifications.legacy_subscribers("notebook://ghost") == []
+
+
+@pytest.mark.asyncio
+class TestBothErasAreTold:
+    """Both halves run, because both eras can be connected at once.
+
+    This server answers 2026-07-28 and 2025-11-25, and a client on each is
+    two clients. Sending only on the wire the last subscriber used would
+    leave the other silent — a bug that appears only when two are connected.
+    """
+
+    async def test_a_legacy_subscriber_is_told(self):
+        told = []
+
+        class _Session:
+            async def send_resource_updated(self, uri):
+                told.append(uri)
+
+        session = _Session()
+        notifications.legacy_subscribe(session, "notebook://work")
+        try:
+            await notifications.publish_notebook_updated(_Server(_Bus()), "work")
+        finally:
+            notifications.legacy_unsubscribe(session, "notebook://work")
+        assert told == ["notebook://work"]
+
+    async def test_the_bus_is_told_as_well(self):
+        bus = _Bus()
+
+        class _Session:
+            async def send_resource_updated(self, uri):
+                return None
+
+        session = _Session()
+        notifications.legacy_subscribe(session, "notebook://work")
+        try:
+            await notifications.publish_notebook_updated(_Server(bus), "work")
+        finally:
+            notifications.legacy_unsubscribe(session, "notebook://work")
+        assert [event.uri for event in bus.published] == ["notebook://work"]
+
+    async def test_a_dead_session_is_dropped_rather_than_retried_for_ever(self):
+        class _Session:
+            async def send_resource_updated(self, uri):
+                raise RuntimeError("gone")
+
+        session = _Session()
+        notifications.legacy_subscribe(session, "notebook://work")
+        await notifications.publish_notebook_updated(_Server(_Bus()), "work")
+        assert notifications.legacy_subscribers("notebook://work") == []
 
 
 class TestThePageSaysWhatHappens:

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -22,6 +22,7 @@ $ pytest tests/test_tasks.py -v
 from __future__ import annotations
 
 import asyncio
+import pathlib
 
 import pytest
 from mcp.shared.exceptions import MCPError
@@ -1000,50 +1001,142 @@ async def test_a_failed_task_keeps_what_it_printed(extension, store):
 # ---------------------------------------------------------------------------
 
 
-def _loop_source() -> str:
-    import inspect
+def _execution_wait_loops() -> dict[str, str]:
+    """Every loop that waits for a cell to finish, found rather than named.
 
-    from jupyter_mcp_server import utils
+    The first version of this read one module — `utils` — and asserted the
+    two hooks were in it. `execute_cell(stream=True)` runs a *second* monitor
+    loop in `execute_cell_tool`, which is the documented mode for
+    long-running cells and therefore the one most likely to be cancelled, and
+    it had neither hook. The test could not see it, so it said nothing.
 
-    source = inspect.getsource(utils)
-    start = source.index("    last_output_count = 0")
-    return source[start : source.index("# Get final result", start)]
-
-
-def test_the_kernel_interrupt_is_registered_by_the_execution_loop():
-    """`register_interrupt` was defined, tested, documented and called by no
-    tool for as long as it existed — so cancelling said `cancelled` while the
-    kernel kept running the cell.
-
-    The *call*, not the name: an earlier version of this asserted
-    `"register_interrupt" in body`, which the import line satisfies on its
-    own, so deleting the call left the test green.
+    So the loops are located by shape: `while not <something>.done():` inside
+    the package. A third one added anywhere is covered on the day it is
+    written, which is the only version of this check worth having.
     """
-    assert "await register_interrupt(kernel.interrupt)" in _loop_source()
+    import ast
+
+    import jupyter_mcp_server
+
+    found: dict[str, str] = {}
+    root = pathlib.Path(jupyter_mcp_server.__file__).parent
+    for path in sorted(root.rglob("*.py")):
+        source = path.read_text()
+        try:
+            tree = ast.parse(source)
+        except SyntaxError:  # pragma: no cover
+            continue
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.While):
+                continue
+            test = node.test
+            if not (
+                isinstance(test, ast.UnaryOp)
+                and isinstance(test.op, ast.Not)
+                and isinstance(test.operand, ast.Call)
+                and isinstance(test.operand.func, ast.Attribute)
+                and test.operand.func.attr == "done"
+            ):
+                continue
+            where = f"{path.relative_to(root)}:{node.lineno}"
+            found[where] = ast.get_source_segment(source, node) or ""
+    return found
 
 
-def test_the_interrupt_is_registered_before_the_wait_begins():
-    """Registered inside the loop, a cell cancelled in its first second has
-    nothing to interrupt."""
-    body = _loop_source()
-    assert body.index("register_interrupt") < body.index(
-        "while not execution_future.done()"
-    )
+def _enclosing_source(where: str) -> str:
+    """The function a loop is in, so the registration before it is visible."""
+    import ast
+
+    import jupyter_mcp_server
+
+    name, line = where.rsplit(":", 1)
+    path = pathlib.Path(jupyter_mcp_server.__file__).parent / name
+    source = path.read_text()
+    tree = ast.parse(source)
+    best = ""
+    for node in ast.walk(tree):
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            end = getattr(node, "end_lineno", node.lineno)
+            if node.lineno <= int(line) <= end:
+                segment = ast.get_source_segment(source, node) or ""
+                # The innermost enclosing function, which is the one holding
+                # the kernel.
+                if not best or len(segment) < len(best):
+                    best = segment
+    return best
 
 
-def test_the_outputs_are_recorded_where_new_ones_are_noticed():
-    """Not on the keepalive tick: that fires on a timer whether or not
-    anything was produced, so recording there would rewrite the same list
-    every few seconds and miss a burst between two ticks."""
-    body = _loop_source()
-    assert "await record_output(safe_extract_outputs(" in body
-    assert body.index("last_output_count = len(current_outputs)") < body.index(
-        "await record_output("
-    )
-    assert body.index("await record_output(") < body.index("emit_execution_progress")
+def test_there_is_more_than_one_execution_wait_loop():
+    """The premise of the two tests below, asserted rather than assumed.
+
+    If this ever finds one loop again, either a duplicate was removed — good,
+    and these tests should be simplified — or the search stopped working, and
+    the tests below became vacuous without saying so.
+    """
+    loops = _execution_wait_loops()
+    assert len(loops) >= 2, f"found {sorted(loops)}"
 
 
-def test_neither_hook_can_fail_the_cell():
+def _loops_that_can_interrupt() -> list[str]:
+    """The loops that hold something interruptible.
+
+    All of them, today. Written as a rule rather than asserted of every loop
+    so that a future wait loop with nothing to stop — waiting on a queue,
+    say — is not required to invent an interrupt.
+    """
+    return [
+        where
+        for where in _execution_wait_loops()
+        if ".interrupt()" in _enclosing_source(where)
+    ]
+
+
+@pytest.mark.parametrize("where", sorted(_loops_that_can_interrupt()))
+def test_every_execution_wait_loop_registers_the_interrupt(where):
+    """Cancelling a task cancels the coroutine that *waits* for the cell. The
+    kernel keeps running it, keeps holding the sandbox and keeps costing
+    money, while the task says `cancelled`.
+
+    The *call*, not the name: an earlier version asserted
+    `"register_interrupt" in body`, which the import line satisfies on its
+    own, so deleting the call left it green.
+    """
+    body = _enclosing_source(where)
+    assert "await register_interrupt(" in body, where
+
+
+def _loops_that_watch_outputs() -> list[str]:
+    """The loops that can see output arrive, which are the ones that can
+    stream it.
+
+    Not every wait loop can: `execute_code` waits on a call that returns its
+    outputs whole, so there is nothing to record until it is over. Demanding
+    it of that loop would be demanding something it has no way to do, and the
+    exemption belongs in the rule rather than in a list of names.
+    """
+    return [
+        where
+        for where, loop in _execution_wait_loops().items()
+        if '"outputs"' in loop
+    ]
+
+
+def test_some_loops_watch_outputs_arrive():
+    """The premise of the test below."""
+    assert _loops_that_watch_outputs()
+
+
+@pytest.mark.parametrize("where", sorted(_loops_that_watch_outputs()))
+def test_every_loop_that_watches_outputs_records_them(where):
+    """A cell cancelled at minute nine of ten has no result and may have
+    printed five hundred lines."""
+    loop = _execution_wait_loops()[where]
+    assert "await record_output(" in loop, where
+
+
+@pytest.mark.parametrize("where", sorted(_loops_that_can_interrupt()))
+def test_neither_hook_can_fail_the_cell(where):
     """Both are bookkeeping about the work. Failing a cell because the note
     about the cell would not go out trades the work for the story about it."""
-    assert _loop_source().count("except Exception") >= 2
+    body = _enclosing_source(where)
+    assert body.count("except Exception") >= 2, where

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -836,139 +836,214 @@ async def test_listing_answers_newest_first(store, extension):
     assert [task.task_id for task in listed.tasks] == ["tsk_2", "tsk_1", "tsk_0"]
 
 
-class TestWhatTheWorkProducedBeforeItStopped:
-    """A cancelled cell that printed five hundred lines printed five hundred
-    lines.
+# ---------------------------------------------------------------------------
+# What the work produced before it stopped
+# ---------------------------------------------------------------------------
 
-    `result` arrives whole when the tool returns, which is the right shape for
-    a call that finishes and no shape at all for one that does not. Cancel a
-    ten-minute cell at minute nine and the task was `cancelled` with
-    `result: None` — indistinguishable from a cell that produced nothing, and
-    the opposite of what the person who cancelled it wanted to read.
+
+@pytest.mark.asyncio
+async def test_cancelling_serves_what_the_work_had_already_printed(extension, store):
+    """The whole point of recording output, through the path a client takes.
+
+    An earlier version of this test called `_mark_cancelled` directly on a
+    still-working record, which is a state the real flow never reaches:
+    `tasks/cancel` writes `cancelled` first and *then* the coroutine unwinds.
+    So the test passed against code that skipped the promotion on every real
+    cancellation — a green test for a feature that never once ran.
     """
+    started = asyncio.Event()
 
-    async def test_a_synchronous_call_records_nothing_and_says_so(self):
-        """It has no task to attach to and needs none: the client is still on
-        the other end of the connection."""
-        assert await record_output(["out"]) is False
+    async def call_next(ctx):
+        await record_output(["line one", "line two"])
+        started.set()
+        await asyncio.Event().wait()
 
-    async def test_the_output_so_far_is_on_the_record(self, store):
-        record = await store.create(TaskRecord(task_id="tsk_partial"))
-        token = CURRENT_TASK.set(record.task_id)
-        try:
-            assert await record_output(["one", "two"]) is True
-        finally:
-            CURRENT_TASK.reset(token)
-        assert (await store.get("tsk_partial")).partial == ["one", "two"]
+    answer = await extension.intercept_tool_call(
+        call(task=TaskMetadata()), object(), call_next
+    )
+    await asyncio.wait_for(started.wait(), timeout=2)
+    await extension._handle_cancel(_Params(answer.task.task_id), object())
+    await settle()
 
-    async def test_it_replaces_rather_than_appends(self, store):
-        """The caller holds the whole list of outputs so far. Appending would
-        make every reader deduplicate what it reads."""
-        await store.create(TaskRecord(task_id="tsk_replace"))
-        token = CURRENT_TASK.set("tsk_replace")
-        try:
-            await record_output(["one"])
-            await record_output(["one", "two"])
-        finally:
-            CURRENT_TASK.reset(token)
-        assert (await store.get("tsk_replace")).partial == ["one", "two"]
-
-    async def test_a_cancelled_task_serves_what_it_produced(self, store):
-        extension = TasksExtension(store)
-        await store.create(TaskRecord(task_id="tsk_c", partial=["printed"]))
-        await extension._mark_cancelled("tsk_c")
-        record = await store.get("tsk_c")
-        assert record.status == "cancelled"
-        assert record.result == ["printed"]
-
-    async def test_a_cancelled_task_that_produced_nothing_has_no_result(
-        self, store
-    ):
-        """Empty is not the same as "we did not look": a task with no partial
-        output must not gain an empty list that reads like a measured zero."""
-        extension = TasksExtension(store)
-        await store.create(TaskRecord(task_id="tsk_none"))
-        await extension._mark_cancelled("tsk_none")
-        assert (await store.get("tsk_none")).result is None
-
-    async def test_a_result_that_arrived_is_not_overwritten_by_the_partial(
-        self, store
-    ):
-        """The tool's own result is the complete one. A race between the tool
-        returning and the cancellation landing must not replace it with the
-        half that was visible a moment earlier."""
-        extension = TasksExtension(store)
-        await store.create(
-            TaskRecord(task_id="tsk_both", partial=["half"], result=["whole"])
-        )
-        await extension._mark_cancelled("tsk_both")
-        assert (await store.get("tsk_both")).result == ["whole"]
-
-    async def test_a_terminal_task_is_not_re_cancelled(self, store):
-        extension = TasksExtension(store)
-        await store.create(
-            TaskRecord(task_id="tsk_done", status="completed", result=["whole"])
-        )
-        await extension._mark_cancelled("tsk_done")
-        record = await store.get("tsk_done")
-        assert record.status == "completed" and record.result == ["whole"]
+    record = await store.get(answer.task.task_id)
+    assert record.status == "cancelled"
+    assert record.result == ["line one", "line two"]
 
 
-class TestTheExecutionLoopActuallyCallsThem:
+@pytest.mark.asyncio
+async def test_a_cancelled_task_that_printed_nothing_has_no_result(extension, store):
+    """Empty is not the same as "we did not look". An empty list here reads
+    as a measured zero rather than as nothing to measure, which is the
+    distinction `tasks/result`'s two refusals exist for."""
+
+    async def call_next(ctx):
+        await asyncio.Event().wait()
+
+    answer = await extension.intercept_tool_call(
+        call(task=TaskMetadata()), object(), call_next
+    )
+    await settle()
+    await extension._handle_cancel(_Params(answer.task.task_id), object())
+    await settle()
+    assert (await store.get(answer.task.task_id)).result is None
+
+
+@pytest.mark.asyncio
+async def test_a_task_that_finished_first_keeps_its_own_result(extension, store):
+    """The race the client lost. A call that returned while the cancellation
+    was landing has the complete answer, and it must not be replaced by the
+    half that was visible a moment earlier."""
+
+    async def call_next(ctx):
+        await record_output(["half"])
+        return ["whole"]
+
+    answer = await extension.intercept_tool_call(
+        call(task=TaskMetadata()), object(), call_next
+    )
+    await settle()
+    await extension._handle_cancel(_Params(answer.task.task_id), object())
+    await settle()
+    record = await store.get(answer.task.task_id)
+    assert record.status == "completed"
+    assert record.result == ["whole"]
+
+
+@pytest.mark.asyncio
+async def test_mark_cancelled_leaves_a_finished_task_alone(extension, store):
+    """A guard, tested as a guard rather than as a path.
+
+    No current caller can reach it: `_mark_cancelled` runs only from `_run`'s
+    `CancelledError` branch, and a call that returned never raises one — so
+    mutation shows nothing else catches this. It is here because
+    `_mark_cancelled` is a method, the invariant is one line, and the failure
+    it prevents is silent: a completed task's own answer replaced by the half
+    that was visible a moment earlier.
+
+    Calling it directly is the mistake that shipped the last version of this
+    feature. The difference is what is being claimed — that the *guard*
+    holds, not that cancellation works.
+    """
+    await store.create(
+        TaskRecord(task_id="tsk_done", status="completed", partial=["half"])
+    )
+    await extension._mark_cancelled("tsk_done")
+    record = await store.get("tsk_done")
+    assert record.status == "completed"
+    assert record.result is None
+
+
+@pytest.mark.asyncio
+async def test_mark_cancelled_does_not_overwrite_a_result_it_already_has(
+    extension, store
+):
+    await store.create(
+        TaskRecord(task_id="tsk_kept", status="cancelled", partial=["half"], result=["whole"])
+    )
+    await extension._mark_cancelled("tsk_kept")
+    assert (await store.get("tsk_kept")).result == ["whole"]
+
+
+@pytest.mark.asyncio
+async def test_a_synchronous_call_records_nothing_and_says_so():
+    """It has no task to attach to and needs none: the client is still on the
+    other end of the connection."""
+    assert await record_output(["out"]) is False
+
+
+@pytest.mark.asyncio
+async def test_the_output_so_far_is_on_the_record(store):
+    await store.create(TaskRecord(task_id="tsk_partial"))
+    token = CURRENT_TASK.set("tsk_partial")
+    try:
+        assert await record_output(["one", "two"], store=store) is True
+    finally:
+        CURRENT_TASK.reset(token)
+    assert (await store.get("tsk_partial")).partial == ["one", "two"]
+
+
+@pytest.mark.asyncio
+async def test_recording_replaces_rather_than_appends(store):
+    """The caller holds the whole list of outputs so far. Appending would
+    make every reader deduplicate what it reads."""
+    await store.create(TaskRecord(task_id="tsk_replace"))
+    token = CURRENT_TASK.set("tsk_replace")
+    try:
+        await record_output(["one"], store=store)
+        await record_output(["one", "two"], store=store)
+    finally:
+        CURRENT_TASK.reset(token)
+    assert (await store.get("tsk_replace")).partial == ["one", "two"]
+
+
+@pytest.mark.asyncio
+async def test_a_failed_task_keeps_what_it_printed(extension, store):
+    """`tasks/result` raises for a failed task, so this is never served — it
+    is kept because a cell that printed for nine minutes and then raised has
+    the output somebody needs in order to see *why*."""
+
+    async def call_next(ctx):
+        await record_output(["progress"])
+        raise ValueError("the kernel is dead")
+
+    answer = await extension.intercept_tool_call(
+        call(task=TaskMetadata()), object(), call_next
+    )
+    await settle()
+    record = await store.get(answer.task.task_id)
+    assert record.status == "failed"
+    assert record.result == ["progress"]
+
+
+# ---------------------------------------------------------------------------
+# The execution loop actually calls them
+# ---------------------------------------------------------------------------
+
+
+def _loop_source() -> str:
+    import inspect
+
+    from jupyter_mcp_server import utils
+
+    source = inspect.getsource(utils)
+    start = source.index("    last_output_count = 0")
+    return source[start : source.index("# Get final result", start)]
+
+
+def test_the_kernel_interrupt_is_registered_by_the_execution_loop():
     """`register_interrupt` was defined, tested, documented and called by no
-    tool for as long as it existed.
+    tool for as long as it existed — so cancelling said `cancelled` while the
+    kernel kept running the cell.
 
-    That is the shape this whole effort keeps finding: the mechanism was
-    built and nothing used it, so cancelling a task said `cancelled` while
-    the kernel kept running the cell. Both hooks are asserted at the one
-    frame that holds the kernel and the outputs — the wait loop in `utils` —
-    because a helper nobody calls passes all of its own tests.
+    The *call*, not the name: an earlier version of this asserted
+    `"register_interrupt" in body`, which the import line satisfies on its
+    own, so deleting the call left the test green.
     """
+    assert "await register_interrupt(kernel.interrupt)" in _loop_source()
 
-    @staticmethod
-    def _loop_source() -> str:
-        import inspect
 
-        from jupyter_mcp_server import utils
+def test_the_interrupt_is_registered_before_the_wait_begins():
+    """Registered inside the loop, a cell cancelled in its first second has
+    nothing to interrupt."""
+    body = _loop_source()
+    assert body.index("register_interrupt") < body.index(
+        "while not execution_future.done()"
+    )
 
-        source = inspect.getsource(utils)
-        start = source.index("    last_output_count = 0")
-        return source[start : source.index("# Get final result", start)]
 
-    def test_the_kernel_interrupt_is_registered(self) -> None:
-        """Cancelling the task cancels the wait; the kernel keeps running the
-        cell, keeps holding the sandbox and keeps costing money."""
-        # The *call*, not the name. An earlier version of this asserted
-        # `"register_interrupt" in body`, which the import line satisfies on
-        # its own — so deleting the call left the test green.
-        body = self._loop_source()
-        assert "await register_interrupt(kernel.interrupt)" in body
+def test_the_outputs_are_recorded_where_new_ones_are_noticed():
+    """Not on the keepalive tick: that fires on a timer whether or not
+    anything was produced, so recording there would rewrite the same list
+    every few seconds and miss a burst between two ticks."""
+    body = _loop_source()
+    assert "await record_output(safe_extract_outputs(" in body
+    assert body.index("last_output_count = len(current_outputs)") < body.index(
+        "await record_output("
+    )
+    assert body.index("await record_output(") < body.index("emit_execution_progress")
 
-    def test_it_is_registered_before_the_wait_begins(self) -> None:
-        """Registered inside the loop, a cell cancelled in its first second
-        has nothing to interrupt."""
-        body = self._loop_source()
-        assert body.index("register_interrupt") < body.index("while not execution_future.done()")
 
-    def test_the_outputs_are_recorded_as_they_arrive(self) -> None:
-        body = self._loop_source()
-        assert "await record_output(safe_extract_outputs(" in body
-
-    def test_recording_is_where_new_outputs_are_noticed(self) -> None:
-        """Not on the keepalive tick: the keepalive fires on a timer whether
-        or not anything was produced, and recording there would rewrite the
-        same list every few seconds and miss a burst between two ticks."""
-        body = self._loop_source()
-        assert body.index("last_output_count = len(current_outputs)") < body.index(
-            "record_output"
-        )
-        assert body.index("await record_output(") < body.index(
-            "emit_execution_progress"
-        )
-
-    def test_neither_can_fail_the_cell(self) -> None:
-        """Both are bookkeeping about the work. A cell that failed because
-        the note about the cell would not go out is trading the work for the
-        story about the work."""
-        body = self._loop_source()
-        assert body.count("except Exception") >= 2
+def test_neither_hook_can_fail_the_cell():
+    """Both are bookkeeping about the work. Failing a cell because the note
+    about the cell would not go out trades the work for the story about it."""
+    assert _loop_source().count("except Exception") >= 2

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -31,6 +31,8 @@ from jupyter_mcp_server.tasks import (
     DEFAULT_TTL_MS,
     current_task,
     register_interrupt,
+    CURRENT_TASK,
+    record_output,
     IDEMPOTENCY_KEY_META,
     TASK_STATUS_NOTIFICATION,
     MAX_TTL_MS,
@@ -832,3 +834,141 @@ async def test_listing_answers_newest_first(store, extension):
         )
     listed = await extension._handle_list(None, object())
     assert [task.task_id for task in listed.tasks] == ["tsk_2", "tsk_1", "tsk_0"]
+
+
+class TestWhatTheWorkProducedBeforeItStopped:
+    """A cancelled cell that printed five hundred lines printed five hundred
+    lines.
+
+    `result` arrives whole when the tool returns, which is the right shape for
+    a call that finishes and no shape at all for one that does not. Cancel a
+    ten-minute cell at minute nine and the task was `cancelled` with
+    `result: None` — indistinguishable from a cell that produced nothing, and
+    the opposite of what the person who cancelled it wanted to read.
+    """
+
+    async def test_a_synchronous_call_records_nothing_and_says_so(self):
+        """It has no task to attach to and needs none: the client is still on
+        the other end of the connection."""
+        assert await record_output(["out"]) is False
+
+    async def test_the_output_so_far_is_on_the_record(self, store):
+        record = await store.create(TaskRecord(task_id="tsk_partial"))
+        token = CURRENT_TASK.set(record.task_id)
+        try:
+            assert await record_output(["one", "two"]) is True
+        finally:
+            CURRENT_TASK.reset(token)
+        assert (await store.get("tsk_partial")).partial == ["one", "two"]
+
+    async def test_it_replaces_rather_than_appends(self, store):
+        """The caller holds the whole list of outputs so far. Appending would
+        make every reader deduplicate what it reads."""
+        await store.create(TaskRecord(task_id="tsk_replace"))
+        token = CURRENT_TASK.set("tsk_replace")
+        try:
+            await record_output(["one"])
+            await record_output(["one", "two"])
+        finally:
+            CURRENT_TASK.reset(token)
+        assert (await store.get("tsk_replace")).partial == ["one", "two"]
+
+    async def test_a_cancelled_task_serves_what_it_produced(self, store):
+        extension = TasksExtension(store)
+        await store.create(TaskRecord(task_id="tsk_c", partial=["printed"]))
+        await extension._mark_cancelled("tsk_c")
+        record = await store.get("tsk_c")
+        assert record.status == "cancelled"
+        assert record.result == ["printed"]
+
+    async def test_a_cancelled_task_that_produced_nothing_has_no_result(
+        self, store
+    ):
+        """Empty is not the same as "we did not look": a task with no partial
+        output must not gain an empty list that reads like a measured zero."""
+        extension = TasksExtension(store)
+        await store.create(TaskRecord(task_id="tsk_none"))
+        await extension._mark_cancelled("tsk_none")
+        assert (await store.get("tsk_none")).result is None
+
+    async def test_a_result_that_arrived_is_not_overwritten_by_the_partial(
+        self, store
+    ):
+        """The tool's own result is the complete one. A race between the tool
+        returning and the cancellation landing must not replace it with the
+        half that was visible a moment earlier."""
+        extension = TasksExtension(store)
+        await store.create(
+            TaskRecord(task_id="tsk_both", partial=["half"], result=["whole"])
+        )
+        await extension._mark_cancelled("tsk_both")
+        assert (await store.get("tsk_both")).result == ["whole"]
+
+    async def test_a_terminal_task_is_not_re_cancelled(self, store):
+        extension = TasksExtension(store)
+        await store.create(
+            TaskRecord(task_id="tsk_done", status="completed", result=["whole"])
+        )
+        await extension._mark_cancelled("tsk_done")
+        record = await store.get("tsk_done")
+        assert record.status == "completed" and record.result == ["whole"]
+
+
+class TestTheExecutionLoopActuallyCallsThem:
+    """`register_interrupt` was defined, tested, documented and called by no
+    tool for as long as it existed.
+
+    That is the shape this whole effort keeps finding: the mechanism was
+    built and nothing used it, so cancelling a task said `cancelled` while
+    the kernel kept running the cell. Both hooks are asserted at the one
+    frame that holds the kernel and the outputs — the wait loop in `utils` —
+    because a helper nobody calls passes all of its own tests.
+    """
+
+    @staticmethod
+    def _loop_source() -> str:
+        import inspect
+
+        from jupyter_mcp_server import utils
+
+        source = inspect.getsource(utils)
+        start = source.index("    last_output_count = 0")
+        return source[start : source.index("# Get final result", start)]
+
+    def test_the_kernel_interrupt_is_registered(self) -> None:
+        """Cancelling the task cancels the wait; the kernel keeps running the
+        cell, keeps holding the sandbox and keeps costing money."""
+        # The *call*, not the name. An earlier version of this asserted
+        # `"register_interrupt" in body`, which the import line satisfies on
+        # its own — so deleting the call left the test green.
+        body = self._loop_source()
+        assert "await register_interrupt(kernel.interrupt)" in body
+
+    def test_it_is_registered_before_the_wait_begins(self) -> None:
+        """Registered inside the loop, a cell cancelled in its first second
+        has nothing to interrupt."""
+        body = self._loop_source()
+        assert body.index("register_interrupt") < body.index("while not execution_future.done()")
+
+    def test_the_outputs_are_recorded_as_they_arrive(self) -> None:
+        body = self._loop_source()
+        assert "await record_output(safe_extract_outputs(" in body
+
+    def test_recording_is_where_new_outputs_are_noticed(self) -> None:
+        """Not on the keepalive tick: the keepalive fires on a timer whether
+        or not anything was produced, and recording there would rewrite the
+        same list every few seconds and miss a burst between two ticks."""
+        body = self._loop_source()
+        assert body.index("last_output_count = len(current_outputs)") < body.index(
+            "record_output"
+        )
+        assert body.index("await record_output(") < body.index(
+            "emit_execution_progress"
+        )
+
+    def test_neither_can_fail_the_cell(self) -> None:
+        """Both are bookkeeping about the work. A cell that failed because
+        the note about the cell would not go out is trading the work for the
+        story about the work."""
+        body = self._loop_source()
+        assert body.count("except Exception") >= 2

--- a/tests/test_use_notebook_remote_rtc_version.py
+++ b/tests/test_use_notebook_remote_rtc_version.py
@@ -16,6 +16,7 @@ from unittest.mock import patch
 
 import pytest
 
+from jupyter_mcp_server.__version__ import __version__
 from jupyter_mcp_server import sandbox_client
 from jupyter_mcp_server.config import reset_config, set_config
 from jupyter_mcp_server.notebook_manager import NotebookManager
@@ -69,7 +70,12 @@ class FakeServerClient:
         self.http_client = FakeHTTPClient(extensions=extensions, error=error)
 
     def get_status(self):
-        return {"version": "2.1.3"}
+        # This is the *Jupyter server's* `/api/status` version, not this
+        # package's — the connectivity precheck only needs the call to
+        # succeed, and nothing here reads the number. It tracks
+        # `__version__` so a release bump does not have to find three fake
+        # servers, and for no deeper reason than that.
+        return {"version": __version__}
 
 
 class FakeKernel:

--- a/tests/test_use_notebook_split_servers.py
+++ b/tests/test_use_notebook_split_servers.py
@@ -15,6 +15,7 @@ from unittest.mock import patch
 import nbformat
 import pytest
 
+from jupyter_mcp_server.__version__ import __version__
 from jupyter_mcp_server.config import get_config, reset_config, set_config
 from jupyter_mcp_server.jupyter_extension.context import get_server_context
 from jupyter_mcp_server.notebook_manager import NotebookManager
@@ -62,7 +63,12 @@ class FakeServerClient:
         self.http_client = SimpleNamespace(session=SimpleNamespace(headers={}))
 
     def get_status(self):
-        return {"version": "2.1.3"}
+        # This is the *Jupyter server's* `/api/status` version, not this
+        # package's — the connectivity precheck only needs the call to
+        # succeed, and nothing here reads the number. It tracks
+        # `__version__` so a release bump does not have to find three fake
+        # servers, and for no deeper reason than that.
+        return {"version": __version__}
 
 
 class FakeKernel:

--- a/tests/test_use_notebook_ui_open.py
+++ b/tests/test_use_notebook_ui_open.py
@@ -12,6 +12,7 @@ that dispatch causes.
 
 import pytest
 
+from jupyter_mcp_server.__version__ import __version__
 from jupyter_mcp_server.config import get_config, reset_config
 from jupyter_mcp_server.jupyter_extension.context import get_server_context
 from jupyter_mcp_server.notebook_manager import NotebookManager
@@ -42,7 +43,12 @@ class FakeServerClient:
         self.contents = FakeContents(names)
 
     def get_status(self):
-        return {"version": "2.1.3"}
+        # This is the *Jupyter server's* `/api/status` version, not this
+        # package's — the connectivity precheck only needs the call to
+        # succeed, and nothing here reads the number. It tracks
+        # `__version__` so a release bump does not have to find three fake
+        # servers, and for no deeper reason than that.
+        return {"version": __version__}
 
 
 class FakeMCPToolsClient:


### PR DESCRIPTION
This PR enhances the tasks subsystem so that (1) cancelling a task running a cell interrupts the kernel (stopping the cell, not just the wait loop) and (2) a cancelled (or failed) task can preserve what it produced before termination by recording partial outputs during execution.

**Changes:**
- Add `TaskRecord.partial` plus a `record_output()` helper, and promote partial output into `result` on cancellation (and retain it on failure).
- Update the cell execution loop to register the kernel interrupt handler and record outputs as they appear.
- Add/extend tests and documentation to lock the behavior and keep docs/code in sync.
</details>

It also add a bump script to ease the version bump at the needed places.

It adds resources: the notebook, its cells and their outputs, for an agent to read.

Lighten README.