### PR TITLE
fix: notifications

### DIFF
--- a/dev/content/notebook.ipynb
+++ b/dev/content/notebook.ipynb
@@ -2712,6 +2712,7 @@
   {
    "cell_type": "code",
    "execution_count": 1,
+   "id": "a92dadf9",
    "metadata": {},
    "outputs": [
     {

--- a/dev/content/notebook.ipynb
+++ b/dev/content/notebook.ipynb
@@ -2712,7 +2712,6 @@
   {
    "cell_type": "code",
    "execution_count": 1,
-   "id": "a92dadf9",
    "metadata": {},
    "outputs": [
     {

--- a/jupyter_mcp_server/notifications.py
+++ b/jupyter_mcp_server/notifications.py
@@ -44,6 +44,7 @@ from __future__ import annotations
 import importlib
 import logging
 import os
+from collections.abc import Sequence
 from typing import Any
 
 logger = logging.getLogger(__name__)
@@ -142,6 +143,47 @@ def notebook_uri(name: str) -> str:
     return f"notebook://{name}"
 
 
+def cell_uri(name: str, cell_id: str) -> str:
+    """The resource URI of one cell — `resources.CELL_RESOURCE` filled in.
+
+    Built here rather than imported from `resources` because that module
+    reaches the notebook, and the publisher runs on the way out of a tool
+    call that has already finished with it.
+    """
+    return f"notebook://{name}/cells/{cell_id}"
+
+
+def changed_cells(result: Any) -> tuple[str, ...]:
+    """Which cells a finished tool call says it acted on.
+
+    Read from the result's `_meta` rather than from the tool's arguments,
+    because the arguments may name a cell by *index* and an index is not
+    something a subscriber can address. The resolver that turns an index into
+    a cell already attaches the id it landed on, for the agent's benefit; this
+    is the same fact, read once more on the way past.
+
+    Inserting a cell attaches nothing, and that is right: the id of a cell
+    that did not exist when somebody subscribed is not an id anybody is
+    subscribed to. The notebook frame carries that news.
+    """
+    meta = getattr(result, "meta", None)
+    if not isinstance(meta, dict):
+        return ()
+    from jupyter_mcp_server.results import meta_key  # noqa: PLC0415
+
+    found: list[str] = []
+    for key in ("cell_id", "cell_ids"):
+        value = meta.get(meta_key(key))
+        if isinstance(value, str):
+            found.append(value)
+        elif isinstance(value, (list, tuple)):
+            found.extend(str(one) for one in value if one)
+    # Ordered, and each said once: two of the eight writing tools resolve
+    # twice (a move has a source and a target) and a subscriber told about
+    # the same cell twice refetches it twice.
+    return tuple(dict.fromkeys(one for one in found if one))
+
+
 def target_notebook(keywords: dict[str, Any], current: Any) -> str:
     """Which notebook a tool call changed.
 
@@ -233,8 +275,21 @@ def _bus(server: Any) -> Any | None:
         return None
 
 
-async def publish_notebook_updated(server: Any, name: str) -> bool:
+async def publish_notebook_updated(
+    server: Any, name: str, cells: Sequence[str] = ()
+) -> bool:
     """Say that this notebook changed. Answers whether anything was told.
+
+    `cells` names the cells that moved, when that is known. Each gets its own
+    frame on `notebook://<name>/cells/<id>`, **as well as** the notebook's —
+    never instead of it. A client subscribed to the notebook asked to hear
+    about the notebook, and quietly narrowing that to the cells this server
+    happened to identify would go silent on a deletion, which is the one
+    change whose id nobody can read afterwards.
+
+    So the notebook frame is what every subscriber can rely on, and the cell
+    frames are what lets an agent watching one cell refetch one cell instead
+    of the document.
 
     Never raises. It runs after a tool has already done its work and
     returned: failing the edit because the *news about* the edit would not go
@@ -243,24 +298,29 @@ async def publish_notebook_updated(server: Any, name: str) -> bool:
     """
     if not name:
         return False
+    uris = [notebook_uri(name)]
+    uris.extend(cell_uri(name, one) for one in dict.fromkeys(cells) if one)
     # A configured publisher replaces the in-process bus entirely: a
     # deployment that has one is a deployment where this process is not where
     # the subscribers are, so publishing to both would be publishing half the
     # event twice.
     publisher = resolve_publisher()
     if publisher is not None:
-        try:
-            return bool(await publisher.publish(notebook_uri(name)))
-        except Exception as error:  # noqa: BLE001 - never in the way of the edit
-            logger.debug("A notebook update could not be published: %s", error)
-            return False
+        told = False
+        for uri in uris:
+            try:
+                told = bool(await publisher.publish(uri)) or told
+            except Exception as error:  # noqa: BLE001 - never in the way of the edit
+                logger.debug("A notebook update could not be published: %s", error)
+        return told
     told = False
     bus = _bus(server)
     if bus is not None:
         try:
             from mcp.server.subscriptions import ResourceUpdated  # noqa: PLC0415
 
-            await bus.publish(ResourceUpdated(uri=notebook_uri(name)))
+            for uri in uris:
+                await bus.publish(ResourceUpdated(uri=uri))
             told = True
         except Exception as error:  # noqa: BLE001 - never in the way of the edit
             logger.debug("A notebook update could not be published: %s", error)
@@ -268,7 +328,10 @@ async def publish_notebook_updated(server: Any, name: str) -> bool:
     # existed — the `return False` above it saw to that — so a server on an
     # SDK without `subscriptions/listen` told its 2025-11-25 subscribers
     # nothing, which is every subscriber it had.
-    return await _tell_legacy_subscribers(notebook_uri(name)) or told
+    reached = False
+    for uri in uris:
+        reached = await _tell_legacy_subscribers(uri) or reached
+    return reached or told
 
 
 async def _tell_legacy_subscribers(uri: str) -> bool:

--- a/jupyter_mcp_server/notifications.py
+++ b/jupyter_mcp_server/notifications.py
@@ -316,14 +316,18 @@ async def publish_notebook_updated(
     told = False
     bus = _bus(server)
     if bus is not None:
-        try:
-            from mcp.server.subscriptions import ResourceUpdated  # noqa: PLC0415
+        # Each URI on its own. One that cannot be published must not take the
+        # rest of the burst with it, and it must not make a publish that did
+        # reach somebody answer that nobody was told — the caller counts that
+        # answer, and a `False` here is read as "nothing is listening".
+        for uri in uris:
+            try:
+                from mcp.server.subscriptions import ResourceUpdated  # noqa: PLC0415
 
-            for uri in uris:
                 await bus.publish(ResourceUpdated(uri=uri))
-            told = True
-        except Exception as error:  # noqa: BLE001 - never in the way of the edit
-            logger.debug("A notebook update could not be published: %s", error)
+                told = True
+            except Exception as error:  # noqa: BLE001 - never in the way of the edit
+                logger.debug("A notebook update could not be published: %s", error)
     # Both halves, always. The legacy half used to be reached only when a bus
     # existed — the `return False` above it saw to that — so a server on an
     # SDK without `subscriptions/listen` told its 2025-11-25 subscribers

--- a/jupyter_mcp_server/results.py
+++ b/jupyter_mcp_server/results.py
@@ -329,7 +329,7 @@ def answer(
     )
 
 
-async def _announce(kind: str, keywords: dict, result: Any) -> None:
+async def _announce(keywords: dict, result: Any) -> None:
     """Tell whoever is subscribed that this call changed a notebook.
 
     Lifted out of the wrapper so the wrapper's `except` covers one named
@@ -420,7 +420,7 @@ def structured(
 
             if kind in notifications.MUTATING_KINDS:
                 try:
-                    await _announce(kind, keywords, result)
+                    await _announce(keywords, result)
                 except Exception:  # noqa: BLE001 - see below
                     # The edit is done and the answer is in hand. Failing the
                     # call because the *news about* it could not be sent

--- a/jupyter_mcp_server/results.py
+++ b/jupyter_mcp_server/results.py
@@ -329,6 +329,24 @@ def answer(
     )
 
 
+async def _announce(kind: str, keywords: dict, result: Any) -> None:
+    """Tell whoever is subscribed that this call changed a notebook.
+
+    Lifted out of the wrapper so the wrapper's `except` covers one named
+    thing rather than a block, and so the two ways news travels — folded into
+    a watcher's debounce, or published here and now — are readable side by
+    side.
+    """
+    from jupyter_mcp_server import notifications  # noqa: PLC0415
+    from jupyter_mcp_server.server import mcp, notebook_manager  # noqa: PLC0415
+    from jupyter_mcp_server.watchers import watchers  # noqa: PLC0415
+
+    name = notifications.target_notebook(keywords, notebook_manager.get_current_notebook)
+    cells = notifications.changed_cells(result)
+    if not watchers.fold(name, cells):
+        await notifications.publish_notebook_updated(mcp, name, cells)
+
+
 def structured(
     kind: str,
     *,
@@ -385,19 +403,31 @@ def structured(
 
             After the call, never before: a subscriber told a cell changed
             before it did refetches the old document and caches it as new.
+
+            The news says **which cell**, when the call resolved one — read
+            back off the result's own `_meta` rather than off the arguments,
+            because an argument may be an index and an index is not something
+            a subscriber can subscribe to.
+
+            And it goes to the watcher rather than out, when the notebook is
+            being watched. The edit is about to arrive back over the
+            watcher's own connection looking like somebody else's, so
+            publishing here as well is two frames for one edit; handing it to
+            the same debounce is one.
             """
             result = await wrapper(*arguments, **keywords)
             from jupyter_mcp_server import notifications  # noqa: PLC0415
 
             if kind in notifications.MUTATING_KINDS:
-                from jupyter_mcp_server.server import mcp, notebook_manager  # noqa: PLC0415
-
-                await notifications.publish_notebook_updated(
-                    mcp,
-                    notifications.target_notebook(
-                        keywords, notebook_manager.get_current_notebook
-                    ),
-                )
+                try:
+                    await _announce(kind, keywords, result)
+                except Exception:  # noqa: BLE001 - see below
+                    # The edit is done and the answer is in hand. Failing the
+                    # call because the *news about* it could not be sent
+                    # would trade the work for the story about the work — and
+                    # the agent would be told its edit failed when it did
+                    # not, and would make it again.
+                    logger.exception("Could not announce a change to %s", kind)
             return result
 
         return announcing

--- a/jupyter_mcp_server/watchers.py
+++ b/jupyter_mcp_server/watchers.py
@@ -93,6 +93,10 @@ class Watch:
     cells: set[str] = field(default_factory=set)
     #: When the current burst must be announced by, however it continues.
     deadline: float | None = None
+    #: How many times the timer has been armed. A firing carries the number
+    #: it was armed with, which is how it knows whether it is still the
+    #: announcement anybody is waiting for.
+    armed: int = 0
     #: The live cells array, for reading an id back off a changed index.
     ycells: Any = field(default=None, repr=False)
 
@@ -317,8 +321,11 @@ class NotebookWatchers:
         when = min(now + DEBOUNCE_SECONDS, watch.deadline)
         if watch.pending is not None:
             watch.pending.cancel()
-        name = watch.name
-        watch.pending = loop.call_at(when, lambda: loop.create_task(self._announce(name)))
+        watch.armed += 1
+        name, generation = watch.name, watch.armed
+        watch.pending = loop.call_at(
+            when, lambda: loop.create_task(self._announce(name, generation))
+        )
 
     @staticmethod
     def _on_this_loop(watch: Watch) -> bool:
@@ -332,29 +339,16 @@ class NotebookWatchers:
         wrapper, which is the news about an edit taking the edit down with
         it. Answering `False` sends the caller back to publishing for itself,
         which is what it would have done had nothing been watching.
+
+        Asking whether the loop is *this* one covers the closed one for free:
+        a closed loop is not a running loop, so a separate `is_closed()` is a
+        guard no input can reach — and an unreachable guard reads like a
+        second condition that matters.
         """
-        loop = watch.loop
-        if loop is None or loop.is_closed():
-            return False
         try:
-            return asyncio.get_running_loop() is loop
-        except RuntimeError:  # no loop at all: not this one
+            return watch.loop is not None and asyncio.get_running_loop() is watch.loop
+        except RuntimeError:  # no loop running at all: certainly not this one
             return False
-
-    @staticmethod
-    def _superseded(watch: Watch) -> bool:
-        """Whether a later timer has already taken over this burst.
-
-        A timer fires and hands the announcement to a *task*, which runs on
-        the next turn of the loop. A change arriving in between re-arms, and
-        without this both the task and the new timer announce — two frames
-        for the burst the debounce exists to make one. The later timer wins,
-        because it is the one that will have seen the whole burst.
-        """
-        pending = watch.pending
-        if pending is None or watch.loop is None:
-            return False
-        return not pending.cancelled() and pending.when() > watch.loop.time()
 
     def fold(self, name: str, cells: Any = ()) -> bool:
         """Take a change *this server* just made into the notebook's debounce.
@@ -378,11 +372,24 @@ class NotebookWatchers:
         self._arm(watch)
         return True
 
-    async def _announce(self, name: str) -> None:
+    async def _announce(self, name: str, generation: int) -> None:
+        """Say what this burst changed, if this is still the burst.
+
+        A timer fires and hands the announcement to a *task*, which runs on
+        the next turn of the loop. A change arriving in between re-arms, and
+        without the generation both this task and the new timer announce —
+        two frames for the burst the debounce exists to make one. The later
+        arming wins, because it is the one that will have seen all of it.
+
+        A **counter** rather than a look at the pending timer's deadline,
+        which is what this was and which was wrong on a coarse clock: asyncio
+        fires a timer when the loop's time is within one clock resolution of
+        its deadline, so on Windows a timer set 20 ms out fires with the
+        deadline still ~15 ms in the future. Reading that as "a later timer
+        is armed" made the notification never arrive at all.
+        """
         watch = self._watching.get(name)
-        if watch is None:
-            return
-        if self._superseded(watch):
+        if watch is None or watch.armed != generation:
             return
         watch.pending = None
         watch.deadline = None

--- a/jupyter_mcp_server/watchers.py
+++ b/jupyter_mcp_server/watchers.py
@@ -24,7 +24,23 @@ origin at all — an update applied from the wire — is somebody's.
 
 Debounced: a person typing produces a transaction per keystroke, and a
 subscriber told once per quarter second learns everything it would have
-learned from a hundred notifications.
+learned from a hundred notifications. With a ceiling, so that somebody who
+never stops typing does not keep the news from going out: a debounce with no
+ceiling is starvation waiting for a fast enough typist.
+
+**The changes this server itself makes are folded into the same debounce.**
+A tool edits a cell and publishes on its way out; the edit then arrives back
+over this connection, and the watcher sees it as somebody's — an update
+applied from the wire carries no origin, and the tool's own connection is not
+this one. That is two frames for one edit. So a watched notebook's tools hand
+their news to `fold` instead of publishing it, and the tool's edit and the
+watcher's sight of it collapse into the one notification the subscriber
+needed. An unwatched notebook is unaffected: its tools publish as before.
+
+**Which cells moved** is read from the same events. A deep observation of the
+cells array names the cell at each changed path, and the inserted cells carry
+their own ids; a deletion's id is gone with the cell, and the notebook frame
+is what covers that.
 
 @module jupyter_mcp_server.watchers
 """
@@ -42,6 +58,12 @@ logger = logging.getLogger(__name__)
 #: How long the watcher waits after a change before announcing it, so a
 #: burst of keystrokes is one notification.
 DEBOUNCE_SECONDS = 0.25
+
+#: The longest a change waits, however continuously the document is being
+#: edited. Without it the timer is re-armed on every keystroke and a
+#: subscriber hears nothing until the typing stops — which for a notebook two
+#: agents are working in may be never.
+MAX_WAIT_SECONDS = 2.0
 
 #: `JUPYTER_MCP_WATCH_NOTEBOOKS=false` turns the persistent connections off:
 #: a deployment that publishes through a configured publisher fed by the
@@ -62,6 +84,17 @@ class Watch:
     changes_seen: int = 0
     connection: Any = None
     subscription: Any = field(default=None, repr=False)
+    #: The deep observation of the cells array, unobserved with the rest.
+    cell_subscription: Any = field(default=None, repr=False)
+    #: The loop the watch runs on, so a change folded in from a tool call
+    #: arms the same timer the observers do.
+    loop: Any = field(default=None, repr=False)
+    #: The cells known to have moved since the last announcement.
+    cells: set[str] = field(default_factory=set)
+    #: When the current burst must be announced by, however it continues.
+    deadline: float | None = None
+    #: The live cells array, for reading an id back off a changed index.
+    ycells: Any = field(default=None, repr=False)
 
 
 def _hash_of(origin: Any) -> Any:
@@ -79,6 +112,65 @@ def _origin_of(event: Any) -> Any:
         return origin() if callable(origin) else origin
     except Exception:  # noqa: BLE001 - an origin that cannot be read is nobody's
         return None
+
+
+def _id_at(ycells: Any, index: Any) -> str:
+    """The id of the cell now at this index, or empty."""
+    if ycells is None or not isinstance(index, int):
+        return ""
+    try:
+        return str(ycells[index]["id"] or "")
+    except Exception:  # noqa: BLE001 - a cell without an id is not an error
+        return ""
+
+
+def _ids_of(event: Any, ycells: Any) -> set[str]:
+    """Which cells one deep event names.
+
+    Three shapes, because a notebook is an array of maps of arrays:
+
+    * a change *inside* a cell — its source, its outputs, its metadata —
+      arrives with the cell's index at the head of the path, and the id is
+      read back off the cell now there;
+    * a change to the array itself has an empty path, and the cells it
+      inserted are in its delta, carrying their own ids. This is how a
+      *moved* cell is named: a move is a delete and an insert of the same
+      cell, and the insert half still knows who it is;
+    * a **deleted** cell names nobody. Its id went with it, and there is
+      nothing left to read. The notebook frame published alongside is what
+      tells a subscriber that something it holds may be gone.
+
+    Reading the document from inside its own observer is safe — pycrdt is
+    inside the transaction, not holding it against readers — and it is the
+    only moment the index and the document agree.
+    """
+    found: set[str] = set()
+    path = list(getattr(event, "path", None) or [])
+    if path:
+        # The head of the path is the cell; everything after it is where in
+        # the cell. `target` is the *deepest* thing that changed, so it is
+        # the cell itself only for a change to the cell's own keys.
+        found.add(_id_at(ycells, path[0]))
+        return {one for one in found if one}
+    for part in getattr(event, "delta", None) or []:
+        if not isinstance(part, dict):
+            continue
+        for item in part.get("insert") or []:
+            try:
+                found.add(str(item["id"] or ""))
+            except Exception:  # noqa: BLE001 - not every insert is a cell with an id
+                continue
+    return {one for one in found if one}
+
+
+def _drop(subscription: Any) -> None:
+    """Let go of a pycrdt subscription, however this version says it."""
+    if subscription is None:
+        return
+    try:
+        subscription.drop()
+    except Exception:  # noqa: BLE001 - a subscription already gone is gone
+        pass
 
 
 class NotebookWatchers:
@@ -150,7 +242,8 @@ class NotebookWatchers:
             await self._close(connection)
             self._watching.pop(name, None)
             return
-        loop = asyncio.get_running_loop()
+        watch.loop = asyncio.get_running_loop()
+        watch.ycells = getattr(getattr(client, "_doc", None), "ycells", None)
 
         # pycrdt hands an observer the origin's *hash*, not the origin: an
         # int origin comes back as itself, anything else as `hash(it)`.
@@ -160,12 +253,34 @@ class NotebookWatchers:
             if _origin_of(event) in ours:
                 return
             watch.changes_seen += 1
-            if watch.pending is not None:
-                watch.pending.cancel()
-            watch.pending = loop.call_later(DEBOUNCE_SECONDS, lambda: loop.create_task(self._announce(name)))
+            self._arm(watch)
+
+        def cells_changed(events: Any) -> None:
+            """Which cells the same transaction touched.
+
+            Separate from `changed` because they observe different things:
+            this one sees only the cells array, and a change to the
+            notebook's metadata is a change nobody would hear about if this
+            were the only observer. Both arm the same timer, so the two
+            observations of one transaction are still one notification.
+            """
+            for event in events or ():
+                if _origin_of(event) in ours:
+                    continue
+                watch.cells.update(_ids_of(event, watch.ycells))
+            self._arm(watch)
 
         try:
             watch.subscription = ydoc.observe(changed)
+            if watch.ycells is not None and hasattr(watch.ycells, "observe_deep"):
+                try:
+                    watch.cell_subscription = watch.ycells.observe_deep(cells_changed)
+                except Exception as error:  # noqa: BLE001 - the notebook frame still goes out
+                    logger.info(
+                        "Notebook [%s] is watched, but which cell moved cannot be read: %s",
+                        name,
+                        error,
+                    )
             logger.info("👀 Watching notebook [%s] for changes made elsewhere", name)
             await asyncio.Event().wait()
         except asyncio.CancelledError:
@@ -177,13 +292,97 @@ class NotebookWatchers:
                     with_sub(watch.subscription)
                 except Exception:  # noqa: BLE001
                     pass
+            _drop(watch.cell_subscription)
             await self._close(connection)
+
+    def _arm(self, watch: Watch) -> None:
+        """Restart this notebook's debounce, without letting it run forever.
+
+        The first change of a burst fixes the moment the burst must be
+        announced by. Every change after it pushes the timer back, but never
+        past that moment — so continuous typing costs a subscriber one
+        notification every `MAX_WAIT_SECONDS` instead of costing it silence.
+        """
+        loop = watch.loop
+        if loop is None:
+            return
+        now = loop.time()
+        if watch.deadline is None:
+            watch.deadline = now + MAX_WAIT_SECONDS
+        when = min(now + DEBOUNCE_SECONDS, watch.deadline)
+        if watch.pending is not None:
+            watch.pending.cancel()
+        name = watch.name
+        watch.pending = loop.call_at(when, lambda: loop.create_task(self._announce(name)))
+
+    @staticmethod
+    def _on_this_loop(watch: Watch) -> bool:
+        """Whether this watch's loop is the one running now.
+
+        A watcher outlives the loop it was started on: the module keeps one
+        `NotebookWatchers` for the process, and the next call may arrive on a
+        different loop — routinely in the tests, and in any host that
+        restarts its loop under a live process. Arming a timer on a closed
+        loop *raises*, and it would raise inside a writing tool's result
+        wrapper, which is the news about an edit taking the edit down with
+        it. Answering `False` sends the caller back to publishing for itself,
+        which is what it would have done had nothing been watching.
+        """
+        loop = watch.loop
+        if loop is None or loop.is_closed():
+            return False
+        try:
+            return asyncio.get_running_loop() is loop
+        except RuntimeError:  # no loop at all: not this one
+            return False
+
+    @staticmethod
+    def _superseded(watch: Watch) -> bool:
+        """Whether a later timer has already taken over this burst.
+
+        A timer fires and hands the announcement to a *task*, which runs on
+        the next turn of the loop. A change arriving in between re-arms, and
+        without this both the task and the new timer announce — two frames
+        for the burst the debounce exists to make one. The later timer wins,
+        because it is the one that will have seen the whole burst.
+        """
+        pending = watch.pending
+        if pending is None or watch.loop is None:
+            return False
+        return not pending.cancelled() and pending.when() > watch.loop.time()
+
+    def fold(self, name: str, cells: Any = ()) -> bool:
+        """Take a change *this server* just made into the notebook's debounce.
+
+        Answers whether it was taken. A caller told `False` has to publish the
+        news itself, which is what an unwatched notebook's tools do.
+
+        This exists because the alternative is two frames for one edit. The
+        tool publishes as it returns; a moment later its edit arrives back
+        over the watcher's connection, carrying no origin, and is announced
+        again as somebody else's. Folding it in makes the tool's edit and the
+        watcher's sight of it the same burst — and picks up any *concurrent*
+        edit by a person in the same window for free, which is the case a
+        plain "suppress the echo" rule would have dropped on the floor.
+        """
+        watch = self._watching.get(name)
+        if watch is None or not self._on_this_loop(watch):
+            return False
+        watch.cells.update(str(one) for one in cells if one)
+        watch.changes_seen += 1
+        self._arm(watch)
+        return True
 
     async def _announce(self, name: str) -> None:
         watch = self._watching.get(name)
         if watch is None:
             return
+        if self._superseded(watch):
+            return
         watch.pending = None
+        watch.deadline = None
+        cells = sorted(watch.cells)
+        watch.cells.clear()
         from jupyter_mcp_server import notifications  # noqa: PLC0415
 
         server = self._server
@@ -192,7 +391,7 @@ class NotebookWatchers:
                 from jupyter_mcp_server.server import mcp as server  # noqa: PLC0415
             except Exception:  # noqa: BLE001
                 server = None
-        told = await notifications.publish_notebook_updated(server, name)
+        told = await notifications.publish_notebook_updated(server, name, cells)
         if told:
             watch.announced += 1
 

--- a/jupyter_mcp_server/watchers.py
+++ b/jupyter_mcp_server/watchers.py
@@ -158,7 +158,7 @@ def _ids_of(event: Any, ycells: Any) -> set[str]:
         for item in part.get("insert") or []:
             try:
                 found.add(str(item["id"] or ""))
-            except Exception:  # noqa: BLE001 - not every insert is a cell with an id
+            except Exception:  # noqa: BLE001, S112 - not every insert is a cell with an id
                 continue
     return {one for one in found if one}
 
@@ -169,7 +169,7 @@ def _drop(subscription: Any) -> None:
         return
     try:
         subscription.drop()
-    except Exception:  # noqa: BLE001 - a subscription already gone is gone
+    except Exception:  # noqa: BLE001, S110 - a subscription already gone is gone
         pass
 
 
@@ -245,42 +245,8 @@ class NotebookWatchers:
         watch.loop = asyncio.get_running_loop()
         watch.ycells = getattr(getattr(client, "_doc", None), "ycells", None)
 
-        # pycrdt hands an observer the origin's *hash*, not the origin: an
-        # int origin comes back as itself, anything else as `hash(it)`.
-        ours = {own, _hash_of(own)} if own is not None else set()
-
-        def changed(event: Any) -> None:
-            if _origin_of(event) in ours:
-                return
-            watch.changes_seen += 1
-            self._arm(watch)
-
-        def cells_changed(events: Any) -> None:
-            """Which cells the same transaction touched.
-
-            Separate from `changed` because they observe different things:
-            this one sees only the cells array, and a change to the
-            notebook's metadata is a change nobody would hear about if this
-            were the only observer. Both arm the same timer, so the two
-            observations of one transaction are still one notification.
-            """
-            for event in events or ():
-                if _origin_of(event) in ours:
-                    continue
-                watch.cells.update(_ids_of(event, watch.ycells))
-            self._arm(watch)
-
         try:
-            watch.subscription = ydoc.observe(changed)
-            if watch.ycells is not None and hasattr(watch.ycells, "observe_deep"):
-                try:
-                    watch.cell_subscription = watch.ycells.observe_deep(cells_changed)
-                except Exception as error:  # noqa: BLE001 - the notebook frame still goes out
-                    logger.info(
-                        "Notebook [%s] is watched, but which cell moved cannot be read: %s",
-                        name,
-                        error,
-                    )
+            self._observe(watch, ydoc, own)
             logger.info("👀 Watching notebook [%s] for changes made elsewhere", name)
             await asyncio.Event().wait()
         except asyncio.CancelledError:
@@ -294,6 +260,45 @@ class NotebookWatchers:
                     pass
             _drop(watch.cell_subscription)
             await self._close(connection)
+
+    def _observe(self, watch: Watch, ydoc: Any, own: Any) -> None:
+        """Start listening to the document, twice.
+
+        Twice because the two observations see different things. The document
+        observer sees every transaction, including a change to the notebook's
+        metadata, which nobody would hear about if the cells were the only
+        thing watched. The deep observation of the cells array is what can
+        say *which* cell moved. Both arm the same timer, so the two sightings
+        of one transaction are still one notification.
+        """
+        # pycrdt hands an observer the origin's *hash*, not the origin: an
+        # int origin comes back as itself, anything else as `hash(it)`.
+        ours = {own, _hash_of(own)} if own is not None else set()
+
+        def changed(_event: Any) -> None:
+            if _origin_of(_event) in ours:
+                return
+            watch.changes_seen += 1
+            self._arm(watch)
+
+        def cells_changed(events: Any) -> None:
+            for event in events or ():
+                if _origin_of(event) in ours:
+                    continue
+                watch.cells.update(_ids_of(event, watch.ycells))
+            self._arm(watch)
+
+        watch.subscription = ydoc.observe(changed)
+        if watch.ycells is None or not hasattr(watch.ycells, "observe_deep"):
+            return
+        try:
+            watch.cell_subscription = watch.ycells.observe_deep(cells_changed)
+        except Exception as error:  # noqa: BLE001 - the notebook frame still goes out
+            logger.info(
+                "Notebook [%s] is watched, but which cell moved cannot be read: %s",
+                watch.name,
+                error,
+            )
 
     def _arm(self, watch: Watch) -> None:
         """Restart this notebook's debounce, without letting it run forever.

--- a/tests/test_a_subscriber_really_hears.py
+++ b/tests/test_a_subscriber_really_hears.py
@@ -76,7 +76,7 @@ def _a_free_port() -> int:
         return int(held.getsockname()[1])
 
 
-def _server(publishes: str = NOTEBOOK, cells: tuple = ()) -> MCPServer:
+def _server(publishes: str = NOTEBOOK, cells: tuple[str, ...] = ()) -> MCPServer:
     """A server with the subscription handlers, registered as the real one does.
 
     Built the way `server.py` builds them — the same two `add_request_handler`

--- a/tests/test_a_subscriber_really_hears.py
+++ b/tests/test_a_subscriber_really_hears.py
@@ -76,7 +76,7 @@ def _a_free_port() -> int:
         return int(held.getsockname()[1])
 
 
-def _server(publishes: str = NOTEBOOK) -> MCPServer:
+def _server(publishes: str = NOTEBOOK, cells: tuple = ()) -> MCPServer:
     """A server with the subscription handlers, registered as the real one does.
 
     Built the way `server.py` builds them — the same two `add_request_handler`
@@ -104,7 +104,7 @@ def _server(publishes: str = NOTEBOOK) -> MCPServer:
     @server.tool()
     async def touch_the_notebook() -> str:
         """Publish, exactly as a writing tool's decorator does on its way out."""
-        told = await notifications.publish_notebook_updated(server, publishes)
+        told = await notifications.publish_notebook_updated(server, publishes, cells)
         return f"told={told}"
 
     return server
@@ -275,6 +275,112 @@ async def test_a_subscriber_hears_nothing_about_another_notebook():
                 json=_rpc(
                     3, "tools/call", {"name": "touch_the_notebook", "arguments": {}}
                 ),
+                headers=headers,
+            )
+            await asyncio.sleep(1.0)
+            listening.cancel()
+
+    assert [message["params"]["uri"] for message in heard] == []
+
+
+@pytest.mark.asyncio
+async def test_a_subscriber_to_one_cell_really_hears_about_that_cell():
+    """The cell half, over the same real connection.
+
+    Naming the cell is only worth anything if the frame naming it reaches a
+    client. This subscribes to a cell *and* to the notebook on one session,
+    publishes one edit that names the cell, and reads both frames off the
+    wire in the order they were written.
+
+    Two subscriptions rather than one because the interesting claim is that
+    the cell frame is an **addition**: a client watching the notebook must
+    still hear the notebook, or a deleted cell — whose id nobody can read
+    afterwards — would go unannounced.
+    """
+    notifications.use_publisher(None)
+    heard: list[dict] = []
+    cell = "cell-that-moved"
+
+    async with _Running(_server(cells=(cell,))) as running:
+        async with httpx.AsyncClient(timeout=30.0) as client:
+            headers = await _connected(client, running.url)
+
+            async def listen() -> None:
+                async with client.stream("GET", running.url, headers=headers) as stream:
+                    assert stream.status_code == 200, "no standalone stream to be told on"
+                    async for line in stream.aiter_lines():
+                        if line.startswith("data: "):
+                            heard.append(json.loads(line[len("data: ") :]))
+
+            listening = asyncio.create_task(listen())
+            await asyncio.sleep(0.5)
+
+            for request_id, uri in (
+                (2, f"notebook://{NOTEBOOK}"),
+                (3, f"notebook://{NOTEBOOK}/cells/{cell}"),
+            ):
+                subscribed = await client.post(
+                    running.url,
+                    json=_rpc(request_id, "resources/subscribe", {"uri": uri}),
+                    headers=headers,
+                )
+                assert subscribed.status_code == 200, subscribed.text
+
+            called = await client.post(
+                running.url,
+                json=_rpc(4, "tools/call", {"name": "touch_the_notebook", "arguments": {}}),
+                headers=headers,
+            )
+            said = _frames(called)[0]["result"]["structuredContent"]["result"]
+            assert said == "told=True", f"the server did not think it told anybody: {said}"
+
+            deadline = asyncio.get_running_loop().time() + ARRIVES_WITHIN
+            while asyncio.get_running_loop().time() < deadline and len(heard) < 2:
+                await asyncio.sleep(0.05)
+            listening.cancel()
+
+    assert [message["params"]["uri"] for message in heard] == [
+        f"notebook://{NOTEBOOK}",
+        f"notebook://{NOTEBOOK}/cells/{cell}",
+    ], "the cell frame did not reach the client, or it arrived instead of the notebook's"
+    assert {message["method"] for message in heard} == {"notifications/resources/updated"}
+
+
+@pytest.mark.asyncio
+async def test_a_subscriber_to_one_cell_hears_nothing_about_another_cell():
+    """The other half of the promise, at cell granularity.
+
+    Without this, subscribing to a cell would be subscribing to the notebook
+    with extra steps — and an agent watching one cell of a hundred would be
+    woken by all hundred.
+    """
+    notifications.use_publisher(None)
+    heard: list[dict] = []
+
+    async with _Running(_server(cells=("a-different-cell",))) as running:
+        async with httpx.AsyncClient(timeout=30.0) as client:
+            headers = await _connected(client, running.url)
+
+            async def listen() -> None:
+                async with client.stream("GET", running.url, headers=headers) as stream:
+                    async for line in stream.aiter_lines():
+                        if line.startswith("data: "):
+                            heard.append(json.loads(line[len("data: ") :]))
+
+            listening = asyncio.create_task(listen())
+            await asyncio.sleep(0.5)
+            await client.post(
+                running.url,
+                json=_rpc(
+                    2,
+                    "resources/subscribe",
+                    {"uri": f"notebook://{NOTEBOOK}/cells/the-one-i-care-about"},
+                ),
+                headers=headers,
+            )
+            await client.post(
+                running.url,
+                json=_rpc(3, "tools/call", {"name": "touch_the_notebook", "arguments": {}}),
                 headers=headers,
             )
             await asyncio.sleep(1.0)

--- a/tests/test_notebook_update_notifications.py
+++ b/tests/test_notebook_update_notifications.py
@@ -183,9 +183,8 @@ class TestTheDecoratorActuallyAnnounces:
 
         from jupyter_mcp_server import results
 
-        source = inspect.getsource(results.structured)
-        assert "publish_notebook_updated(" in source
-        assert "MUTATING_KINDS" in source
+        assert "MUTATING_KINDS" in inspect.getsource(results.structured)
+        assert "publish_notebook_updated(" in inspect.getsource(results._announce)
 
     def test_it_publishes_after_the_call_and_not_before(self):
         """A subscriber told a cell changed before it did refetches the old
@@ -195,7 +194,7 @@ class TestTheDecoratorActuallyAnnounces:
         from jupyter_mcp_server import results
 
         source = inspect.getsource(results.structured)
-        assert source.index("await wrapper(") < source.index("publish_notebook_updated(")
+        assert source.index("await wrapper(") < source.index("_announce(")
 
 
 class TestTheOlderWayToAsk:

--- a/tests/test_which_cell_moved.py
+++ b/tests/test_which_cell_moved.py
@@ -1,0 +1,560 @@
+# Copyright (c) 2024- Datalayer, Inc.
+#
+# BSD 3-Clause License
+
+"""The notification says which **cell** moved, not only which notebook.
+
+`resources/updated` naming `notebook://<handle>` tells an agent to read the
+whole notebook again. It does not tell it what changed, so an agent watching
+one cell of a hundred-cell notebook refetches the hundred. `CELL_RESOURCE`
+has existed as a URI template since resources shipped, and nothing published
+it.
+
+Two halves have to agree for that to work. A writing tool knows the cell it
+resolved, and says so in its result already, for the agent's benefit. The
+watcher sees a pycrdt event and has to map it back to the cells that moved.
+
+And a third thing, which is why this is one change rather than two: the two
+halves used to announce the *same edit twice*. The tool published on its way
+out; the edit then arrived back over the watcher's own connection with no
+origin on it, looking like somebody else's, and was announced again. Naming
+the cell would have made that two identical cell frames. So the tool's news
+is folded into the watcher's debounce instead.
+
+Launch the tests:
+```
+$ pytest tests/test_which_cell_moved.py -v
+```
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import pycrdt
+import pytest
+
+from jupyter_mcp_server import notifications, resources
+from jupyter_mcp_server import watchers as module
+from jupyter_mcp_server.watchers import NotebookWatchers
+from tests.test_notebook_update_notifications import _Bus, _FakeSession, _Server
+
+
+class Cells:
+    """A notebook's cells array, as the nbmodel client exposes it."""
+
+    def __init__(self, *ids: str) -> None:
+        self.ydoc = pycrdt.Doc()
+        self.ycells = pycrdt.Array()
+        self.ydoc["cells"] = self.ycells
+        for one in ids:
+            self.ycells.append(
+                pycrdt.Map({"id": one, "source": pycrdt.Text(""), "outputs": pycrdt.Array()})
+            )
+        self.seen: list[set[str]] = []
+        self.ycells.observe_deep(self._note)
+
+    def _note(self, events) -> None:
+        for event in events:
+            self.seen.append(module._ids_of(event, self.ycells))
+
+    def named(self) -> set[str]:
+        found: set[str] = set()
+        for one in self.seen:
+            found |= one
+        return found
+
+
+class FakeNotebookClient:
+    """The nbmodel client's shape, with real cells to observe."""
+
+    def __init__(self, *ids: str) -> None:
+        self._changes_origin = object()
+        self.cells = Cells(*ids)
+        self._doc = type(
+            "YNotebook", (), {"_ydoc": self.cells.ydoc, "ycells": self.cells.ycells}
+        )()
+
+    def edit_source(self, index: int, text: str, *, origin=None) -> None:
+        with self.cells.ydoc.transaction(origin=origin):
+            self.cells.ycells[index]["source"] = pycrdt.Text(text)
+
+    def insert(self, cell_id: str, *, origin=None) -> None:
+        with self.cells.ydoc.transaction(origin=origin):
+            self.cells.ycells.append(
+                pycrdt.Map({"id": cell_id, "source": pycrdt.Text(""), "outputs": pycrdt.Array()})
+            )
+
+    def delete(self, index: int, *, origin=None) -> None:
+        with self.cells.ydoc.transaction(origin=origin):
+            del self.cells.ycells[index]
+
+
+class FakeConnection:
+    def __init__(self, client) -> None:
+        self.client = client
+        self.closed = False
+
+    async def __aenter__(self):
+        return self.client
+
+    async def __aexit__(self, *exc):
+        self.closed = True
+
+
+class FakeManager:
+    def __init__(self, client) -> None:
+        self.connection = FakeConnection(client)
+
+    def is_local_notebook(self, name):
+        return False
+
+    def get_notebook_connection(self, name):
+        return self.connection
+
+
+@pytest.fixture
+def fast(monkeypatch):
+    monkeypatch.setattr(module, "DEBOUNCE_SECONDS", 0.02)
+    monkeypatch.setattr(module, "MAX_WAIT_SECONDS", 0.08)
+
+
+async def _settle(seconds=0.12):
+    await asyncio.sleep(seconds)
+
+
+class TestTheCellUri:
+    """One spelling of a cell's URI, not two."""
+
+    def test_it_is_the_template_filled_in(self):
+        assert notifications.cell_uri("welcome", "abc") == resources.CELL_RESOURCE.format(
+            name="welcome", cell_id="abc"
+        )
+
+    def test_it_sits_under_the_notebook_it_belongs_to(self):
+        """A subscriber that asked for the notebook and one that asked for a
+        cell must be able to tell from the URI which is which."""
+        assert notifications.cell_uri("welcome", "abc").startswith(
+            notifications.notebook_uri("welcome") + "/"
+        )
+
+
+class TestWhichCellsATooldTouched:
+    """Read off the result's `_meta`, where the resolver already put it."""
+
+    def _result(self, **meta):
+        from jupyter_mcp_server.results import meta_key
+
+        return type("R", (), {"meta": {meta_key(k): v for k, v in meta.items()}})()
+
+    def test_the_one_cell_a_tool_resolved(self):
+        assert notifications.changed_cells(self._result(cell_id="abc")) == ("abc",)
+
+    def test_the_several_a_delete_resolved(self):
+        assert notifications.changed_cells(self._result(cell_ids=["a", "b"])) == ("a", "b")
+
+    def test_a_cell_named_twice_is_said_once(self):
+        """A move resolves a source and a target, and a subscriber told about
+        the same cell twice refetches it twice."""
+        assert notifications.changed_cells(self._result(cell_id="a", cell_ids=["a", "b"])) == (
+            "a",
+            "b",
+        )
+
+    def test_an_insert_names_no_cell(self):
+        """Nothing was subscribed to a cell that did not exist."""
+        assert notifications.changed_cells(self._result()) == ()
+
+    def test_a_result_with_no_meta_at_all(self):
+        assert notifications.changed_cells(type("R", (), {"meta": None})()) == ()
+
+    def test_something_that_is_not_a_result(self):
+        assert notifications.changed_cells("not a result") == ()
+
+    def test_a_blank_id_is_not_an_id(self):
+        assert notifications.changed_cells(self._result(cell_ids=["", "b"])) == ("b",)
+
+    def test_a_blank_single_id_is_not_an_id_either(self):
+        """`notebook://nb/cells/` names no cell, and a subscriber sent it
+        would refetch a URI that reads as an error."""
+        assert notifications.changed_cells(self._result(cell_id="")) == ()
+
+
+@pytest.mark.asyncio
+class TestPublishingNamesTheCell:
+    async def test_the_cell_gets_its_own_frame(self):
+        bus = _Bus()
+        told = await notifications.publish_notebook_updated(_Server(bus), "nb", ["abc"])
+        assert told is True
+        assert "notebook://nb/cells/abc" in [event.uri for event in bus.published]
+
+    async def test_the_notebook_frame_is_still_sent(self):
+        """As well as, never instead of. A client subscribed to the notebook
+        asked about the notebook, and a deletion is a change whose cell id
+        nobody can read afterwards."""
+        bus = _Bus()
+        await notifications.publish_notebook_updated(_Server(bus), "nb", ["abc"])
+        assert [event.uri for event in bus.published] == [
+            "notebook://nb",
+            "notebook://nb/cells/abc",
+        ]
+
+    async def test_no_cells_is_the_notebook_alone(self):
+        bus = _Bus()
+        await notifications.publish_notebook_updated(_Server(bus), "nb")
+        assert [event.uri for event in bus.published] == ["notebook://nb"]
+
+    async def test_the_same_cell_twice_is_one_frame(self):
+        bus = _Bus()
+        await notifications.publish_notebook_updated(_Server(bus), "nb", ["a", "a", "b"])
+        assert [event.uri for event in bus.published] == [
+            "notebook://nb",
+            "notebook://nb/cells/a",
+            "notebook://nb/cells/b",
+        ]
+
+    async def test_a_subscriber_to_one_cell_hears_about_that_cell(self):
+        heard: list[str] = []
+
+        class Session(_FakeSession):
+            async def send_resource_updated(self, uri):
+                heard.append(uri)
+
+        session = Session()
+        notifications.legacy_subscribe(session, "notebook://nb/cells/abc")
+        try:
+            await notifications.publish_notebook_updated(_Server(None), "nb", ["abc"])
+        finally:
+            notifications.legacy_unsubscribe(session, "notebook://nb/cells/abc")
+        assert heard == ["notebook://nb/cells/abc"]
+
+    async def test_a_subscriber_to_one_cell_hears_nothing_about_another(self):
+        heard: list[str] = []
+
+        class Session(_FakeSession):
+            async def send_resource_updated(self, uri):
+                heard.append(uri)
+
+        session = Session()
+        notifications.legacy_subscribe(session, "notebook://nb/cells/abc")
+        try:
+            await notifications.publish_notebook_updated(_Server(None), "nb", ["other"])
+        finally:
+            notifications.legacy_unsubscribe(session, "notebook://nb/cells/abc")
+        assert heard == []
+
+
+class TestWhichCellsAnEventNames:
+    """Mapping a pycrdt event back to the cells that moved."""
+
+    def test_a_change_inside_a_cell_names_it(self):
+        client = FakeNotebookClient("one", "two")
+        client.edit_source(1, "print(1)")
+        assert client.cells.named() == {"two"}
+
+    def test_an_output_appended_names_the_cell(self):
+        client = FakeNotebookClient("one")
+        with client.cells.ydoc.transaction():
+            client.cells.ycells[0]["outputs"].append(pycrdt.Map({"output_type": "stream"}))
+        assert client.cells.named() == {"one"}
+
+    def test_an_inserted_cell_names_itself(self):
+        client = FakeNotebookClient("one")
+        client.cells.seen.clear()
+        client.insert("two")
+        assert client.cells.named() == {"two"}
+
+    def test_a_deleted_cell_names_nobody(self):
+        """Its id went with it. The notebook frame is what covers a deletion,
+        which is why the notebook frame is never replaced by cell frames."""
+        client = FakeNotebookClient("one", "two")
+        client.cells.seen.clear()
+        client.delete(0)
+        assert client.cells.named() == set()
+
+
+@pytest.mark.asyncio
+class TestTheWatcherSaysWhichCell:
+    async def test_somebody_elses_edit_names_the_cell_they_edited(self, fast):
+        bus = _Bus()
+        watchers = NotebookWatchers()
+        watchers.serve(_Server(bus))
+        client = FakeNotebookClient("one", "two")
+        assert watchers.watch("nb", FakeManager(client)) is True
+        await _settle(0.05)
+        client.edit_source(1, "print(1)", origin="jupyterlab-user")
+        await _settle()
+        assert [event.uri for event in bus.published] == [
+            "notebook://nb",
+            "notebook://nb/cells/two",
+        ]
+        watchers.stop_all()
+        await _settle(0.02)
+
+    async def test_a_notebook_with_no_readable_cells_still_announces(self, fast):
+        """The deep observation is an improvement on the notebook frame, not
+        a replacement for it: a client that exposes no cells array is watched
+        exactly as before."""
+        from tests.test_notebook_watchers import FakeClient, FakeManager as PlainManager
+
+        bus = _Bus()
+        watchers = NotebookWatchers()
+        watchers.serve(_Server(bus))
+        client = FakeClient()
+        watchers.watch("nb", PlainManager(client))
+        await _settle(0.05)
+        client.edit(origin="somebody")
+        await _settle()
+        assert [event.uri for event in bus.published] == ["notebook://nb"]
+        watchers.stop_all()
+        await _settle(0.02)
+
+
+@pytest.mark.asyncio
+class TestFoldingTheToolsOwnNews:
+    async def test_an_unwatched_notebook_is_not_folded(self, fast):
+        """Which is what makes the caller publish it itself."""
+        watchers = NotebookWatchers()
+        assert watchers.fold("nb", ["abc"]) is False
+
+    async def test_a_watched_one_takes_it_and_announces_it(self, fast):
+        bus = _Bus()
+        watchers = NotebookWatchers()
+        watchers.serve(_Server(bus))
+        watchers.watch("nb", FakeManager(FakeNotebookClient("one")))
+        await _settle(0.05)
+        assert watchers.fold("nb", ["one"]) is True
+        await _settle()
+        assert [event.uri for event in bus.published] == [
+            "notebook://nb",
+            "notebook://nb/cells/one",
+        ]
+        watchers.stop_all()
+        await _settle(0.02)
+
+    async def test_one_edit_seen_twice_is_one_notification(self, fast):
+        """The tool folds its news in, and the same edit then arrives over
+        the watcher's connection carrying no origin. Two sightings, one
+        frame — which is the whole reason the fold exists."""
+        bus = _Bus()
+        watchers = NotebookWatchers()
+        watchers.serve(_Server(bus))
+        client = FakeNotebookClient("one")
+        watchers.watch("nb", FakeManager(client))
+        await _settle(0.05)
+        watchers.fold("nb", ["one"])
+        client.edit_source(0, "print(1)")  # the same edit, arriving from the wire
+        await _settle()
+        assert [event.uri for event in bus.published] == [
+            "notebook://nb",
+            "notebook://nb/cells/one",
+        ]
+        watchers.stop_all()
+        await _settle(0.02)
+
+    async def test_a_watch_on_another_loop_does_not_take_it(self, fast):
+        """The watchers outlive the loop they were started on — one object
+        per process, and the next call may arrive on a different one. Arming
+        a timer on a closed loop raises, and it would raise inside a writing
+        tool's result wrapper: the news about an edit taking the edit down
+        with it. Refusing sends the caller back to publishing for itself."""
+        watchers = NotebookWatchers()
+        watchers.serve(_Server(_Bus()))
+        watchers.watch("nb", FakeManager(FakeNotebookClient("one")))
+        await _settle(0.05)
+        watch = watchers._watching["nb"]
+        assert watchers.fold("nb", ["one"]) is True, "the live loop should be taken"
+
+        gone = asyncio.new_event_loop()
+        gone.close()
+        watch.loop = gone
+        assert watchers.fold("nb", ["one"]) is False
+
+        watch.loop = asyncio.new_event_loop()
+        try:
+            assert watchers.fold("nb", ["one"]) is False, "a different live loop is not this one"
+        finally:
+            watch.loop.close()
+
+    async def test_a_watch_that_has_not_connected_yet_does_not_take_it(self, fast):
+        """Its loop is set when the connection opens. Taking the news before
+        then would arm nothing and tell nobody, which is worse than the
+        caller publishing it."""
+        watchers = NotebookWatchers()
+        watchers.serve(_Server(_Bus()))
+        watchers.watch("nb", FakeManager(FakeNotebookClient("one")))
+        assert watchers.fold("nb", ["one"]) is False
+        watchers.stop_all()
+        await _settle(0.02)
+
+
+@pytest.mark.asyncio
+class TestTheDebounceHasACeiling:
+    async def test_continuous_editing_is_still_announced(self, fast):
+        """A debounce with no ceiling is starvation waiting for a fast enough
+        typist: every keystroke pushes the timer back, and a subscriber hears
+        nothing until the typing stops."""
+        bus = _Bus()
+        watchers = NotebookWatchers()
+        watchers.serve(_Server(bus))
+        client = FakeNotebookClient("one")
+        watchers.watch("nb", FakeManager(client))
+        await _settle(0.05)
+        for index in range(40):
+            client.edit_source(0, f"print({index})", origin="typing")
+            await asyncio.sleep(0.01)
+        assert len(bus.published) >= 2, "the ceiling never fired"
+        watchers.stop_all()
+        await _settle(0.02)
+
+    async def test_a_later_timer_takes_over_from_one_that_has_fired(self, fast):
+        """A timer fires and hands the announcement to a task, which runs a
+        turn later; a change arriving in between re-arms. Without this both
+        announce, and the debounce that exists to make one frame makes two."""
+        bus = _Bus()
+        watchers = NotebookWatchers()
+        watchers.serve(_Server(bus))
+        watchers.watch("nb", FakeManager(FakeNotebookClient("one")))
+        await _settle(0.05)
+        watch = watchers._watching["nb"]
+        watch.pending = watch.loop.call_at(watch.loop.time() + 10, lambda: None)
+        await watchers._announce("nb")
+        assert bus.published == [], "announced over a timer that had not fired yet"
+        watch.pending.cancel()
+        watchers.stop_all()
+        await _settle(0.02)
+
+    async def test_one_burst_s_cells_are_not_the_next_one_s(self, fast):
+        """Otherwise a subscriber is told to refetch a cell that has not
+        changed since it last did — every burst carrying every cell the
+        notebook has ever had."""
+        bus = _Bus()
+        watchers = NotebookWatchers()
+        watchers.serve(_Server(bus))
+        client = FakeNotebookClient("one", "two")
+        watchers.watch("nb", FakeManager(client))
+        await _settle(0.05)
+        client.edit_source(0, "print(1)", origin="typing")
+        await _settle()
+        client.edit_source(1, "print(2)", origin="typing")
+        await _settle()
+        assert [event.uri for event in bus.published] == [
+            "notebook://nb",
+            "notebook://nb/cells/one",
+            "notebook://nb",
+            "notebook://nb/cells/two",
+        ]
+        watchers.stop_all()
+        await _settle(0.02)
+
+    async def test_a_quiet_notebook_is_announced_once(self, fast):
+        bus = _Bus()
+        watchers = NotebookWatchers()
+        watchers.serve(_Server(bus))
+        client = FakeNotebookClient("one")
+        watchers.watch("nb", FakeManager(client))
+        await _settle(0.05)
+        client.edit_source(0, "print(1)", origin="typing")
+        await _settle(0.3)
+        assert [event.uri for event in bus.published] == [
+            "notebook://nb",
+            "notebook://nb/cells/one",
+        ]
+        watchers.stop_all()
+        await _settle(0.02)
+
+
+@pytest.mark.asyncio
+class TestTheWrapperHandsItToTheWatcher:
+    """The decorator around every writing tool, run rather than read.
+
+    The tests next door assert on the *source* of `results.structured`, which
+    says the call is written and not that it happens. These two run a
+    decorated tool and watch where its news goes.
+    """
+
+    def _tool(self):
+        from jupyter_mcp_server.results import add_meta, structured
+
+        @structured("cell.edit")
+        async def edit_a_cell(notebook_name: str = "nb"):
+            add_meta(cell_id="one")
+            return "edited"
+
+        return edit_a_cell
+
+    def _stubs(self, monkeypatch, watchers):
+        from jupyter_mcp_server import server as server_module
+        from jupyter_mcp_server import watchers as watchers_module
+
+        monkeypatch.setattr(watchers_module, "watchers", watchers)
+        monkeypatch.setattr(
+            server_module.notebook_manager, "get_current_notebook", lambda: "nb", raising=False
+        )
+
+    async def test_a_watched_notebook_s_edit_is_folded_rather_than_published(
+        self, monkeypatch, fast
+    ):
+        bus = _Bus()
+        watchers = NotebookWatchers()
+        watchers.serve(_Server(bus))
+        watchers.watch("nb", FakeManager(FakeNotebookClient("one")))
+        await _settle(0.05)
+        self._stubs(monkeypatch, watchers)
+
+        await self._tool()(notebook_name="nb")
+        assert bus.published == [], "published straight out; the watcher will announce it again"
+        await _settle()
+        assert [event.uri for event in bus.published] == [
+            "notebook://nb",
+            "notebook://nb/cells/one",
+        ]
+        watchers.stop_all()
+        await _settle(0.02)
+
+    async def test_an_unwatched_one_is_published_at_once_and_names_the_cell(
+        self, monkeypatch, fast
+    ):
+        """Nothing is watching, so nothing else will say it. Waiting for a
+        debounce that will never fire is how a subscriber hears nothing."""
+        bus = _Bus()
+        watchers = NotebookWatchers()
+        watchers.serve(_Server(bus))
+        self._stubs(monkeypatch, watchers)
+        from jupyter_mcp_server import server as server_module
+
+        monkeypatch.setattr(server_module, "mcp", _Server(bus), raising=False)
+
+        await self._tool()(notebook_name="nb")
+        assert [event.uri for event in bus.published] == [
+            "notebook://nb",
+            "notebook://nb/cells/one",
+        ]
+
+
+@pytest.mark.asyncio
+class TestTheNewsNeverTakesTheEditWithIt:
+    """The edit is done and the answer is in hand when the news goes out.
+
+    An agent told its edit failed when it did not makes the edit again — so
+    an announcement that raises must cost the announcement and nothing else.
+    This is the failure that reached the integration suite: folding into a
+    watcher whose loop had been closed raised out of the wrapper, and every
+    writing tool in the run answered `Event loop is closed`.
+    """
+
+    async def test_a_failing_announcement_still_answers(self, monkeypatch):
+        from jupyter_mcp_server import results
+
+        async def explode(*_arguments, **_keywords):
+            raise RuntimeError("Event loop is closed")
+
+        monkeypatch.setattr(results, "_announce", explode)
+
+        @results.structured("cell.edit")
+        async def edit_a_cell(notebook_name: str = "nb"):
+            return "edited"
+
+        answer = await edit_a_cell(notebook_name="nb")
+        assert answer.structured_content["result"] == "edited"
+        assert not answer.is_error

--- a/tests/test_which_cell_moved.py
+++ b/tests/test_which_cell_moved.py
@@ -143,7 +143,7 @@ class TestTheCellUri:
         )
 
 
-class TestWhichCellsATooldTouched:
+class TestWhichCellsAToolTouched:
     """Read off the result's `_meta`, where the resolver already put it."""
 
     def _result(self, **meta):
@@ -215,6 +215,31 @@ class TestPublishingNamesTheCell:
             "notebook://nb",
             "notebook://nb/cells/a",
             "notebook://nb/cells/b",
+        ]
+
+    async def test_a_uri_that_cannot_be_published_does_not_take_the_rest(self):
+        """One frame failing must not silence the others, and must not make a
+        publish that did reach somebody answer that nobody was told. The
+        caller counts that answer, and `False` there reads as "nothing is
+        listening"."""
+
+        class Choosy:
+            def __init__(self) -> None:
+                self.published: list = []
+
+            async def publish(self, event) -> None:
+                if str(event.uri).endswith("/cells/first"):
+                    raise RuntimeError("that stream is gone")
+                self.published.append(event)
+
+        bus = Choosy()
+        told = await notifications.publish_notebook_updated(
+            _Server(bus), "nb", ["first", "second"]
+        )
+        assert told is True, "somebody was told, and the answer said nobody was"
+        assert [event.uri for event in bus.published] == [
+            "notebook://nb",
+            "notebook://nb/cells/second",
         ]
 
     async def test_a_subscriber_to_one_cell_hears_about_that_cell(self):

--- a/tests/test_which_cell_moved.py
+++ b/tests/test_which_cell_moved.py
@@ -117,11 +117,13 @@ class FakeManager:
 
 @pytest.fixture
 def fast(monkeypatch):
-    monkeypatch.setattr(module, "DEBOUNCE_SECONDS", 0.02)
-    monkeypatch.setattr(module, "MAX_WAIT_SECONDS", 0.08)
+    # Not smaller: Windows' clock resolution is about 16 ms, so a debounce of
+    # 20 ms is a debounce the loop cannot tell from zero.
+    monkeypatch.setattr(module, "DEBOUNCE_SECONDS", 0.05)
+    monkeypatch.setattr(module, "MAX_WAIT_SECONDS", 0.2)
 
 
-async def _settle(seconds=0.12):
+async def _settle(seconds=0.3):
     await asyncio.sleep(seconds)
 
 
@@ -283,7 +285,7 @@ class TestTheWatcherSaysWhichCell:
         watchers.serve(_Server(bus))
         client = FakeNotebookClient("one", "two")
         assert watchers.watch("nb", FakeManager(client)) is True
-        await _settle(0.05)
+        await _settle(0.1)
         client.edit_source(1, "print(1)", origin="jupyterlab-user")
         await _settle()
         assert [event.uri for event in bus.published] == [
@@ -291,7 +293,7 @@ class TestTheWatcherSaysWhichCell:
             "notebook://nb/cells/two",
         ]
         watchers.stop_all()
-        await _settle(0.02)
+        await _settle(0.05)
 
     async def test_a_notebook_with_no_readable_cells_still_announces(self, fast):
         """The deep observation is an improvement on the notebook frame, not
@@ -302,12 +304,12 @@ class TestTheWatcherSaysWhichCell:
         watchers.serve(_Server(bus))
         client = FakeClient()
         watchers.watch("nb", PlainManager(client))
-        await _settle(0.05)
+        await _settle(0.1)
         client.edit(origin="somebody")
         await _settle()
         assert [event.uri for event in bus.published] == ["notebook://nb"]
         watchers.stop_all()
-        await _settle(0.02)
+        await _settle(0.05)
 
 
 @pytest.mark.asyncio
@@ -322,7 +324,7 @@ class TestFoldingTheToolsOwnNews:
         watchers = NotebookWatchers()
         watchers.serve(_Server(bus))
         watchers.watch("nb", FakeManager(FakeNotebookClient("one")))
-        await _settle(0.05)
+        await _settle(0.1)
         assert watchers.fold("nb", ["one"]) is True
         await _settle()
         assert [event.uri for event in bus.published] == [
@@ -330,7 +332,7 @@ class TestFoldingTheToolsOwnNews:
             "notebook://nb/cells/one",
         ]
         watchers.stop_all()
-        await _settle(0.02)
+        await _settle(0.05)
 
     async def test_one_edit_seen_twice_is_one_notification(self, fast):
         """The tool folds its news in, and the same edit then arrives over
@@ -341,7 +343,7 @@ class TestFoldingTheToolsOwnNews:
         watchers.serve(_Server(bus))
         client = FakeNotebookClient("one")
         watchers.watch("nb", FakeManager(client))
-        await _settle(0.05)
+        await _settle(0.1)
         watchers.fold("nb", ["one"])
         client.edit_source(0, "print(1)")  # the same edit, arriving from the wire
         await _settle()
@@ -350,7 +352,7 @@ class TestFoldingTheToolsOwnNews:
             "notebook://nb/cells/one",
         ]
         watchers.stop_all()
-        await _settle(0.02)
+        await _settle(0.05)
 
     async def test_a_watch_on_another_loop_does_not_take_it(self, fast):
         """The watchers outlive the loop they were started on — one object
@@ -361,7 +363,7 @@ class TestFoldingTheToolsOwnNews:
         watchers = NotebookWatchers()
         watchers.serve(_Server(_Bus()))
         watchers.watch("nb", FakeManager(FakeNotebookClient("one")))
-        await _settle(0.05)
+        await _settle(0.1)
         watch = watchers._watching["nb"]
         assert watchers.fold("nb", ["one"]) is True, "the live loop should be taken"
 
@@ -385,7 +387,7 @@ class TestFoldingTheToolsOwnNews:
         watchers.watch("nb", FakeManager(FakeNotebookClient("one")))
         assert watchers.fold("nb", ["one"]) is False
         watchers.stop_all()
-        await _settle(0.02)
+        await _settle(0.05)
 
 
 @pytest.mark.asyncio
@@ -399,30 +401,69 @@ class TestTheDebounceHasACeiling:
         watchers.serve(_Server(bus))
         client = FakeNotebookClient("one")
         watchers.watch("nb", FakeManager(client))
-        await _settle(0.05)
-        for index in range(40):
+        await _settle(0.1)
+        for index in range(60):
             client.edit_source(0, f"print({index})", origin="typing")
             await asyncio.sleep(0.01)
         assert len(bus.published) >= 2, "the ceiling never fired"
         watchers.stop_all()
-        await _settle(0.02)
+        await _settle(0.05)
 
-    async def test_a_later_timer_takes_over_from_one_that_has_fired(self, fast):
+    async def test_a_later_arming_takes_over_from_one_that_has_fired(self, fast):
         """A timer fires and hands the announcement to a task, which runs a
-        turn later; a change arriving in between re-arms. Without this both
-        announce, and the debounce that exists to make one frame makes two."""
+        turn later; a change arriving in between re-arms. Without the
+        generation both announce, and the debounce that exists to make one
+        frame makes two.
+
+        A counter rather than a look at the pending timer's deadline: asyncio
+        fires a timer when the loop is within one clock resolution of it, so
+        on a coarse clock a timer fires with its own deadline still in the
+        future — and reading that as "a later timer is armed" is a
+        notification that never arrives."""
         bus = _Bus()
         watchers = NotebookWatchers()
         watchers.serve(_Server(bus))
         watchers.watch("nb", FakeManager(FakeNotebookClient("one")))
-        await _settle(0.05)
+        await _settle(0.1)
         watch = watchers._watching["nb"]
-        watch.pending = watch.loop.call_at(watch.loop.time() + 10, lambda: None)
-        await watchers._announce("nb")
-        assert bus.published == [], "announced over a timer that had not fired yet"
-        watch.pending.cancel()
+
+        watchers.fold("nb", ["one"])
+        superseded = watch.armed
+        watchers.fold("nb", ["one"])
+        await watchers._announce("nb", superseded)
+        assert bus.published == [], "an announcement from an arming already taken over"
+
+        await _settle()
+        assert [event.uri for event in bus.published] == [
+            "notebook://nb",
+            "notebook://nb/cells/one",
+        ], "and the arming that took over still announces"
         watchers.stop_all()
-        await _settle(0.02)
+        await _settle(0.1)
+
+    async def test_a_timer_that_fires_early_still_announces(self, fast):
+        """asyncio runs a timer once the loop's time is within one clock
+        resolution of its deadline. On Windows that resolution is about 16 ms,
+        so a 50 ms debounce fires with its own deadline still in the future —
+        and an announcement that declined on "the deadline has not passed" was
+        an announcement that never arrived at all. Two Windows jobs failed on
+        exactly this, on a Linux-green suite."""
+        bus = _Bus()
+        watchers = NotebookWatchers()
+        watchers.serve(_Server(bus))
+        watchers.watch("nb", FakeManager(FakeNotebookClient("one")))
+        await _settle(0.1)
+        watch = watchers._watching["nb"]
+
+        watchers.fold("nb", ["one"])
+        assert watch.pending.when() > watch.loop.time(), "the deadline is still ahead"
+        await watchers._announce("nb", watch.armed)
+        assert [event.uri for event in bus.published] == [
+            "notebook://nb",
+            "notebook://nb/cells/one",
+        ]
+        watchers.stop_all()
+        await _settle(0.05)
 
     async def test_one_burst_s_cells_are_not_the_next_one_s(self, fast):
         """Otherwise a subscriber is told to refetch a cell that has not
@@ -433,7 +474,7 @@ class TestTheDebounceHasACeiling:
         watchers.serve(_Server(bus))
         client = FakeNotebookClient("one", "two")
         watchers.watch("nb", FakeManager(client))
-        await _settle(0.05)
+        await _settle(0.1)
         client.edit_source(0, "print(1)", origin="typing")
         await _settle()
         client.edit_source(1, "print(2)", origin="typing")
@@ -445,7 +486,7 @@ class TestTheDebounceHasACeiling:
             "notebook://nb/cells/two",
         ]
         watchers.stop_all()
-        await _settle(0.02)
+        await _settle(0.05)
 
     async def test_a_quiet_notebook_is_announced_once(self, fast):
         bus = _Bus()
@@ -453,7 +494,7 @@ class TestTheDebounceHasACeiling:
         watchers.serve(_Server(bus))
         client = FakeNotebookClient("one")
         watchers.watch("nb", FakeManager(client))
-        await _settle(0.05)
+        await _settle(0.1)
         client.edit_source(0, "print(1)", origin="typing")
         await _settle(0.3)
         assert [event.uri for event in bus.published] == [
@@ -461,7 +502,7 @@ class TestTheDebounceHasACeiling:
             "notebook://nb/cells/one",
         ]
         watchers.stop_all()
-        await _settle(0.02)
+        await _settle(0.05)
 
 
 @pytest.mark.asyncio
@@ -499,7 +540,7 @@ class TestTheWrapperHandsItToTheWatcher:
         watchers = NotebookWatchers()
         watchers.serve(_Server(bus))
         watchers.watch("nb", FakeManager(FakeNotebookClient("one")))
-        await _settle(0.05)
+        await _settle(0.1)
         self._stubs(monkeypatch, watchers)
 
         await self._tool()(notebook_name="nb")
@@ -510,7 +551,7 @@ class TestTheWrapperHandsItToTheWatcher:
             "notebook://nb/cells/one",
         ]
         watchers.stop_all()
-        await _settle(0.02)
+        await _settle(0.05)
 
     async def test_an_unwatched_one_is_published_at_once_and_names_the_cell(
         self, monkeypatch, fast

--- a/tests/test_which_cell_moved.py
+++ b/tests/test_which_cell_moved.py
@@ -38,6 +38,8 @@ from jupyter_mcp_server import notifications, resources
 from jupyter_mcp_server import watchers as module
 from jupyter_mcp_server.watchers import NotebookWatchers
 from tests.test_notebook_update_notifications import _Bus, _FakeSession, _Server
+from tests.test_notebook_watchers import FakeClient
+from tests.test_notebook_watchers import FakeManager as PlainManager
 
 
 class Cells:
@@ -295,8 +297,6 @@ class TestTheWatcherSaysWhichCell:
         """The deep observation is an improvement on the notebook frame, not
         a replacement for it: a client that exposes no cells array is watched
         exactly as before."""
-        from tests.test_notebook_watchers import FakeClient, FakeManager as PlainManager
-
         bus = _Bus()
         watchers = NotebookWatchers()
         watchers.serve(_Server(bus))


### PR DESCRIPTION
This PR refines notebook update notifications so subscribers can be told which cell changed (not just which notebook), while also preventing duplicate announcements by folding tool-originated edits into the watcher’s debounce window.

Changes:

Add cell-level update URIs (notebook://<name>/cells/<id>) alongside the existing notebook-level URI.
Enhance watchers with a debounced announcement “ceiling” and fold tool-originated changes into the same debounce to avoid double notifications.
Add/adjust tests to validate cell URI construction, cell-id extraction from results and CRDT events, and end-to-end delivery over a real Streamable HTTP connection.