### PR TITLE
fix(outputs): strip every CSI escape, not only colour

### DIFF
--- a/jupyter_mcp_server/utils.py
+++ b/jupyter_mcp_server/utils.py
@@ -540,7 +540,7 @@ def extract_output(output: dict | Any) -> str | ImageContent:
 
 def strip_ansi_codes(text: str) -> str:
     """Remove ANSI escape sequences from text."""
-    ansi_escape = re.compile(r"\x1b\[[0-9;]*m")
+    ansi_escape = re.compile(r"\x1b\[[0-?]*[ -/]*[@-~]")
     return ansi_escape.sub("", text)
 
 

--- a/tests/test_ansi_escape_stripping.py
+++ b/tests/test_ansi_escape_stripping.py
@@ -1,0 +1,41 @@
+# Copyright (c) 2024- Datalayer, Inc.
+#
+# BSD 3-Clause License
+
+"""Unit tests for stripping ANSI escape sequences out of cell output.
+
+strip_ansi_codes matched only the SGR colour sequences, so every other escape
+a kernel writes survived into the text handed back to the client. A nested
+tqdm bar moves the cursor with ESC[A on each redraw whether or not the stream
+is a terminal, and those bytes came through in the stream output.
+"""
+
+from jupyter_mcp_server.utils import extract_output, strip_ansi_codes
+
+# Two redraws of a nested tqdm bar, captured from tqdm writing to a
+# non-terminal stream with position=1.
+NESTED_TQDM_TEXT = (
+    "\r  0%|   | 0/2 [00:00<?, ?it/s]\x1b[A\n"
+    "\r 50%|5| 1/2 [00:00<00:00, 1075it/s]\x1b[A\n"
+)
+
+
+def test_colour_sequences_are_still_stripped():
+    assert strip_ansi_codes("\x1b[31mred\x1b[0m") == "red"
+
+
+def test_cursor_movement_is_stripped():
+    assert strip_ansi_codes("done\x1b[A") == "done"
+
+
+def test_erase_line_and_cursor_visibility_are_stripped():
+    assert strip_ansi_codes("\x1b[2K\x1b[?25lworking\x1b[?25h") == "working"
+
+
+def test_a_nested_progress_bar_reads_back_without_escapes():
+    stream = {"output_type": "stream", "name": "stderr", "text": NESTED_TQDM_TEXT}
+    assert "\x1b" not in extract_output(stream)
+
+
+def test_brackets_without_an_escape_are_left_alone():
+    assert strip_ansi_codes("matched [0-9]* twice") == "matched [0-9]* twice"


### PR DESCRIPTION
Fixes #426.

`strip_ansi_codes` matched `\x1b\[[0-9;]*m`, so it only took out colour. A nested tqdm bar moves the cursor with `ESC[A` on every redraw whether or not the stream is a terminal, and those bytes came back in the stream output; erase-line and the cursor-hide pair did the same.

Widened the pattern to the CSI form, so `ESC[`, parameter bytes, intermediate bytes, one final byte. That is a superset of what it matched before, and text that merely contains something like `[0-9]*` is untouched because the `ESC` is required.

I left OSC alone, so the `ESC]8;;` hyperlink form that rich emits still comes through. I have no case of one reaching a cell output, and guessing at where the string terminator lands seemed worse than leaving it.

Tests cover colour, cursor movement, erase-line, the cursor-hide pair, and a captured nested-tqdm redraw through `extract_output`. The non-colour ones fail on main. The suite's live-server tests do not start for me (jupyter lab will not run as root in my container), so those are unrun on both sides.
