### PR TITLE
feat(extension): serve prompts and resources in JUPYTER_SERVER mode

### DIFF
--- a/docs/docs/architecture/index.mdx
+++ b/docs/docs/architecture/index.mdx
@@ -356,6 +356,13 @@ never propagates errors into a tool call. See
 1. The `CallToolResult` is serialized in wire form and returned as the JSON-RPC
    response.
 
+`prompts/list`, `prompts/get`, `resources/list`, `resources/templates/list` and
+`resources/read` take the same route: the handler asks the same `MCPServer`
+instance, so the extension serves the prompts and resources the standalone
+server serves. `resources/subscribe` is the exception — it is driven over the
+SDK's own session bus, which a Tornado request does not have, so a client that
+wants notifications about a resource uses the standalone server.
+
 ### `execute_code` with a sandbox variant
 
 1. The sandboxes extension's `intercept_execute_code()` is asked first; when a

--- a/jupyter_mcp_server/jupyter_extension/handlers.py
+++ b/jupyter_mcp_server/jupyter_extension/handlers.py
@@ -9,11 +9,23 @@ This module provides handlers that bridge between Tornado (Jupyter Server) and
 MCPServer, managing the MCP protocol lifecycle and request proxying.
 """
 
+import base64
 import json
 import logging
 from typing import Any
 
 from jupyter_server.base.handlers import JupyterHandler
+from mcp.server.mcpserver.exceptions import ResourceError, ResourceNotFoundError
+from mcp.types import (
+    INTERNAL_ERROR,
+    INVALID_PARAMS,
+    BlobResourceContents,
+    ListPromptsResult,
+    ListResourcesResult,
+    ListResourceTemplatesResult,
+    ReadResourceResult,
+    TextResourceContents,
+)
 from tornado.web import HTTPError
 
 from jupyter_mcp_server.__version__ import __version__
@@ -44,6 +56,30 @@ async def _fetch_jupyter_tools(**kwargs):
     from jupyter_mcp_tools import get_tools
 
     return await get_tools(wait_timeout=5, **kwargs)
+
+
+def _sdk_result(request_id: Any, result: Any) -> dict:
+    """A JSON-RPC response carrying an SDK result object.
+
+    Serialized the way the ``tools/call`` branch already serializes its
+    ``CallToolResult``: camelCase keys, nothing null, and no ``resultType``,
+    which belongs to a newer protocol revision than the one this handler
+    announces. Building the SDK's own result model rather than a hand-rolled
+    dict is what keeps this transport's wire identical to the one the
+    standalone server puts out for the same request.
+    """
+    return {
+        "jsonrpc": "2.0",
+        "id": request_id,
+        "result": result.model_dump(
+            by_alias=True, mode="json", exclude_none=True, exclude={"result_type"}
+        ),
+    }
+
+
+def _error_response(request_id: Any, code: int, message: str) -> dict:
+    """A JSON-RPC error response."""
+    return {"jsonrpc": "2.0", "id": request_id, "error": {"code": code, "message": message}}
 
 
 class MCPSSEHandler(JupyterHandler):
@@ -416,14 +452,8 @@ class MCPSSEHandler(JupyterHandler):
                         "id": request_id,
                         "error": {"code": -32603, "message": f"Internal error calling tool: {e!s}"},
                     }
-            elif method == "prompts/list":
-                # List available prompts - return empty list if no prompts defined
-                logger.info("Listing prompts...")
-                response = {"jsonrpc": "2.0", "id": request_id, "result": {"prompts": []}}
-            elif method == "resources/list":
-                # List available resources - return empty list if no resources defined
-                logger.info("Listing resources...")
-                response = {"jsonrpc": "2.0", "id": request_id, "result": {"resources": []}}
+            elif method in _PROMPT_AND_RESOURCE_METHODS:
+                response = await _PROMPT_AND_RESOURCE_METHODS[method](self, request_id, params)
             else:
                 # Method not supported
                 response = {
@@ -451,6 +481,146 @@ class MCPSSEHandler(JupyterHandler):
                 )
             )
             self.finish()
+
+    # ------------------------------------------------------------------
+    # Prompts and resources.
+    #
+    # All five route to the same shared `mcp` object the tool branches
+    # above use, so this transport serves whatever the server registered
+    # rather than a second, smaller list of its own. `resources/subscribe`
+    # and `resources/unsubscribe` are deliberately *not* here: they are
+    # driven over the SDK's own session bus, which a Tornado request does
+    # not have.
+    # ------------------------------------------------------------------
+
+    async def _list_prompts(self, request_id: Any, params: dict) -> dict:
+        """`prompts/list`: every prompt registered on the shared server."""
+        from jupyter_mcp_server.server import mcp
+
+        try:
+            return _sdk_result(request_id, ListPromptsResult(prompts=await mcp.list_prompts()))
+        except Exception as e:
+            logger.error(f"Error listing prompts: {e}", exc_info=True)
+            return _error_response(
+                request_id, INTERNAL_ERROR, f"Internal error listing prompts: {e!s}"
+            )
+
+    async def _get_prompt(self, request_id: Any, params: dict) -> dict:
+        """`prompts/get`: render one prompt.
+
+        The prompt bodies are already mode-aware — `jupyter_cite` reads the
+        notebook through `contents_manager` in JUPYTER_SERVER mode — so
+        nothing here has to know which mode it is running in.
+        """
+        from jupyter_mcp_server.server import mcp
+
+        name = params.get("name")
+        if not isinstance(name, str):
+            return _error_response(request_id, INVALID_PARAMS, "prompts/get needs a prompt 'name'")
+        try:
+            result = await mcp.get_prompt(name, params.get("arguments") or None)
+            return _sdk_result(request_id, result)
+        except Exception as e:
+            logger.error(f"Error getting prompt {name}: {e}", exc_info=True)
+            return _error_response(
+                request_id, INTERNAL_ERROR, f"Internal error getting prompt: {e!s}"
+            )
+
+    async def _list_resources(self, request_id: Any, params: dict) -> dict:
+        """`resources/list`: the concrete resources, without the templates."""
+        from jupyter_mcp_server.server import mcp
+
+        try:
+            return _sdk_result(
+                request_id, ListResourcesResult(resources=await mcp.list_resources())
+            )
+        except Exception as e:
+            logger.error(f"Error listing resources: {e}", exc_info=True)
+            return _error_response(
+                request_id, INTERNAL_ERROR, f"Internal error listing resources: {e!s}"
+            )
+
+    async def _list_resource_templates(self, request_id: Any, params: dict) -> dict:
+        """`resources/templates/list`: the parameterized `notebook://` ones.
+
+        Separate from `resources/list` on the wire, and the notebook
+        resources live only here — a client that asked only for the concrete
+        list would see none of them.
+        """
+        from jupyter_mcp_server.server import mcp
+
+        try:
+            return _sdk_result(
+                request_id,
+                ListResourceTemplatesResult(resource_templates=await mcp.list_resource_templates()),
+            )
+        except Exception as e:
+            logger.error(f"Error listing resource templates: {e}", exc_info=True)
+            return _error_response(
+                request_id, INTERNAL_ERROR, f"Internal error listing resource templates: {e!s}"
+            )
+
+    async def _read_resource(self, request_id: Any, params: dict) -> dict:
+        """`resources/read`: one resource's contents.
+
+        The `ReadResourceContents` the SDK hands back become
+        `TextResourceContents` or `BlobResourceContents` exactly as the SDK's
+        own `resources/read` handler builds them, so bytes arrive base64 in a
+        `blob` rather than mangled into a `text` field.
+        """
+        from jupyter_mcp_server.server import mcp
+
+        uri = params.get("uri")
+        if not isinstance(uri, str):
+            return _error_response(request_id, INVALID_PARAMS, "resources/read needs a 'uri'")
+        try:
+            results = await mcp.read_resource(uri)
+        except ResourceError as error:
+            # The mapping the SDK makes for the same failure: asking for a
+            # resource that is not there is the caller's mistake, anything
+            # else is ours.
+            code = INVALID_PARAMS if isinstance(error, ResourceNotFoundError) else INTERNAL_ERROR
+            logger.info(f"Resource {uri!r} failed: {error}")
+            return _error_response(request_id, code, str(error))
+        except Exception as e:
+            logger.error(f"Error reading resource {uri}: {e}", exc_info=True)
+            return _error_response(
+                request_id, INTERNAL_ERROR, f"Internal error reading resource: {e!s}"
+            )
+
+        contents: list[TextResourceContents | BlobResourceContents] = []
+        for item in results:
+            if isinstance(item.content, bytes):
+                contents.append(
+                    BlobResourceContents(
+                        uri=uri,
+                        blob=base64.b64encode(item.content).decode(),
+                        mime_type=item.mime_type or "application/octet-stream",
+                        _meta=item.meta,
+                    )
+                )
+            else:
+                contents.append(
+                    TextResourceContents(
+                        uri=uri,
+                        text=item.content,
+                        mime_type=item.mime_type or "text/plain",
+                        _meta=item.meta,
+                    )
+                )
+        return _sdk_result(request_id, ReadResourceResult(contents=contents))
+
+
+#: The prompt and resource methods `MCPSSEHandler.post` dispatches. A table
+#: rather than five more `elif` branches, because `post` is already long and
+#: these five differ only in which method of the shared `mcp` object they ask.
+_PROMPT_AND_RESOURCE_METHODS = {
+    "prompts/list": MCPSSEHandler._list_prompts,
+    "prompts/get": MCPSSEHandler._get_prompt,
+    "resources/list": MCPSSEHandler._list_resources,
+    "resources/templates/list": MCPSSEHandler._list_resource_templates,
+    "resources/read": MCPSSEHandler._read_resource,
+}
 
 
 class MCPHandler(JupyterHandler):

--- a/jupyter_mcp_server/resources.py
+++ b/jupyter_mcp_server/resources.py
@@ -35,7 +35,10 @@ import importlib
 import json
 import logging
 import os
+from pathlib import Path
 from typing import Any
+
+from jupyter_core.utils import ensure_async
 
 from jupyter_mcp_server.models import Notebook
 
@@ -157,7 +160,14 @@ async def read_notebook(notebook_manager: Any, name: str) -> Notebook:
     Through the same connection the tools use, so a resource read right after
     a write sees the write: the collaborative document is the truth, and
     reading the file from disk would answer with whatever was last saved.
+
+    Which connection that is depends on the mode, exactly as it does for
+    `read_notebook`'s tool: in JUPYTER_SERVER mode there is no notebook
+    websocket to open — `NotebookConnection` refuses a local notebook — and
+    the document is reached through the server this process is part of.
     """
+    from jupyter_mcp_server.server_context import ServerContext  # noqa: PLC0415
+    from jupyter_mcp_server.tools._base import ServerMode  # noqa: PLC0415
     from jupyter_mcp_server.utils import resolve_notebook_connection  # noqa: PLC0415
 
     if name not in notebook_manager:
@@ -165,8 +175,41 @@ async def read_notebook(notebook_manager: Any, name: str) -> Notebook:
             f"No notebook named {name!r} is in use. Open one with use_notebook, "
             "and list what is open with list_notebooks."
         )
+    context = ServerContext.get_instance()
+    if context.mode == ServerMode.JUPYTER_SERVER and context.contents_manager is not None:
+        return await _read_notebook_locally(notebook_manager, name, context.contents_manager)
     async with resolve_notebook_connection(notebook_manager, name) as content:
         return Notebook(**content.as_dict())
+
+
+async def _read_notebook_locally(
+    notebook_manager: Any, name: str, contents_manager: Any
+) -> Notebook:
+    """The notebook, read the way the local tools read it.
+
+    The live YDoc first — the same source every cell-mutation tool writes
+    to — so a resource read right after our own write sees it rather than
+    the on-disk copy the autosave has not flushed yet. `contents_manager` is
+    the fallback for a notebook nobody has a collaborative session on.
+    """
+    from jupyter_mcp_server.jupyter_extension.context import get_server_context  # noqa: PLC0415
+    from jupyter_mcp_server.utils import get_notebook_model  # noqa: PLC0415
+
+    notebook_path = notebook_manager.get_notebook_path(name)
+    serverapp = get_server_context().serverapp
+
+    ydoc_path = notebook_path
+    if serverapp and not Path(ydoc_path).is_absolute():
+        ydoc_path = str(Path(serverapp.root_dir) / ydoc_path)
+
+    nb_model = await get_notebook_model(serverapp, ydoc_path) if serverapp else None
+    if nb_model:
+        return Notebook(**nb_model.as_dict())
+
+    model = await ensure_async(contents_manager.get(notebook_path, content=True, type="notebook"))
+    if "content" not in model:
+        raise ResourceNotFound(f"Could not read notebook content from {notebook_path}")
+    return Notebook(**model["content"])
 
 
 def find_cell(notebook: Notebook, cell_id: str) -> tuple[int, Any]:

--- a/tests/test_prompts.py
+++ b/tests/test_prompts.py
@@ -6,24 +6,26 @@
 Test for MCP Prompts Feature
 """
 
-import os
-
 import pytest
 
 from .test_common import MCPClient, timeout_wrapper
 
-# Now, prompt feature is only available in MCP_SERVER mode.
-pytestmark = pytest.mark.skipif(
-    not os.environ.get("TEST_MCP_SERVER", "false").lower() == "true",
-    reason="Prompt feature is only available in MCP_SERVER mode now.",
-)
+
+@pytest.mark.asyncio
+@timeout_wrapper(60)
+async def test_the_prompt_is_listed(mcp_client_parametrized: MCPClient):
+    """A prompt a client cannot see is a prompt it will never ask for, and
+    both transports advertise the `prompts` capability in their handshake."""
+    async with mcp_client_parametrized as client:
+        listed = await client._session.list_prompts()
+        assert "jupyter_cite" in {prompt.name for prompt in listed.prompts}
 
 
 @pytest.mark.asyncio
 @timeout_wrapper(60)
-async def test_jupyter_cite(mcp_client: MCPClient):
+async def test_jupyter_cite(mcp_client_parametrized: MCPClient):
     """Test jupyter cite prompt feature"""
-    async with mcp_client:
+    async with mcp_client_parametrized as mcp_client:
         await mcp_client.use_notebook("new", "new.ipynb")
         await mcp_client.use_notebook("notebook", "notebook.ipynb")
         # Test prompt injection

--- a/tests/test_resources_both_modes.py
+++ b/tests/test_resources_both_modes.py
@@ -1,0 +1,135 @@
+#!/usr/bin/env python3
+# Copyright (c) 2024- Datalayer, Inc.
+#
+# BSD 3-Clause License
+
+"""The notebook resources, over the wire, in both deployment modes.
+
+`test_notebook_resources.py` proves `resources.py` — the URI shapes, the MIME
+types, what a cell document contains. This proves a client can actually reach
+any of it, which is a different question and was answered differently by the
+two transports: the standalone server served all three templates while the
+JupyterLab extension served none, having advertised `resources` in its
+handshake all the same.
+
+Nothing here is mode-specific. Every assertion is about what the protocol
+says, so both parametrizations run the same code and a mode that stops
+serving a resource fails rather than quietly returning an empty list.
+
+```
+$ pytest tests/test_resources_both_modes.py -v
+```
+"""
+
+import json
+import uuid
+from pathlib import Path
+
+import pytest
+from mcp.shared.exceptions import MCPError
+
+from jupyter_mcp_server import resources
+
+from .test_common import MCPClient, timeout_wrapper
+
+CAPABILITIES_URI = "capabilities://"
+
+#: Where both fixtures root their Jupyter server, per `tests/conftest.py`.
+CONTENT_DIR = Path("dev/content")
+
+
+async def _templates(client: MCPClient) -> dict:
+    result = await client._session.list_resource_templates()
+    return {template.uri_template: template for template in result.resource_templates}
+
+
+async def _read(client: MCPClient, uri: str) -> str:
+    result = await client._session.read_resource(uri)
+    return "".join(block.text for block in result.contents if getattr(block, "text", None))
+
+
+@pytest.mark.asyncio
+@timeout_wrapper(60)
+async def test_the_three_notebook_templates_are_offered(mcp_client_parametrized: MCPClient):
+    """The notebook resources are *templates*: they carry `{name}`, so they
+    never appear in `resources/list`. A deployment that answered only
+    `resources/list` would look like it served resources and offer none of
+    the ones that matter."""
+    async with mcp_client_parametrized as client:
+        offered = await _templates(client)
+        for uri in (
+            resources.NOTEBOOK_RESOURCE,
+            resources.CELL_RESOURCE,
+            resources.OUTPUT_RESOURCE,
+        ):
+            assert uri in offered, f"{uri} is not offered; got {sorted(offered)}"
+
+
+@pytest.mark.asyncio
+@timeout_wrapper(60)
+async def test_a_concrete_resource_is_listed(mcp_client_parametrized: MCPClient):
+    """`resources/list` is the other half, and it is not empty either."""
+    async with mcp_client_parametrized as client:
+        listed = await client._session.list_resources()
+        assert CAPABILITIES_URI in {str(resource.uri) for resource in listed.resources}
+
+
+@pytest.mark.asyncio
+@timeout_wrapper(60)
+async def test_a_notebook_reads_back_as_nbformat_json(mcp_client_parametrized: MCPClient):
+    """The point of the whole resource: an agent that wants the document asks
+    for the document, rather than paying for a tool result that pushes it."""
+    async with mcp_client_parametrized as client:
+        await client.use_notebook("notebook", "notebook.ipynb")
+        document = json.loads(await _read(client, "notebook://notebook"))
+        assert document["cells"], "the notebook came back with no cells"
+        assert "# Matplotlib Examples" in json.dumps(document["cells"][0]["source"])
+
+
+@pytest.mark.asyncio
+@timeout_wrapper(90)
+async def test_a_cell_lists_its_outputs_by_uri_rather_than_inlining_them(
+    mcp_client_parametrized: MCPClient,
+):
+    """A cell that printed a megabyte would otherwise spend a megabyte of the
+    client's context every time anybody read the cell.
+
+    On a notebook of its own, because the ones that ship with the repo
+    predate nbformat 4.5 and have no cell ids to address.
+    """
+    notebook_file = f"resources_{uuid.uuid4().hex[:8]}.ipynb"
+    on_disk = CONTENT_DIR / notebook_file
+    try:
+        async with mcp_client_parametrized as client:
+            await client.use_notebook("resources", notebook_file, mode="create")
+            await client.insert_execute_code_cell(0, "print('an output to read')")
+
+            document = json.loads(await _read(client, "notebook://resources"))
+            cell = next((c for c in document["cells"] if c.get("id") and c.get("outputs")), None)
+            assert cell is not None, "the created notebook has no cell with an id and an output"
+
+            read_back = json.loads(await _read(client, f"notebook://resources/cells/{cell['id']}"))
+            assert read_back["id"] == cell["id"]
+            for output in read_back["outputs"]:
+                assert output["uri"].startswith(
+                    f"notebook://resources/cells/{cell['id']}/outputs/"
+                )
+                assert "text" not in output and "data" not in output
+
+            assert "an output to read" in await _read(client, read_back["outputs"][0]["uri"])
+    finally:
+        on_disk.unlink(missing_ok=True)
+
+
+@pytest.mark.asyncio
+@timeout_wrapper(60)
+async def test_a_notebook_nobody_opened_is_refused_rather_than_answered(
+    mcp_client_parametrized: MCPClient,
+):
+    """A protocol error rather than an empty document, which a client cannot
+    tell from a notebook that really has no cells."""
+    async with mcp_client_parametrized as client:
+        await client.use_notebook("notebook", "notebook.ipynb")
+        with pytest.raises(MCPError) as refused:
+            await _read(client, "notebook://nothing-is-open-under-this-name")
+        assert "nothing-is-open-under-this-name" in str(refused.value)


### PR DESCRIPTION
A client connected to the JupyterLab-extension deployment is told in the handshake that this server has prompts and resources, and then cannot reach any of them. `jupyter_cite` is invisible, the three `notebook://` templates are invisible, and three of the five methods do not exist at all:

```
POST /mcp  initialize
  -> {"capabilities": {"tools": {}, "prompts": {}, "resources": {}}, "serverInfo": {"version": "2.1.7"}}
POST /mcp  prompts/list             -> {"result": {"prompts": []}}
POST /mcp  resources/list           -> {"result": {"resources": []}}
POST /mcp  resources/templates/list -> {"error": {"code": -32601, "message": "Method not found: resources/templates/list"}}
POST /mcp  prompts/get              -> {"error": {"code": -32601, "message": "Method not found: prompts/get"}}
POST /mcp  resources/read           -> {"error": {"code": -32601, "message": "Method not found: resources/read"}}
```

The standalone server, from the same checkout, serves `jupyter_cite`, `capabilities://` and all three `notebook://` templates.

`jupyter_mcp_server/jupyter_extension/handlers.py:419-426`:

```python
elif method == "prompts/list":
    # List available prompts - return empty list if no prompts defined
    logger.info("Listing prompts...")
    response = {"jsonrpc": "2.0", "id": request_id, "result": {"prompts": []}}
elif method == "resources/list":
    # List available resources - return empty list if no resources defined
    logger.info("Listing resources...")
    response = {"jsonrpc": "2.0", "id": request_id, "result": {"resources": []}}
```

Those two branches and the `capabilities` dict above them arrived together in `3a4e06d` ("fix ressources and prompts list", #117), which closed #113. At that date the comments were true — the server had no prompts and no resources, so `[]` was the honest answer and advertising the capability was reasonable. `jupyter_cite` landed three weeks later (#147, #159, #161) and the notebook resources ten months later (#422). Both registered on the shared `MCPServer` object, neither reached this transport, and the placeholder became an advertisement the extension does not honour.

## What this does

`prompts/list`, `prompts/get`, `resources/list`, `resources/templates/list` and `resources/read` now go to the same `mcp` object the `tools/list` and `tools/call` branches already delegate to. There is no second registry, and no new prompt or resource — the extension serves what the server has.

Each response is built from the SDK's own result model (`ListPromptsResult`, `GetPromptResult`, …) and dumped with the same arguments the `tools/call` branch uses for its `CallToolResult`, so the wire is the one the standalone server produces for the same request. `resources/read` turns `ReadResourceContents` into `TextResourceContents` / `BlobResourceContents` the way the SDK's own `resources/read` handler does, so binary content arrives base64 in a `blob` rather than coerced into `text`, and it maps `ResourceNotFoundError` to `-32602` and every other `ResourceError` to `-32603`, again matching the SDK.

`resources.read_notebook` needed a mode branch. It called `resolve_notebook_connection`, and `NotebookConnection` refuses a local notebook by design — *"This is only used in MCP_SERVER mode […] In JUPYTER_SERVER mode (local), notebook content is accessed directly via contents_manager"*. It now reads the way `ReadNotebookTool` does in that mode: the live YDoc first, `contents_manager.get()` as the fallback. `JupyterCitePrompt` already had its own `ServerMode.JUPYTER_SERVER` branch and needed no change.

**Subscriptions are deliberately out of scope.** `resources/subscribe` and `resources/unsubscribe` are registered on `mcp._lowlevel_server` and driven over the SDK's session bus, which a Tornado request does not have. They stay MCP_SERVER-only; there is a line saying so on the architecture page.

The same five requests after the change:

```
POST /mcp  prompts/list
  -> {"result": {"prompts": [{"name": "jupyter_cite", "arguments": [...]}]}}
POST /mcp  resources/list
  -> {"result": {"resources": [{"uri": "capabilities://", "mimeType": "text/plain", ...}]}}
POST /mcp  resources/templates/list
  -> {"result": {"resourceTemplates": [
       {"name": "notebook", "uriTemplate": "notebook://{name}", ...},
       {"name": "notebook-cell", "uriTemplate": "notebook://{name}/cells/{cell_id}", ...},
       {"name": "notebook-cell-output", "uriTemplate": "notebook://{name}/cells/{cell_id}/outputs/{index}", ...}]}}
POST /mcp  prompts/get  {"name": "jupyter_cite", "arguments": {"cell_indices": "0", ...}}
  -> {"result": {"messages": [{"role": "user", "content": {"type": "text",
       "text": "USER Cite cells [0] from notebook default, ..."}}]}}
POST /mcp  resources/read  {"uri": "capabilities://"}
  -> {"result": {"contents": [{"uri": "capabilities://", "mimeType": "text/plain", "text": "{...}"}]}}
```

## Tests

`tests/test_prompts.py` loses its `pytestmark` skipif — the only mode-gated skip in the suite, whose reason read *"Prompt feature is only available in MCP_SERVER mode now."* — and moves from `mcp_client` to `mcp_client_parametrized`, so the existing `test_jupyter_cite` now runs against both deployments unchanged. A `prompts/list` test is added beside it.

`tests/test_resources_both_modes.py` is new: both transports, the same assertions. It covers the three templates, `resources/list`, reading a notebook back as nbformat JSON, a cell listing its outputs by URI rather than inlining them, reading one of those outputs, and an unopened notebook coming back as a protocol error rather than an empty document. It creates its own notebook for the cell case, because the ones in `dev/content/` predate nbformat 4.5 and have no cell ids to address. `tests/test_notebook_resources.py` stays as the unit test of `resources.py`.

Against the unfixed tree, `TEST_JUPYTER_SERVER=true`:

```
FAILED tests/test_prompts.py::test_the_prompt_is_listed[jupyter_extension]
  AssertionError: assert 'jupyter_cite' in set()
FAILED tests/test_prompts.py::test_jupyter_cite[jupyter_extension]
  MCPError: Method not found: prompts/get
FAILED tests/test_resources_both_modes.py::test_the_three_notebook_templates_are_offered[jupyter_extension]
  MCPError: Method not found: resources/templates/list
FAILED tests/test_resources_both_modes.py::test_a_concrete_resource_is_listed[jupyter_extension]
  AssertionError: assert 'capabilities://' in set()
FAILED tests/test_resources_both_modes.py::test_a_notebook_reads_back_as_nbformat_json[jupyter_extension]
  MCPError: Method not found: resources/read
FAILED tests/test_resources_both_modes.py::test_a_cell_lists_its_outputs_by_uri_rather_than_inlining_them[jupyter_extension]
  MCPError: Method not found: resources/read
FAILED tests/test_resources_both_modes.py::test_a_notebook_nobody_opened_is_refused_rather_than_answered[jupyter_extension]
  MCPError: Method not found: resources/read
7 failed in 4.01s
```

With the fix, both modes:

```
14 passed in 26.74s
```

Full suite:

- `make test-extensions` — 67 passed
- `make test-mcp-server` — 1 failed, 1089 passed, 8 skipped, 4 errors
- `make test-jupyter-server` — 1 failed, 1075 passed, 22 skipped, 4 errors

The one failure and the four errors are `tests/test_use_notebook_ui_open.py` and `tests/test_use_notebook_split_servers.py::test_split_opens_ui_on_document_server`; they fail the same way on `main` at `3aa8cfd` with none of this applied, and touch nothing here.

`ruff check` reports nothing new on the touched files.
