### PR TITLE
fix(cell-source): split a cell's source on newlines only

### DIFF
--- a/jupyter_mcp_server/utils.py
+++ b/jupyter_mcp_server/utils.py
@@ -621,17 +621,17 @@ def normalize_cell_source(source: Any) -> list[str]:
     if isinstance(source, list):
         return [str(line) for line in source]
 
-    # If it's a string, split by newlines
-    if isinstance(source, str):
-        # Split by newlines but preserve the newline characters except for the last line
-        lines = source.splitlines(keepends=True)
-        # Remove trailing newline from the last line if present
-        if lines and lines[-1].endswith("\n"):
-            lines[-1] = lines[-1][:-1]
-        return lines
+    if not isinstance(source, str):
+        source = str(source)
 
-    # Fallback: convert to string and split
-    return str(source).splitlines(keepends=True)
+    # Split on "\n" and nothing else. str.splitlines also breaks on \v, \f,
+    # \x1c-\x1e, \x85, \u2028 and \u2029, none of which ends a line in a
+    # notebook, so a cell holding one came back with a line break in it.
+    lines = source.split("\n")
+    # A trailing "\n" ends the last line, it does not start a new one.
+    if lines[-1] == "":
+        lines.pop()
+    return [line + "\n" for line in lines[:-1]] + lines[-1:]
 
 
 def format_TSV(headers: list[str], rows: list[list[str]]) -> str:

--- a/tests/test_cell_source_line_splitting.py
+++ b/tests/test_cell_source_line_splitting.py
@@ -1,0 +1,68 @@
+# Copyright (c) 2024- Datalayer, Inc.
+#
+# BSD 3-Clause License
+
+"""A cell's source is line-broken by ``\\n`` and by nothing else.
+
+``normalize_cell_source`` used ``str.splitlines``, which also breaks on ``\\v``,
+``\\f``, ``\\x1c``, ``\\x1d``, ``\\x1e``, ``\\x85``, ``\\u2028`` and ``\\u2029``.
+None of those ends a line in nbformat, so a cell holding one read back with a
+line break the notebook does not contain: ``read_cell`` and ``read_notebook``
+join the pieces with ``\\n`` on the way out, and ``get_overview`` counted the
+pieces and reported hidden lines for a one-line cell.
+
+Launch the tests:
+```
+$ pytest tests/test_cell_source_line_splitting.py -v
+```
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from jupyter_mcp_server.models import Cell
+from jupyter_mcp_server.utils import normalize_cell_source
+
+NOT_LINE_BREAKS = [
+    "\v",
+    "\f",
+    "\x1c",
+    "\x1d",
+    "\x1e",
+    "\x85",
+    "\u2028",
+    "\u2029",
+]
+
+
+@pytest.mark.parametrize("character", NOT_LINE_BREAKS)
+def test_a_cell_holding_one_stays_one_line(character):
+    source = f"text = 'a{character}b'"
+    assert normalize_cell_source(source) == [source]
+    cell = Cell(index=0, cell_type="code", source=source, id="c1")
+    assert cell.get_source("readable") == source
+    assert cell.get_overview() == source
+
+
+@pytest.mark.parametrize("character", NOT_LINE_BREAKS)
+def test_it_still_splits_on_the_newlines_around_it(character):
+    cell = Cell(index=0, cell_type="code", source=f"x{character}y\nz", id="c1")
+    assert cell.get_source("raw") == [f"x{character}y\n", "z"]
+    assert cell.get_overview() == f"x{character}y...(1 lines hidden)"
+
+
+@pytest.mark.parametrize(
+    ("source", "lines"),
+    [
+        ("", []),
+        ("one", ["one"]),
+        ("one\ntwo", ["one\n", "two"]),
+        ("one\ntwo\n", ["one\n", "two"]),
+        ("one\n\ntwo", ["one\n", "\n", "two"]),
+        ("\n", [""]),
+        (["one\n", "two"], ["one\n", "two"]),
+    ],
+)
+def test_newline_splitting_is_unchanged(source, lines):
+    assert normalize_cell_source(source) == lines


### PR DESCRIPTION
Fixes #436.

`normalize_cell_source` used `str.splitlines`, which also breaks on `\v`, `\f`, `\x1c`, `\x1d`, `\x1e`, `\x85`, `\u2028` and `\u2029`. Those don't end a line in a notebook, so `read_cell` and `read_notebook` joined the pieces back with `\n` and handed back source carrying a line break the cell doesn't have. `get_overview` counted the same pieces, so a one line cell reported a hidden line.

Split on `\n` and put the endings back. Everything else stays as it was, including the trim of the last line's trailing newline.

One thing changed past the split: the non-str fallback at the bottom now goes through the same path, so it trims that last newline the way the str branch always did. That read like an oversight rather than a difference anyone wanted, but say the word and I'll leave it alone.

Added `tests/test_cell_source_line_splitting.py`. The first two cases fail on main, the third pins the ordinary newline behaviour so the trim doesn't drift.
