### PR TITLE
fix(use_notebook): bind the kernel_id passed in MCP_SERVER mode

### DIFF
--- a/docs/sourcey/mcp.json
+++ b/docs/sourcey/mcp.json
@@ -1679,7 +1679,7 @@
           },
           "kernel_id": {
             "default": null,
-            "description": "Specific kernel ID to use (will create new if skipped)",
+            "description": "Id of an existing kernel (or sandbox, for a non-Jupyter sandbox variant) to attach the notebook to. A new one is created if skipped.",
             "title": "Kernel Id",
             "type": "string"
           }

--- a/docs/sourcey/tools/use_notebook.md
+++ b/docs/sourcey/tools/use_notebook.md
@@ -19,7 +19,7 @@ Reactivate previously activated notebook using same notebook_name and notebook_p
 | `notebook_name` | string | yes | — | Unique identifier for the notebook |
 | `notebook_path` | string | yes | — | Path to the notebook file, relative to the Jupyter server root (e.g. 'notebook.ipynb') |
 | `mode` | `connect` · `create` | no | `"connect"` | Notebook operation mode: 'connect' to connect to existing and activate it, 'create' to create new and activate it |
-| `kernel_id` | string | no | `null` | Specific kernel ID to use (will create new if skipped) |
+| `kernel_id` | string | no | `null` | Id of an existing kernel (or sandbox, for a non-Jupyter sandbox variant) to attach the notebook to. A new one is created if skipped. |
 
 ## Output
 

--- a/jupyter_mcp_server/server.py
+++ b/jupyter_mcp_server/server.py
@@ -796,7 +796,11 @@ async def use_notebook(
         ),
     ] = "connect",
     kernel_id: Annotated[
-        str, Field(description="Specific kernel ID to use (will create new if skipped)")
+        str,
+        Field(
+            description="Id of an existing kernel (or sandbox, for a non-Jupyter sandbox variant)"
+            " to attach the notebook to. A new one is created if skipped."
+        ),
     ] = None,
 ) -> ToolAnswer:
     """Use a notebook and activate it for following cell operations.

--- a/jupyter_mcp_server/tools/use_notebook_tool.py
+++ b/jupyter_mcp_server/tools/use_notebook_tool.py
@@ -410,6 +410,14 @@ class UseNotebookTool(BaseTool):
             # # Create/connect to kernel based on mode
             if mode == ServerMode.MCP_SERVER and sandbox_server_client is not None:
                 if kernel_id is not None:
+                    if config.uses_sandbox_variant():
+                        # The extension builds the sandbox and never sees the
+                        # id; attaching to a Jupyter kernel is a jupyter-server
+                        # variant thing.
+                        return (
+                            f"kernel_id only applies to the 'jupyter-server' sandbox variant;"
+                            f" the configured variant is '{config.sandbox_variant}'."
+                        )
                     kernels = sandbox_server_client.kernels.list_kernels()
                     kernel_exists = any(kernel.id == kernel_id for kernel in kernels)
                     if not kernel_exists:
@@ -430,17 +438,19 @@ class UseNotebookTool(BaseTool):
                 # through whichever sandbox is configured — so the variant is
                 # honoured rather than assumed.
                 #
-                # A `kernel_id` given here is only checked for existence: it is
-                # not carried to that first execution, which builds a kernel
-                # from the configuration. Reusing a particular one means naming
-                # it at execution time, or setting `code_sandbox_id`.
-                if config.start_new_code_sandbox:
+                # A `kernel_id` names a kernel that already exists (checked
+                # above), so attaching to it starts nothing and is done right
+                # away — the lazy path would otherwise build a fresh kernel
+                # from the configuration and drop the id (#425).
+                if kernel_id is not None or config.start_new_code_sandbox:
                     # The operator asked for a sandbox up front, so start one.
                     # Through the shared factory, which consults the installed
                     # extensions first and so honours `--sandbox-variant`.
                     from jupyter_mcp_server.utils import create_code_sandbox
 
-                    kernel = create_code_sandbox(config, logger, path=notebook_path)
+                    kernel = create_code_sandbox(
+                        config, logger, path=notebook_path, kernel_id=kernel_id
+                    )
                     info_list.append(f"[INFO] Connected to kernel '{kernel.id}'.")
                 else:
                     kernel = None

--- a/jupyter_mcp_server/tools/use_notebook_tool.py
+++ b/jupyter_mcp_server/tools/use_notebook_tool.py
@@ -443,7 +443,7 @@ class UseNotebookTool(BaseTool):
                     from jupyter_mcp_server.utils import create_code_sandbox
 
                     kernel = create_code_sandbox(
-                        config, logger, path=notebook_path, kernel_id=kernel_id
+                        config, logger, path=notebook_path, code_sandbox_id=kernel_id
                     )
                     info_list.append(f"[INFO] Connected to kernel '{kernel.id}'.")
                 else:

--- a/jupyter_mcp_server/tools/use_notebook_tool.py
+++ b/jupyter_mcp_server/tools/use_notebook_tool.py
@@ -409,15 +409,9 @@ class UseNotebookTool(BaseTool):
 
             # # Create/connect to kernel based on mode
             if mode == ServerMode.MCP_SERVER and sandbox_server_client is not None:
-                if kernel_id is not None:
-                    if config.uses_sandbox_variant():
-                        # The extension builds the sandbox and never sees the
-                        # id; attaching to a Jupyter kernel is a jupyter-server
-                        # variant thing.
-                        return (
-                            f"kernel_id only applies to the 'jupyter-server' sandbox variant;"
-                            f" the configured variant is '{config.sandbox_variant}'."
-                        )
+                # The Jupyter kernel list can only vouch for a Jupyter kernel;
+                # another variant's sandbox is resolved by that variant.
+                if kernel_id is not None and not config.uses_sandbox_variant():
                     kernels = sandbox_server_client.kernels.list_kernels()
                     kernel_exists = any(kernel.id == kernel_id for kernel in kernels)
                     if not kernel_exists:
@@ -438,10 +432,10 @@ class UseNotebookTool(BaseTool):
                 # through whichever sandbox is configured — so the variant is
                 # honoured rather than assumed.
                 #
-                # A `kernel_id` names a kernel that already exists (checked
-                # above), so attaching to it starts nothing and is done right
-                # away — the lazy path would otherwise build a fresh kernel
-                # from the configuration and drop the id (#425).
+                # A `kernel_id` names an execution backend that already exists,
+                # so attaching to it starts nothing and is done right away —
+                # the lazy path would otherwise build a fresh one from the
+                # configuration and drop the id (#425).
                 if kernel_id is not None or config.start_new_code_sandbox:
                     # The operator asked for a sandbox up front, so start one.
                     # Through the shared factory, which consults the installed

--- a/jupyter_mcp_server/tools/use_notebook_tool.py
+++ b/jupyter_mcp_server/tools/use_notebook_tool.py
@@ -432,10 +432,8 @@ class UseNotebookTool(BaseTool):
                 # through whichever sandbox is configured — so the variant is
                 # honoured rather than assumed.
                 #
-                # A `kernel_id` names an execution backend that already exists,
-                # so attaching to it starts nothing and is done right away —
-                # the lazy path would otherwise build a fresh one from the
-                # configuration and drop the id (#425).
+                # A `kernel_id` names a backend that already exists, so attaching
+                # to it starts nothing and is done right away (#425).
                 if kernel_id is not None or config.start_new_code_sandbox:
                     # The operator asked for a sandbox up front, so start one.
                     # Through the shared factory, which consults the installed

--- a/jupyter_mcp_server/utils.py
+++ b/jupyter_mcp_server/utils.py
@@ -665,7 +665,9 @@ def format_TSV(headers: list[str], rows: list[list[str]]) -> str:
 ###############################################################################
 
 
-def create_code_sandbox(config, logger, path: str | None = None) -> CodeSandboxClient:
+def create_code_sandbox(
+    config, logger, path: str | None = None, kernel_id: str | None = None
+) -> CodeSandboxClient:
     """Create a new code sandbox using current configuration.
 
     Creation is resolved in this order:
@@ -682,6 +684,9 @@ def create_code_sandbox(config, logger, path: str | None = None) -> CodeSandboxC
     ``path`` is the root-relative path of the notebook the sandbox belongs to.
     Jupyter Server derives the kernel's working directory from it, so relative
     file access inside a notebook resolves against the notebook's own directory.
+
+    ``kernel_id`` attaches to that existing kernel instead of starting one; it
+    falls back to the process-wide ``code_sandbox_id`` setting.
     """
     from jupyter_mcp_server.extensions import get_extension_manager
     from jupyter_mcp_server.sandbox_client import create_jupyter_sandbox_client
@@ -700,7 +705,7 @@ def create_code_sandbox(config, logger, path: str | None = None) -> CodeSandboxC
         code_sandbox = create_jupyter_sandbox_client(
             server_url=config.code_sandbox_url,
             token=None if auth_headers else config.code_sandbox_token,
-            kernel_id=config.code_sandbox_id,
+            kernel_id=kernel_id or config.code_sandbox_id,
             path=path,
             timeout=getattr(config, "execution_timeout", None),
             reconnect_interval=getattr(config, "reconnect_interval", 0) or 0,

--- a/jupyter_mcp_server/utils.py
+++ b/jupyter_mcp_server/utils.py
@@ -685,11 +685,17 @@ def create_code_sandbox(
     Jupyter Server derives the kernel's working directory from it, so relative
     file access inside a notebook resolves against the notebook's own directory.
 
-    ``kernel_id`` attaches to that existing kernel instead of starting one; it
-    falls back to the process-wide ``code_sandbox_id`` setting.
+    ``kernel_id`` attaches to that existing execution backend — a Jupyter kernel,
+    or a sandbox for another variant — instead of starting one. It travels as
+    ``code_sandbox_id``, the configuration field the extensions already read, so
+    every variant sees it without a change to the extension hook. It falls back
+    to the process-wide ``code_sandbox_id`` setting.
     """
     from jupyter_mcp_server.extensions import get_extension_manager
     from jupyter_mcp_server.sandbox_client import create_jupyter_sandbox_client
+
+    if kernel_id:
+        config = config.model_copy(update={"code_sandbox_id": kernel_id})
 
     extension_code_sandbox = get_extension_manager().create_code_sandbox(config, logger)
     if extension_code_sandbox is not None:
@@ -705,7 +711,7 @@ def create_code_sandbox(
         code_sandbox = create_jupyter_sandbox_client(
             server_url=config.code_sandbox_url,
             token=None if auth_headers else config.code_sandbox_token,
-            kernel_id=kernel_id or config.code_sandbox_id,
+            kernel_id=config.code_sandbox_id,
             path=path,
             timeout=getattr(config, "execution_timeout", None),
             reconnect_interval=getattr(config, "reconnect_interval", 0) or 0,

--- a/jupyter_mcp_server/utils.py
+++ b/jupyter_mcp_server/utils.py
@@ -666,7 +666,7 @@ def format_TSV(headers: list[str], rows: list[list[str]]) -> str:
 
 
 def create_code_sandbox(
-    config, logger, path: str | None = None, kernel_id: str | None = None
+    config, logger, path: str | None = None, code_sandbox_id: str | None = None
 ) -> CodeSandboxClient:
     """Create a new code sandbox using current configuration.
 
@@ -685,17 +685,15 @@ def create_code_sandbox(
     Jupyter Server derives the kernel's working directory from it, so relative
     file access inside a notebook resolves against the notebook's own directory.
 
-    ``kernel_id`` attaches to that existing execution backend — a Jupyter kernel,
-    or a sandbox for another variant — instead of starting one. It travels as
-    ``code_sandbox_id``, the configuration field the extensions already read, so
-    every variant sees it without a change to the extension hook. It falls back
-    to the process-wide ``code_sandbox_id`` setting.
+    ``code_sandbox_id`` attaches to that existing backend (a Jupyter kernel, or a
+    sandbox for another variant) instead of starting one. It overrides the
+    configured ``code_sandbox_id`` so extensions see it too.
     """
     from jupyter_mcp_server.extensions import get_extension_manager
     from jupyter_mcp_server.sandbox_client import create_jupyter_sandbox_client
 
-    if kernel_id:
-        config = config.model_copy(update={"code_sandbox_id": kernel_id})
+    if code_sandbox_id:
+        config = config.model_copy(update={"code_sandbox_id": code_sandbox_id})
 
     extension_code_sandbox = get_extension_manager().create_code_sandbox(config, logger)
     if extension_code_sandbox is not None:

--- a/tests/test_use_notebook_kernel_id.py
+++ b/tests/test_use_notebook_kernel_id.py
@@ -160,7 +160,7 @@ def test_create_code_sandbox__leaves_the_process_config_untouched(recorded_sandb
 
     config = set_config(code_sandbox_url=SANDBOX_URL)
 
-    utils.create_code_sandbox(config, logging.getLogger("test"), kernel_id=EXISTING_KERNEL_ID)
+    utils.create_code_sandbox(config, logging.getLogger("test"), code_sandbox_id=EXISTING_KERNEL_ID)
 
     assert recorded_sandbox_kwargs["kernel_id"] == EXISTING_KERNEL_ID
     assert get_config().code_sandbox_id is None

--- a/tests/test_use_notebook_kernel_id.py
+++ b/tests/test_use_notebook_kernel_id.py
@@ -22,25 +22,12 @@ SANDBOX_URL = "http://sandbox.example"
 EXISTING_KERNEL_ID = "afd51e4a-existing"
 
 
-class _FakeContents:
-    @staticmethod
-    def list_directory(path):
-        return [SimpleNamespace(name="nb.ipynb")]
-
-    @staticmethod
-    def get(path):
-        return {"content": {"cells": []}}
-
-
-class _FakeKernels:
-    @staticmethod
-    def list_kernels():
-        return [SimpleNamespace(id=EXISTING_KERNEL_ID)]
-
-
 class FakeServerClient:
-    contents = _FakeContents
-    kernels = _FakeKernels
+    contents = SimpleNamespace(
+        list_directory=lambda path: [SimpleNamespace(name="nb.ipynb")],
+        get=lambda path: {"content": {"cells": []}},
+    )
+    kernels = SimpleNamespace(list_kernels=lambda: [SimpleNamespace(id=EXISTING_KERNEL_ID)])
 
     def get_status(self):
         return {}
@@ -150,17 +137,3 @@ async def test_use_notebook__hands_the_id_to_the_extension_for_another_variant(
     assert seen_config["code_sandbox_id"] == EXISTING_KERNEL_ID
     assert notebook_manager.get_code_sandbox_id("demo") == EXISTING_KERNEL_ID
     assert recorded_sandbox_kwargs == {}, "the Jupyter client must not be built"
-
-
-def test_create_code_sandbox__leaves_the_process_config_untouched(recorded_sandbox_kwargs):
-    import logging
-
-    from jupyter_mcp_server import utils
-    from jupyter_mcp_server.config import get_config
-
-    config = set_config(code_sandbox_url=SANDBOX_URL)
-
-    utils.create_code_sandbox(config, logging.getLogger("test"), code_sandbox_id=EXISTING_KERNEL_ID)
-
-    assert recorded_sandbox_kwargs["kernel_id"] == EXISTING_KERNEL_ID
-    assert get_config().code_sandbox_id is None

--- a/tests/test_use_notebook_kernel_id.py
+++ b/tests/test_use_notebook_kernel_id.py
@@ -128,10 +128,39 @@ async def test_use_notebook__rejects_an_unknown_kernel_id(recorded_sandbox_kwarg
 
 
 @pytest.mark.asyncio
-async def test_use_notebook__rejects_kernel_id_for_a_non_jupyter_variant(recorded_sandbox_kwargs):
+async def test_use_notebook__hands_the_id_to_the_extension_for_another_variant(
+    monkeypatch, recorded_sandbox_kwargs
+):
+    """The extension reads `code_sandbox_id`; a per-call id must arrive there."""
     set_config(code_sandbox_url=SANDBOX_URL, sandbox_variant="datalayer")
+    seen_config = {}
 
-    reply = await _use_notebook(NotebookManager(), EXISTING_KERNEL_ID)
+    def extension_sandbox(config, logger):
+        seen_config["code_sandbox_id"] = config.code_sandbox_id
+        return SimpleNamespace(id=config.code_sandbox_id, is_alive=lambda: True)
 
-    assert "jupyter-server" in reply
-    assert recorded_sandbox_kwargs == {}
+    monkeypatch.setattr(
+        "jupyter_mcp_server.extensions.get_extension_manager",
+        lambda: SimpleNamespace(create_code_sandbox=extension_sandbox),
+    )
+    notebook_manager = NotebookManager()
+
+    await _use_notebook(notebook_manager, EXISTING_KERNEL_ID)
+
+    assert seen_config["code_sandbox_id"] == EXISTING_KERNEL_ID
+    assert notebook_manager.get_code_sandbox_id("demo") == EXISTING_KERNEL_ID
+    assert recorded_sandbox_kwargs == {}, "the Jupyter client must not be built"
+
+
+def test_create_code_sandbox__leaves_the_process_config_untouched(recorded_sandbox_kwargs):
+    import logging
+
+    from jupyter_mcp_server import utils
+    from jupyter_mcp_server.config import get_config
+
+    config = set_config(code_sandbox_url=SANDBOX_URL)
+
+    utils.create_code_sandbox(config, logging.getLogger("test"), kernel_id=EXISTING_KERNEL_ID)
+
+    assert recorded_sandbox_kwargs["kernel_id"] == EXISTING_KERNEL_ID
+    assert get_config().code_sandbox_id is None

--- a/tests/test_use_notebook_kernel_id.py
+++ b/tests/test_use_notebook_kernel_id.py
@@ -1,0 +1,137 @@
+# Copyright (c) 2024- Datalayer, Inc.
+#
+# BSD 3-Clause License
+
+"""``use_notebook(kernel_id=...)`` in MCP_SERVER mode binds that kernel (#425).
+
+Since #372 the id was only checked for existence and then dropped: execution
+went to a kernel built from the configuration. A caller attaching the MCP to
+the kernel a human already has open never shared its variables.
+"""
+
+from types import SimpleNamespace
+
+import pytest
+
+from jupyter_mcp_server.config import reset_config, set_config
+from jupyter_mcp_server.notebook_manager import NotebookManager
+from jupyter_mcp_server.tools._base import ServerMode
+from jupyter_mcp_server.tools.use_notebook_tool import UseNotebookTool
+
+SANDBOX_URL = "http://sandbox.example"
+EXISTING_KERNEL_ID = "afd51e4a-existing"
+
+
+class _FakeContents:
+    @staticmethod
+    def list_directory(path):
+        return [SimpleNamespace(name="nb.ipynb")]
+
+    @staticmethod
+    def get(path):
+        return {"content": {"cells": []}}
+
+
+class _FakeKernels:
+    @staticmethod
+    def list_kernels():
+        return [SimpleNamespace(id=EXISTING_KERNEL_ID)]
+
+
+class FakeServerClient:
+    contents = _FakeContents
+    kernels = _FakeKernels
+
+    def get_status(self):
+        return {}
+
+
+@pytest.fixture
+def recorded_sandbox_kwargs(monkeypatch):
+    seen = {}
+
+    def fake_client(**kwargs):
+        seen.update(kwargs)
+        return SimpleNamespace(id=kwargs["kernel_id"], is_alive=lambda: True)
+
+    monkeypatch.setattr(
+        "jupyter_mcp_server.sandbox_client.create_jupyter_sandbox_client", fake_client
+    )
+    # add_notebook starts a watcher that would make a real HTTP request.
+    monkeypatch.setattr("jupyter_mcp_server.watchers.watchers.watch", lambda name, manager: False)
+    monkeypatch.setattr(
+        "jupyter_mcp_server.extensions.get_extension_manager",
+        lambda: SimpleNamespace(create_code_sandbox=lambda config, logger: None),
+    )
+    monkeypatch.setattr(
+        "jupyter_mcp_server.server_context.ServerContext.get_instance",
+        staticmethod(
+            lambda: SimpleNamespace(
+                document_server_client=FakeServerClient(),
+                document_auth_headers={},
+                code_sandbox_auth_headers={},
+            )
+        ),
+    )
+    reset_config()
+    yield seen
+    reset_config()
+
+
+async def _use_notebook(notebook_manager, kernel_id):
+    return await UseNotebookTool().execute(
+        mode=ServerMode.MCP_SERVER,
+        sandbox_server_client=FakeServerClient(),
+        notebook_manager=notebook_manager,
+        notebook_name="demo",
+        notebook_path="nb.ipynb",
+        use_mode="connect",
+        code_sandbox_url=SANDBOX_URL,
+        kernel_id=kernel_id,
+    )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("start_new_code_sandbox", [True, False])
+async def test_use_notebook__binds_the_requested_kernel(
+    recorded_sandbox_kwargs, start_new_code_sandbox
+):
+    set_config(code_sandbox_url=SANDBOX_URL, start_new_code_sandbox=start_new_code_sandbox)
+    notebook_manager = NotebookManager()
+
+    reply = await _use_notebook(notebook_manager, EXISTING_KERNEL_ID)
+
+    assert recorded_sandbox_kwargs["kernel_id"] == EXISTING_KERNEL_ID
+    assert notebook_manager.get_code_sandbox_id("demo") == EXISTING_KERNEL_ID
+    assert f"Connected to kernel '{EXISTING_KERNEL_ID}'" in reply
+
+
+@pytest.mark.asyncio
+async def test_use_notebook__without_kernel_id_stays_lazy(recorded_sandbox_kwargs):
+    set_config(code_sandbox_url=SANDBOX_URL, start_new_code_sandbox=False)
+    notebook_manager = NotebookManager()
+
+    await _use_notebook(notebook_manager, None)
+
+    assert recorded_sandbox_kwargs == {}
+    assert notebook_manager.get_code_sandbox("demo") is None
+
+
+@pytest.mark.asyncio
+async def test_use_notebook__rejects_an_unknown_kernel_id(recorded_sandbox_kwargs):
+    set_config(code_sandbox_url=SANDBOX_URL)
+
+    reply = await _use_notebook(NotebookManager(), "no-such-kernel")
+
+    assert "not found" in reply
+    assert recorded_sandbox_kwargs == {}
+
+
+@pytest.mark.asyncio
+async def test_use_notebook__rejects_kernel_id_for_a_non_jupyter_variant(recorded_sandbox_kwargs):
+    set_config(code_sandbox_url=SANDBOX_URL, sandbox_variant="datalayer")
+
+    reply = await _use_notebook(NotebookManager(), EXISTING_KERNEL_ID)
+
+    assert "jupyter-server" in reply
+    assert recorded_sandbox_kwargs == {}


### PR DESCRIPTION
Fixes #425

## Problem

In MCP_SERVER mode, `use_notebook(kernel_id=X)` checked that X exists, then ignored it. Execution ran on a new kernel built from the configuration. JUPYTER_SERVER mode already binds X. Regressed in #372 (1.3.7).

## Fix

- `use_notebook` with a `kernel_id` attaches to that backend right away. The backend already exists, so nothing is started. #372's goals hold: no runtime is spent on open, and the sandbox variant is honoured.
- `create_code_sandbox` gets a per-call `code_sandbox_id`. It overrides `config.code_sandbox_id`, the field the sandboxes extension already reads, so every sandbox variant sees the id. The extension hook is unchanged.
- The Jupyter kernel-list existence check runs only for the `jupyter-server` variant.
- Without `kernel_id`, behaviour is unchanged (eager or lazy from config).
- Tool description now says "kernel (or sandbox)".

## Tests

`tests/test_use_notebook_kernel_id.py`, 5 tests:

- requested kernel is bound, eager and lazy config
- no `kernel_id` keeps the lazy path
- unknown `kernel_id` is rejected before any sandbox is built
- for another variant, the id reaches the extension hook and no Jupyter client is built

Related suites (`test_code_sandbox_notebook_cwd`, `test_use_notebook_already_connected`, `test_use_notebook_reconnect_interval`, `test_ensure_code_sandbox_alive_server_liveness`, `test_cli_typer_config`) pass. Ruff clean on the touched code.

## Not in this PR

Pre-existing, also reachable today with `CODE_SANDBOX_ID`:

- `restart_notebook` on an attached kernel reconnects instead of restarting, but reports success. Fix: REST `POST /api/kernels/{id}/restart`.
- With `kernel.auto-restart` on, a dead attached kernel is replaced from the configuration without telling the caller.
- The sandboxes extension forwards `code_sandbox_id` only for `jupyter-server`, `google-colab` and `kaggle`. The generic variants (`datalayer`, `docker`, `modal`, ...) do not apply it yet.
