### PR TITLE
feat: sandboxes snapshot

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -57,6 +57,12 @@ To get started with development, you'll need to set up your environment.
    make test
    ```
 
+1. **Sync sourcey:**
+
+   ```bash
+   make sync-sourcey
+   ```
+
 1. **Build Python Package/Docker Image:**
 
    ```bash

--- a/docs/sourcey/mcp.json
+++ b/docs/sourcey/mcp.json
@@ -861,6 +861,19 @@
             "default": null,
             "description": "Modal Python version override (e.g. 3.12). Only used for modal variant.",
             "title": "Python Version"
+          },
+          "snapshot_name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Start from a saved snapshot instead of an empty sandbox, restoring the state it was taken in. Only the datalayer variant has snapshots; naming one for any other variant is refused rather than quietly started empty.",
+            "title": "Snapshot Name"
           }
         },
         "required": [

--- a/docs/sourcey/tools/launch_sandbox.md
+++ b/docs/sourcey/tools/launch_sandbox.md
@@ -28,6 +28,7 @@ MCP_SERVER and JUPYTER_SERVER modes.
 | `channels_url` | string \| null | no | `null` | Notebook session WebSocket channels URL to derive server_url/kernel_id (google-colab or kaggle variant) |
 | `token` | string \| null | no | `null` | Kaggle API token for the kaggle variant (falls back to KAGGLE_API_TOKEN) |
 | `python_version` | string \| null | no | `null` | Modal Python version override (e.g. 3.12). Only used for modal variant. |
+| `snapshot_name` | string \| null | no | `null` | Start from a saved snapshot instead of an empty sandbox, restoring the state it was taken in. Only the datalayer variant has snapshots; naming one for any other variant is refused rather than quietly started empty. |
 
 ## Output
 
@@ -75,14 +76,15 @@ MCP_SERVER and JUPYTER_SERVER modes.
       "proxy_token": null,
       "channels_url": null,
       "token": null,
-      "python_version": null
+      "python_version": null,
+      "snapshot_name": null
     }
   }
 }
 ```
 
 ```python
-result = await session.call_tool("launch_sandbox", arguments={"sandbox_name": "<sandbox_name>", "variant": None, "timeout": 60, "environment": None, "gpu": None, "server_url": None, "kernel_id": None, "proxy_token": None, "channels_url": None, "token": None, "python_version": None})
+result = await session.call_tool("launch_sandbox", arguments={"sandbox_name": "<sandbox_name>", "variant": None, "timeout": 60, "environment": None, "gpu": None, "server_url": None, "kernel_id": None, "proxy_token": None, "channels_url": None, "token": None, "python_version": None, "snapshot_name": None})
 ```
 
 ## Source

--- a/extensions/sandboxes/jupyter_mcp_sandboxes/extension.py
+++ b/extensions/sandboxes/jupyter_mcp_sandboxes/extension.py
@@ -43,6 +43,22 @@ class SandboxesExtension(JupyterMCPExtension):
     def __init__(self) -> None:
         self._manager = CodeSandboxManager()
 
+    @property
+    def sandboxes(self) -> CodeSandboxManager:
+        """The sandboxes this extension launched, for extensions built on it.
+
+        A downstream extension adding a sandbox tool — a snapshot, a mount —
+        has to act on *this* registry, the one `launch_sandbox` wrote to and
+        `use_sandbox` points into. Building its own would be a second set of
+        sandboxes with the same names, where "the active one" means two
+        different things depending on which tool you called.
+
+        Public rather than reached for: the alternative is downstream code
+        touching ``_manager``, which works until this class holds its
+        sandboxes some other way.
+        """
+        return self._manager
+
     def manifest(self) -> PluginManifest:
         return PluginManifest(
             name="jupyter-mcp-sandboxes",
@@ -264,6 +280,18 @@ class SandboxesExtension(JupyterMCPExtension):
                     )
                 ),
             ] = None,
+            snapshot_name: Annotated[
+                str | None,
+                Field(
+                    description=(
+                        "Start from a saved snapshot instead of an empty "
+                        "sandbox, restoring the state it was taken in. Only "
+                        "the datalayer variant has snapshots; naming one for "
+                        "any other variant is refused rather than quietly "
+                        "started empty."
+                    )
+                ),
+            ] = None,
         ) -> ToolAnswer:
             """Launch a code sandbox that can be used instead of Jupyter kernels.
 
@@ -297,6 +325,7 @@ class SandboxesExtension(JupyterMCPExtension):
                     channels_url=channels_url,
                     token=token,
                     python_version=python_version,
+                    snapshot_name=snapshot_name,
                 )
             )
 

--- a/extensions/sandboxes/jupyter_mcp_sandboxes/manager.py
+++ b/extensions/sandboxes/jupyter_mcp_sandboxes/manager.py
@@ -40,6 +40,7 @@ class CodeSandboxManager:
         token: str | None = None,
         run_url: str | None = None,
         python_version: str | None = None,
+        snapshot_name: str | None = None,
     ) -> dict[str, Any]:
         """Launch and register a new code sandbox."""
         if sandbox_name in self._sandboxes:
@@ -101,6 +102,20 @@ class CodeSandboxManager:
                 create_kwargs["token"] = token
             if run_url:
                 create_kwargs["run_url"] = run_url
+            # Start from a saved state rather than an empty one. Named per
+            # variant rather than passed for all of them because a variant
+            # that does not know the argument would take it as an unexpected
+            # keyword and fail the launch — a caller who asked for a snapshot
+            # on a backend without them should be told that, not handed a
+            # TypeError from a constructor.
+            if snapshot_name:
+                create_kwargs["snapshot_name"] = snapshot_name
+
+        if snapshot_name and variant != "datalayer":
+            raise ValueError(
+                f"Sandbox variant '{variant}' cannot start from a snapshot; "
+                "only 'datalayer' can."
+            )
 
         sandbox = CodeSandboxClient.create(**create_kwargs)
         sandbox.start()

--- a/extensions/sandboxes/jupyter_mcp_sandboxes/manager.py
+++ b/extensions/sandboxes/jupyter_mcp_sandboxes/manager.py
@@ -50,6 +50,16 @@ class CodeSandboxManager:
         # variant with an underscore or in capitals lands on the same branch
         # below as one naming it canonically.
         variant = normalize_variant(variant)
+        # Decided once, so the two places that ask "was a snapshot wanted"
+        # cannot answer differently. An empty string means the argument was
+        # not given — the same reading `environment` and `gpu` get, and the
+        # one the hosted gateway relies on when it turns its own empty
+        # strings into `None`. Whitespace means the same and used to mean
+        # something else: `"  "` is truthy, so it was refused on one variant
+        # and handed to the Datalayer constructor as a snapshot name on the
+        # other, where nothing can be called that and the caller found out
+        # from two packages away.
+        wanted_snapshot = (snapshot_name or "").strip()
         create_kwargs: dict[str, Any] = {
             "variant": variant,
             "timeout": timeout,
@@ -108,10 +118,10 @@ class CodeSandboxManager:
             # keyword and fail the launch — a caller who asked for a snapshot
             # on a backend without them should be told that, not handed a
             # TypeError from a constructor.
-            if snapshot_name:
-                create_kwargs["snapshot_name"] = snapshot_name
+            if wanted_snapshot:
+                create_kwargs["snapshot_name"] = wanted_snapshot
 
-        if snapshot_name and variant != "datalayer":
+        if wanted_snapshot and variant != "datalayer":
             raise ValueError(
                 f"Sandbox variant '{variant}' cannot start from a snapshot; "
                 "only 'datalayer' can."

--- a/extensions/sandboxes/jupyter_mcp_sandboxes/tools.py
+++ b/extensions/sandboxes/jupyter_mcp_sandboxes/tools.py
@@ -33,6 +33,7 @@ class LaunchSandboxTool(BaseTool):
         channels_url: str | None = None,
         token: str | None = None,
         python_version: str | None = None,
+        snapshot_name: str | None = None,
         **kwargs,
     ) -> dict[str, Any]:
         if code_sandbox_manager is None:
@@ -52,6 +53,7 @@ class LaunchSandboxTool(BaseTool):
             channels_url=channels_url,
             token=token,
             python_version=python_version,
+            snapshot_name=snapshot_name,
         )
 
         return {

--- a/jupyter_mcp_server/extensions.py
+++ b/jupyter_mcp_server/extensions.py
@@ -139,6 +139,25 @@ class ExtensionManager:
         self._extensions[manifest.name] = extension
         logger.info("Registered Jupyter MCP extension: %s", manifest.name)
 
+    def get(self, name: str) -> Optional[JupyterMCPExtension]:
+        """The registered extension published under this manifest name.
+
+        Extensions are meant to compose — that is what registering them in
+        name order is *for*: one extension narrowing or extending a tool an
+        earlier one put on the server. Composing needs a way to reach the
+        extension being built on, and until now the only route was
+        ``manager._extensions``, another object's private dict. A downstream
+        extension reaching in that way keeps working right up to the day this
+        class stores its extensions differently, and then breaks with an
+        ``AttributeError`` in somebody else's package.
+
+        ``None`` for a name that is not registered, because "the extension you
+        build on is not installed" is an ordinary configuration, not an error:
+        the caller degrades — leaving its tool off the list — rather than
+        failing the whole server's startup.
+        """
+        return self._extensions.get(name)
+
     def discover(self) -> None:
         """Discover extensions published on the entry-point group.
 

--- a/tests/test_extensions_compose.py
+++ b/tests/test_extensions_compose.py
@@ -1,0 +1,83 @@
+# Copyright (c) 2024- Datalayer, Inc.
+#
+# BSD 3-Clause License
+
+"""One extension building on another, without reaching into its insides.
+
+Extensions register in name order, and that ordering exists for exactly one
+reason: so an extension can narrow or extend a tool an earlier one already
+put on the server. Doing that means reaching the extension being built on and
+the state it keeps — and until these two accessors existed the only route was
+`manager._extensions` and `extension._manager`, two private attributes in
+somebody else's package. Code that reaches that way works until the day this
+package stores things differently, and then breaks downstream.
+
+Launch the tests:
+```
+$ pytest tests/test_extensions_compose.py -v
+```
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from reactor import PluginCompatibility, PluginManifest
+
+from jupyter_mcp_sandboxes.extension import SandboxesExtension
+from jupyter_mcp_server.extensions import ExtensionManager, JupyterMCPExtension
+
+
+class _Named(JupyterMCPExtension):
+    def __init__(self, name: str) -> None:
+        self._name = name
+
+    def manifest(self) -> Any:
+        return PluginManifest(
+            name=self._name,
+            version="0.0.1",
+            description="A registered extension",
+            author="Tests",
+            compatibility=PluginCompatibility(api_version="v1"),
+        )
+
+
+def test_a_registered_extension_is_reachable_by_its_manifest_name():
+    manager = ExtensionManager()
+    first = _Named("alpha")
+    manager.register(first)
+    manager.register(_Named("beta"))
+    assert manager.get("alpha") is first
+
+
+def test_an_extension_that_is_not_installed_is_none_rather_than_an_error():
+    """Not installed is a configuration, not a failure.
+
+    The caller degrades — leaving its tool off the list — and a server that
+    raised here would refuse to start because an optional package was absent.
+    """
+    assert ExtensionManager().get("not-installed") is None
+
+
+def test_the_sandboxes_extension_publishes_the_registry_its_tools_write_to():
+    """The same object, not an equal one.
+
+    A downstream tool acting on its own manager would be a second set of
+    sandboxes under the same names, where "the active one" means two
+    different things depending on which tool you asked.
+    """
+    extension = SandboxesExtension()
+    assert extension.sandboxes is extension._manager
+
+
+def test_the_sandboxes_extension_is_found_under_the_name_it_publishes():
+    """The lookup and the manifest have to agree.
+
+    A downstream extension asks for a string. If that string is not the one
+    the manifest declares, `get` answers None, the tool is quietly left off
+    the list, and nothing anywhere says why.
+    """
+    manager = ExtensionManager()
+    extension = SandboxesExtension()
+    manager.register(extension)
+    assert manager.get(extension.manifest().name) is extension

--- a/tests/test_launching_from_a_snapshot.py
+++ b/tests/test_launching_from_a_snapshot.py
@@ -76,6 +76,50 @@ def test_a_launch_without_one_does_not_mention_it(created):
     assert "snapshot_name" not in created[0]
 
 
+@pytest.mark.parametrize("given", ["", "   ", "\t\n"])
+def test_a_name_that_is_only_space_is_no_name_at_all(created, given):
+    """Whitespace means "not given", the same as an empty string.
+
+    It used to mean something else, because `"  "` is truthy: a variant
+    without snapshots refused it, and the Datalayer one passed it to the
+    constructor as a snapshot name. Nothing can be called that, so the caller
+    found out from two packages away — which is the failure the refusal
+    exists to replace.
+
+    Empty stays "not given" rather than becoming a refusal, deliberately.
+    That is the reading `environment` and `gpu` already have here, and the
+    one the hosted gateway relies on when it turns its own empty strings into
+    `None` before calling this.
+    """
+    CodeSandboxManager().launch(
+        sandbox_name="fresh", variant="datalayer", timeout=60.0, snapshot_name=given
+    )
+    assert "snapshot_name" not in created[0]
+
+
+@pytest.mark.parametrize("given", ["", "   "])
+def test_and_does_not_refuse_a_variant_that_has_no_snapshots(created, given):
+    """The other half of the same question, and the one that decides whether
+    a launch happens at all: nothing was asked for, so there is nothing to
+    refuse."""
+    CodeSandboxManager().launch(
+        sandbox_name="fresh", variant="modal", timeout=60.0, snapshot_name=given
+    )
+    assert created, "a launch that asked for no snapshot was refused"
+
+
+def test_a_name_with_space_around_it_is_the_name(created):
+    """Trimmed rather than rejected. A name pasted out of a list arrives with
+    a newline on it often enough that refusing would be the wrong lesson."""
+    CodeSandboxManager().launch(
+        sandbox_name="restored",
+        variant="datalayer",
+        timeout=60.0,
+        snapshot_name="  before-the-training-run\n",
+    )
+    assert created[0]["snapshot_name"] == "before-the-training-run"
+
+
 @pytest.mark.parametrize("variant", ["eval", "modal", "e2b", "docker"])
 def test_a_variant_without_snapshots_refuses_rather_than_starting_empty(created, variant):
     """The failure this prevents is silent, which is why it is a refusal.

--- a/tests/test_launching_from_a_snapshot.py
+++ b/tests/test_launching_from_a_snapshot.py
@@ -1,0 +1,96 @@
+# Copyright (c) 2024- Datalayer, Inc.
+#
+# BSD 3-Clause License
+
+"""Starting a sandbox from a saved state, and the one variant that can.
+
+`code_sandboxes` has taken a `snapshot_name` on the Datalayer sandbox since
+before this extension existed; the extension simply never passed it, so a
+saved state was reachable from the library and not from a tool. These are the
+two things that go wrong when a launch argument is threaded through three
+layers: it arrives nowhere, or it arrives everywhere.
+
+Launch the tests:
+```
+$ pytest tests/test_launching_from_a_snapshot.py -v
+```
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from jupyter_mcp_sandboxes.manager import CodeSandboxManager
+
+
+class _Sandbox:
+    """Enough of a sandbox to be launched and serialized."""
+
+    def __init__(self, **kwargs: Any) -> None:
+        self.kwargs = kwargs
+        self.config = type("Config", (), {"environment": None, "gpu": None})()
+        self.info = type("Info", (), {"variant": kwargs.get("variant")})()
+        self.id = "sbx-1"
+
+    def start(self) -> None:
+        return None
+
+
+@pytest.fixture()
+def created(monkeypatch):
+    """Every `CodeSandboxClient.create` call the manager made."""
+    calls: list[dict[str, Any]] = []
+
+    def create(**kwargs: Any) -> _Sandbox:
+        calls.append(kwargs)
+        return _Sandbox(**kwargs)
+
+    monkeypatch.setattr(
+        "jupyter_mcp_sandboxes.manager.CodeSandboxClient",
+        type("Client", (), {"create": staticmethod(create)}),
+    )
+    return calls
+
+
+def test_a_datalayer_launch_carries_the_snapshot_to_the_library(created):
+    """The whole point: the name reaches the constructor that reads it."""
+    CodeSandboxManager().launch(
+        sandbox_name="restored",
+        variant="datalayer",
+        timeout=60.0,
+        snapshot_name="before-the-training-run",
+    )
+    assert created[0]["snapshot_name"] == "before-the-training-run"
+
+
+def test_a_launch_without_one_does_not_mention_it(created):
+    """Absent, not None.
+
+    `snapshot_name=None` reaches the constructor as an argument that was
+    given, and a variant reading "was a snapshot asked for" by presence
+    rather than by truthiness would answer yes.
+    """
+    CodeSandboxManager().launch(sandbox_name="fresh", variant="datalayer", timeout=60.0)
+    assert "snapshot_name" not in created[0]
+
+
+@pytest.mark.parametrize("variant", ["eval", "modal", "e2b", "docker"])
+def test_a_variant_without_snapshots_refuses_rather_than_starting_empty(created, variant):
+    """The failure this prevents is silent, which is why it is a refusal.
+
+    Passing the argument on to a variant that does not know it is a
+    `TypeError` from a constructor two packages away; dropping it is worse —
+    the caller asked to continue from a saved state, got an empty sandbox
+    that looks identical, and finds out when the variables are not there.
+    """
+    with pytest.raises(ValueError) as refusal:
+        CodeSandboxManager().launch(
+            sandbox_name="restored",
+            variant=variant,
+            timeout=60.0,
+            snapshot_name="before-the-training-run",
+        )
+    assert variant in str(refusal.value)
+    assert not created, "a refused launch must not have created a sandbox"

--- a/tests/test_notebook_resources.py
+++ b/tests/test_notebook_resources.py
@@ -153,8 +153,21 @@ class TestWhatIsRegistered:
     def test_the_scheme_is_provider_neutral(self, templates):
         """This server talks to a Jupyter server. A `datalayer://` URI here
         would be a hosted platform's identifier on a resource that has
-        nothing to do with it."""
-        for uri in templates:
+        nothing to do with it.
+
+        About *these three* rather than about everything on the server. A
+        deployment is supposed to add resources of its own under its own
+        scheme — that is what the extension mechanism is for — so sweeping
+        the whole registry made this a claim about whatever else happened to
+        be installed, and it failed the moment a hosted gateway's extension
+        was present in the same environment.
+        """
+        for uri in (
+            resources.NOTEBOOK_RESOURCE,
+            resources.CELL_RESOURCE,
+            resources.OUTPUT_RESOURCE,
+        ):
+            assert uri in templates
             assert not uri.startswith("datalayer://")
 
     def test_a_notebook_is_addressed_by_name_not_by_path(self, templates):


### PR DESCRIPTION
The current snapshot_name handling is truthiness-based, which can silently ignore empty/whitespace snapshot requests and undermine the “refuse rather than start empty” behavior guarantee.

Once you've addressed the issues Copilot identified, you can request another Copilot review.

Pull request overview
This PR enhances the sandboxes extension to support starting a sandbox launch from a named snapshot (for the datalayer variant only) and improves extension composition by adding public accessors for looking up registered extensions and sharing the sandboxes registry, while adjusting tests to avoid making environment-dependent assertions about third-party extensions.

Changes:

Thread snapshot_name from the launch_sandbox tool through to CodeSandboxManager.launch, and explicitly refuse snapshot launches for non-datalayer variants.
Add ExtensionManager.get(name) and SandboxesExtension.sandboxes to support composing extensions without reaching into private attributes.
Make the notebook resource scheme test assert only the core notebook/cell/output templates, not the full registry (so extensions can add their own schemes).