### PR TITLE
fix(revalidation): keep the declared envelope in a not-modified reply

### DIFF
--- a/docs/docs/architecture/caching/index.mdx
+++ b/docs/docs/architecture/caching/index.mdx
@@ -53,6 +53,12 @@ It says `notModified` rather than simply being empty, because a client that
 read an empty result as an empty *notebook* would show somebody no cells at
 all.
 
+The reply still carries `"structuredContent": {"kind": "notebook.read"}`. Both
+tools advertise an output schema, and a client validates what comes back
+against it, so an answer with no structured content at all fails there rather
+than being read as *not modified*. Only the payload is left out — which is
+where the saving is.
+
 :::caution This saves bandwidth, not work
 
 The tool still runs. The version is computed from what it answered, so there

--- a/jupyter_mcp_server/revalidation.py
+++ b/jupyter_mcp_server/revalidation.py
@@ -64,16 +64,32 @@ def answered_etag(result: Any) -> str:
     return str(_cache_block(getattr(result, "meta", None)).get("etag") or "")
 
 
-def not_modified(block: dict[str, Any]) -> CallToolResult:
+def answered_kind(result: Any) -> str:
+    """What kind of answer a result is, from its structured content."""
+    structured = getattr(result, "structured_content", None)
+    if not isinstance(structured, dict):
+        return ""
+    return str(structured.get("kind") or "")
+
+
+def not_modified(block: dict[str, Any], kind: str = "") -> CallToolResult:
     """The answer to a client that already has this result.
 
     Carries the hints again, so holding it for another window costs nothing,
     and says plainly that there is no payload rather than answering an empty
     one.
+
+    It keeps the answer's `kind` for a harder reason than tidiness. Both
+    revalidated tools declare an output schema, and a client validates every
+    non-error result against the one it was given: `ClientSession` raises
+    `RuntimeError` when a tool that declares a schema comes back with no
+    structured content at all. An empty envelope would therefore turn the
+    cheap question into a failed call. The payload stays omitted — that is
+    where the saving is, and `kind` is the only field either schema requires.
     """
     return CallToolResult(
         content=[],
-        structured_content=None,
+        structured_content={"kind": kind} if kind else None,
         meta={CACHE_META_KEY: {**block, NOT_MODIFIED_KEY: True}},
     )
 
@@ -109,7 +125,7 @@ class RevalidationExtension(Extension):
             # has never seen.
             return result
         logger.debug("Answering not-modified for %s", getattr(params, "name", ""))
-        return not_modified(block)
+        return not_modified(block, answered_kind(result))
 
 
 def revalidation_extension() -> RevalidationExtension:

--- a/tests/test_revalidation.py
+++ b/tests/test_revalidation.py
@@ -20,16 +20,21 @@ $ pytest tests/test_revalidation.py -v
 
 from __future__ import annotations
 
+import anyio
 import pytest
+from mcp import ClientSession
+from mcp.server import MCPServer
+from mcp.shared.memory import create_client_server_memory_streams
 from mcp.types import CallToolRequestParams, CallToolResult, TextContent
 
-from jupyter_mcp_server.results import CACHE_META_KEY, answer, etag_for
+from jupyter_mcp_server.results import CACHE_META_KEY, ToolAnswer, answer, etag_for, structured
 from jupyter_mcp_server.revalidation import (
     NOT_MODIFIED_KEY,
     REVALIDATION_EXTENSION,
     RevalidationExtension,
     answered_etag,
     requested_etag,
+    revalidation_extension,
 )
 
 
@@ -86,7 +91,7 @@ class TestRevalidating:
         block = served_back.meta[CACHE_META_KEY]
         assert block[NOT_MODIFIED_KEY] is True
         assert served_back.content == []
-        assert served_back.structured_content is None
+        assert served_back.structured_content == {"kind": "notebook.read"}
 
     async def test_not_modified_says_so_rather_than_being_empty(self, extension):
         """A client that read an empty result as an empty notebook would show
@@ -156,9 +161,60 @@ class TestRevalidating:
         assert ran == [1]
 
 
+    async def test_not_modified_keeps_the_envelope_the_schema_declares(self, extension):
+        """`read_notebook` and `read_cell` advertise an output schema, and a
+        client validates every non-error result against it — an answer with no
+        structured content at all raises there. So the reply keeps `kind`, the
+        only field the schema requires, and omits the payload."""
+        result = read({"cells": [1, 2]}, kind="cell.read")
+        served_back = await served(extension, holding(answered_etag(result)), result)
+        assert served_back.structured_content == {"kind": "cell.read"}
+        assert "cells" not in served_back.structured_content
+
+
 def test_the_extension_identifier_is_one_constant():
     assert RevalidationExtension.identifier == REVALIDATION_EXTENSION
 
 
 def test_the_settings_name_the_field_a_client_reads():
     assert RevalidationExtension().settings()["notModifiedKey"] == NOT_MODIFIED_KEY
+
+
+@pytest.mark.asyncio
+async def test_a_client_can_revalidate_a_read_without_the_call_failing():
+    """The round trip the caching page documents, through a real client.
+
+    The tests above hand `intercept_tool_call` a stub and read the result
+    themselves, which is why the envelope going missing was invisible: the
+    schema a tool declares is only enforced on the client side, one layer
+    further out than any of them reach.
+    """
+    server = MCPServer("revalidation-round-trip", extensions=[revalidation_extension()])
+
+    @server.tool()
+    @structured("notebook.read", ttl_ms=5000, etag=True)
+    async def read_notebook() -> ToolAnswer:
+        """A read that stamps a version, as the real one does."""
+        return {"cells": [{"index": 0, "source": "1 + 1"}]}
+
+    async with create_client_server_memory_streams() as (client_streams, server_streams):
+        async with anyio.create_task_group() as group:
+
+            async def serve():
+                low = server._lowlevel_server
+                await low.run(*server_streams, low.create_initialization_options())
+
+            group.start_soon(serve)
+            async with ClientSession(*client_streams) as session:
+                await session.initialize()
+                first = await session.call_tool("read_notebook", {})
+                etag = first.meta[CACHE_META_KEY]["etag"]
+
+                again = await session.call_tool(
+                    "read_notebook", {}, meta={CACHE_META_KEY: {"etag": etag}}
+                )
+
+            assert again.meta[CACHE_META_KEY][NOT_MODIFIED_KEY] is True
+            assert again.structured_content == {"kind": "notebook.read"}
+            assert again.content == []
+            group.cancel_scope.cancel()


### PR DESCRIPTION
The ETag round trip documented in `docs/architecture/caching` raises on the official SDK client instead of saving anything. Send back a matching etag for `read_notebook` or `read_cell` and `ClientSession.call_tool` blows up with `RuntimeError: Tool read_notebook has an output schema but did not return structured content` — the revalidation extension answers with `structured_content=None`, and both tools declare an output schema, so `validate_tool_result` (`mcp/client/session.py:1145`) rejects the reply before the caller ever sees the `notModified` flag.

The history is easy to follow: `661a4e8` gave all the tools output schemas so a client would not have to call one to learn what comes back, and `0ba594d` added revalidation two days later, which quietly reintroduced the missing-schema case on that one branch.

The fix is one field — `not_modified()` now carries `{"kind": ...}`, taken from the result the tool actually produced. The payload is still omitted, which is where the saving is, and `kind` is the only property either schema requires (checked against the live schemas of both tools). Nothing upstream is going to cover this: python-sdk #3345/#3346 deal with the neighbouring `structuredContent: null` on the wire and say explicitly that servers on this SDK never emit that shape, since results serialise with `exclude_none=True`. "Schema declared, field omitted" is deliberate client behaviour.

I had to change one existing assertion — `test_revalidation.py` asserted `structured_content is None`, which reads more like a description of what the code happened to do than a contract; the "not modified rather than nothing" guarantee lives in the `notModified` key and is still asserted separately. The reason none of the existing tests caught this is worth noting: they call `intercept_tool_call` with a stub `call_next` and inspect the result themselves, and the schema is only enforced one layer further out, on the client. So the new test runs the round trip through a real `ClientSession` over in-memory streams — it fails on current `main` with exactly the `RuntimeError` above.

Full suite is green (1179 passed, 3 skipped), and ruff/mypy on the touched files show no new findings.
