### PR TITLE
feat(execute): run cells through the runtime's /execute route so outputs survive the worker

### DIFF
--- a/docs/docs/architecture/index.mdx
+++ b/docs/docs/architecture/index.mdx
@@ -202,6 +202,22 @@ document with `NbModelClient` (jupyter-nbmodel-client over Y.js), so cell edits
 land in the same document the user's JupyterLab is showing. Execution goes
 through a `CodeSandboxClient` built by `sandbox_client.py`.
 
+By default that client drives the kernel from this process and writes each
+output into the document as it arrives, so a cell's outputs stop if this
+process stops — a gateway rollout, an idle reap, a crash. Set
+`execute_via_http` (env `JUPYTER_MCP_EXECUTE_VIA_HTTP`) and, on the default
+`jupyter-server` variant, `execute_cell` instead **POSTs to the runtime's own
+`/api/kernels/{id}/execute` route** (jupyter-server-nbmodel) and polls the
+request it returns. The runtime runs the cell and writes the outputs into the
+collaborative document **server-side**, so a run — and its outputs — survive
+the loss of this process; what this process loses when it stops is only the
+ability to keep reporting progress. It is used only when the document and cell
+ids resolve (so the runtime knows where to write); otherwise, and for every
+non-`jupyter-server` variant, execution stays on the WebSocket path above.
+`execute_code`, which targets no cell, always uses the WebSocket path — the
+durability is a property of cell execution, where there is a document cell to
+write into.
+
 ### Backends (`jupyter_extension/backends/`)
 
 `Backend` is the abstract interface for notebook and kernel operations —

--- a/docs/sourcey/config-fields.json
+++ b/docs/sourcey/config-fields.json
@@ -139,6 +139,12 @@
    "type": "<class 'int'>",
    "default": 3600,
    "description": "Maximum allowed timeout in seconds for code execution."
+  },
+  {
+   "name": "execute_via_http",
+   "type": "<class 'bool'>",
+   "default": "PydanticUndefined",
+   "description": "In MCP_SERVER mode, run cell execution through the runtime's own HTTP /api/kernels/{id}/execute route instead of driving the kernel from this worker. The runtime then writes the outputs into the collaborative document server-side, so a run's outputs survive the loss of this worker. Only the default 'jupyter-server' variant has that route; other sandbox variants ignore the flag and keep the WebSocket path. Off by default; set JUPYTER_MCP_EXECUTE_VIA_HTTP."
   }
  ]
 }

--- a/docs/sourcey/configuration.md
+++ b/docs/sourcey/configuration.md
@@ -32,6 +32,7 @@ All runtime settings live on the `JupyterMCPConfig` pydantic model ([`jupyter_mc
 | `reconnect_interval` | int | `0` | Seconds to wait before reconnecting a dropped WebSocket connection to the kernel. 0 disables auto-reconnect. |
 | `execution_timeout` | int | `120` | Default timeout in seconds for code execution. |
 | `max_execution_timeout` | int | `3600` | Maximum allowed timeout in seconds for code execution. |
+| `execute_via_http` | bool | `"PydanticUndefined"` | In MCP_SERVER mode, run cell execution through the runtime's own HTTP /api/kernels/{id}/execute route instead of driving the kernel from this worker. The runtime then writes the outputs into the collaborative document server-side, so a run's outputs survive the loss of this worker. Only the default 'jupyter-server' variant has that route; other sandbox variants ignore the flag and keep the WebSocket path. Off by default; set JUPYTER_MCP_EXECUTE_VIA_HTTP. |
 
 ## Transports
 

--- a/docs/sourcey/mcp.json
+++ b/docs/sourcey/mcp.json
@@ -3,7 +3,7 @@
   "mcpVersion": "2025-11-25",
   "server": {
     "name": "Jupyter MCP Server",
-    "version": "2.1.10"
+    "version": "2.1.11"
   },
   "capabilities": {
     "experimental": {},

--- a/extensions/mcpb/manifest.json
+++ b/extensions/mcpb/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": "0.4",
   "name": "jupyter-mcp-server",
   "display_name": "Jupyter MCP Server",
-  "version": "2.1.10",
+  "version": "2.1.11",
   "description": "Connect AI agents to Jupyter Notebooks - execute code, manage notebooks, and interact with kernels in real-time",
   "long_description": "The Jupyter MCP Server enables AI agents like Claude to connect to and manage Jupyter Notebooks in real-time. It provides 14 tools to execute code, manage notebooks, read and write cells, and interact with Jupyter kernels through the standardized Model Context Protocol.\n\n**Requirements:** You need a running Jupyter server (JupyterLab or Jupyter Notebook) to connect to. Start one with:\n```\npip install jupyterlab\njupyter lab --port 8888 --IdentityProvider.token MY_TOKEN\n```",
   "author": {

--- a/extensions/mcpb/pyproject.toml
+++ b/extensions/mcpb/pyproject.toml
@@ -4,7 +4,7 @@
 
 [project]
 name = "jupyter-mcp-server-mcpb"
-version = "2.1.10"
+version = "2.1.11"
 description = "Jupyter MCP Server - MCPB bundle for one-click installation in Claude Desktop"
 requires-python = ">=3.10"
 dependencies = [

--- a/jupyter_mcp_server/__version__.py
+++ b/jupyter_mcp_server/__version__.py
@@ -4,4 +4,4 @@
 
 """Jupyter MCP Server."""
 
-__version__ = "2.1.10"
+__version__ = "2.1.11"

--- a/jupyter_mcp_server/config.py
+++ b/jupyter_mcp_server/config.py
@@ -153,7 +153,12 @@ class JupyterMCPConfig(BaseModel):
         default=3600, gt=0, description="Maximum allowed timeout in seconds for code execution."
     )
     execute_via_http: bool = Field(
-        default=False,
+        # Read from the environment by default so a deployment can turn it on
+        # with JUPYTER_MCP_EXECUTE_VIA_HTTP without threading a flag through
+        # every set_config caller; an explicit set_config(execute_via_http=...)
+        # still wins. Evaluated per-construction, so the env is read when the
+        # worker builds its config, not at import time.
+        default_factory=lambda: _get_env_bool("JUPYTER_MCP_EXECUTE_VIA_HTTP", False),
         description=(
             "In MCP_SERVER mode, run cell execution through the runtime's own "
             "HTTP /api/kernels/{id}/execute route instead of driving the kernel "
@@ -161,7 +166,7 @@ class JupyterMCPConfig(BaseModel):
             "collaborative document server-side, so a run's outputs survive the "
             "loss of this worker. Only the default 'jupyter-server' variant has "
             "that route; other sandbox variants ignore the flag and keep the "
-            "WebSocket path. Off by default."
+            "WebSocket path. Off by default; set JUPYTER_MCP_EXECUTE_VIA_HTTP."
         ),
     )
 

--- a/jupyter_mcp_server/config.py
+++ b/jupyter_mcp_server/config.py
@@ -152,6 +152,18 @@ class JupyterMCPConfig(BaseModel):
     max_execution_timeout: int = Field(
         default=3600, gt=0, description="Maximum allowed timeout in seconds for code execution."
     )
+    execute_via_http: bool = Field(
+        default=False,
+        description=(
+            "In MCP_SERVER mode, run cell execution through the runtime's own "
+            "HTTP /api/kernels/{id}/execute route instead of driving the kernel "
+            "from this worker. The runtime then writes the outputs into the "
+            "collaborative document server-side, so a run's outputs survive the "
+            "loss of this worker. Only the default 'jupyter-server' variant has "
+            "that route; other sandbox variants ignore the flag and keep the "
+            "WebSocket path. Off by default."
+        ),
+    )
 
     model_config = ConfigDict(validate_assignment=True, arbitrary_types_allowed=True)
 

--- a/jupyter_mcp_server/tools/execute_cell_tool.py
+++ b/jupyter_mcp_server/tools/execute_cell_tool.py
@@ -466,9 +466,13 @@ class ExecuteCellTool(BaseTool):
                 _config = get_config()
                 if _config.execute_via_http and not _config.uses_sandbox_variant():
                     http_cell_id = notebook[cell_index].get("id")
-                    http_document_id = document_id_from_ws_url(
-                        getattr(notebook, "_ws_url", "") or getattr(notebook, "path", "")
-                    )
+                    # Only a real websocket URL carries the RTC room id. The
+                    # notebook *path* must not be a fallback: parsing it would
+                    # make a bogus `json:notebook:<path>` room and misroute the
+                    # run to no document. No ws_url -> unresolved -> the guard
+                    # below keeps this on the WebSocket path.
+                    ws_url = getattr(notebook, "ws_url", None) or getattr(notebook, "_ws_url", None)
+                    http_document_id = document_id_from_ws_url(ws_url)
                     if http_cell_id and http_document_id:
                         from jupyter_mcp_server.server_context import (  # noqa: PLC0415
                             ServerContext,

--- a/jupyter_mcp_server/tools/execute_cell_tool.py
+++ b/jupyter_mcp_server/tools/execute_cell_tool.py
@@ -16,9 +16,11 @@ from jupyter_mcp_server.hooks import HookEvent, HookRegistry
 from jupyter_mcp_server.tools._base import BaseTool, ServerMode
 from jupyter_mcp_server.utils import (
     clean_notebook_outputs,
+    document_id_from_ws_url,
     emit_execution_progress,
     execute_cell_with_forced_sync,
     execute_via_execution_stack,
+    execute_via_execution_stack_http,
     get_current_notebook_context,
     get_jupyter_ydoc,
     safe_extract_outputs,
@@ -448,6 +450,53 @@ class ExecuteCellTool(BaseTool):
                     )
 
                 cell_source = str(notebook[cell_index].get("source", ""))
+
+                # Execution through the runtime's own /execute route: the
+                # runtime runs the cell and writes its outputs into the
+                # collaborative document server-side, so a run's outputs survive
+                # the loss of this worker. Only the default jupyter-server
+                # variant has that route, and only when both the document and
+                # the cell are known — without them the runtime would run the
+                # cell but write no outputs, so fall back to the WebSocket path
+                # rather than lose the durability this exists for. The HTTP
+                # driver fires its own BEFORE/AFTER_EXECUTE, so this branches
+                # before the hook below to avoid firing it twice.
+                from jupyter_mcp_server.config import get_config  # noqa: PLC0415
+
+                _config = get_config()
+                if _config.execute_via_http and not _config.uses_sandbox_variant():
+                    http_cell_id = notebook[cell_index].get("id")
+                    http_document_id = document_id_from_ws_url(
+                        getattr(notebook, "_ws_url", "") or getattr(notebook, "path", "")
+                    )
+                    if http_cell_id and http_document_id:
+                        from jupyter_mcp_server.server_context import (  # noqa: PLC0415
+                            ServerContext,
+                        )
+
+                        auth_headers = ServerContext.get_instance().code_sandbox_auth_headers
+                        logger.info(
+                            f"Executing cell {cell_index} through the runtime's /execute route "
+                            f"(document {http_document_id}, cell {http_cell_id}, timeout: {timeout_seconds}s)"
+                        )
+                        return await execute_via_execution_stack_http(
+                            server_url=_config.code_sandbox_url,
+                            token=None if auth_headers else _config.code_sandbox_token,
+                            auth_headers=auth_headers or None,
+                            kernel_id=kid,
+                            code=cell_source,
+                            document_id=http_document_id,
+                            cell_id=http_cell_id,
+                            timeout=timeout_seconds,
+                            logger=logger,
+                            progress_callback=progress_callback,
+                            progress_interval=progress_interval,
+                        )
+                    logger.info(
+                        "execute_via_http is on but the document or cell id could not be "
+                        "resolved; falling back to the WebSocket execution path"
+                    )
+
                 hooks = HookRegistry.get_instance()
                 hook_ctx = await hooks.fire(
                     HookEvent.BEFORE_EXECUTE,

--- a/jupyter_mcp_server/utils.py
+++ b/jupyter_mcp_server/utils.py
@@ -1087,6 +1087,38 @@ def is_missing_kernel_message(message: Any) -> bool:
     return "kernel" in text and "not found" in text
 
 
+def document_id_from_ws_url(ws_url: str | None) -> str | None:
+    """The RTC room id the runtime writes outputs into, parsed from a ws_url.
+
+    An ``NbModelClient`` connects to a room whose id is the last path segment
+    of its websocket url — ``json:notebook:<fileId>`` on a Jupyter server, or a
+    bare room id on a Datalayer runtime's documents endpoint. The runtime's
+    ``/execute`` route wants the ``json:notebook:<fileId>`` form (the same one
+    the in-process path builds), so a bare id is wrapped and an already
+    fully-qualified one is kept.
+
+    Returns ``None`` when no id can be read. The caller treats that as "cannot
+    persist server-side" and stays on the WebSocket path rather than POSTing a
+    run whose outputs would land in no document — the exact failure routing
+    through the runtime exists to prevent.
+    """
+    from urllib.parse import unquote, urlparse  # noqa: PLC0415
+
+    if not ws_url:
+        return None
+    path = urlparse(ws_url).path.rstrip("/")
+    if not path:
+        return None
+    segment = unquote(path.split("/")[-1])
+    if not segment:
+        return None
+    # A fully-qualified room id (`format:type:fileId`) is used as-is; a bare
+    # file id is wrapped the way the in-process path builds document_id.
+    if segment.count(":") >= 2:
+        return segment
+    return f"json:notebook:{segment}"
+
+
 async def _finish_execution_stack_result(
     result: dict,
     *,

--- a/jupyter_mcp_server/utils.py
+++ b/jupyter_mcp_server/utils.py
@@ -3,6 +3,7 @@
 # BSD 3-Clause License
 
 import asyncio
+import contextlib
 import json
 import os
 import re
@@ -1086,6 +1087,141 @@ def is_missing_kernel_message(message: Any) -> bool:
     return "kernel" in text and "not found" in text
 
 
+async def _finish_execution_stack_result(
+    result: dict,
+    *,
+    code: str,
+    kernel_id: str,
+    metadata: dict,
+    logger,
+    raw_outputs: list | None,
+    execution_count_out: list | None,
+    hook_ctx,
+) -> list[str | ImageContent]:
+    """Turn a terminal ExecutionStack result into formatted outputs.
+
+    Shared by the in-process driver (``execute_via_execution_stack``, which
+    gets the result straight off the extension's ``ExecutionStack``) and the
+    HTTP one (``execute_via_execution_stack_http``, which polls the runtime's
+    ``/api/kernels/{id}/execute`` route). The transport differs; the result
+    shape does not — the HTTP route serializes ``ExecutionStack.get(...)``
+    verbatim, so the same dict reaches here either way. Fires exactly one
+    ``AFTER_EXECUTE`` for the ``hook_ctx`` the caller already opened, and
+    raises :class:`MissingKernelError` for a gone kernel so the caller's
+    one-shot retry can run (its ``AFTER_EXECUTE`` is the caller's to fire).
+    """
+    # The kernel's reply carries the real execution_count for both the error
+    # and success cases (a kernel increments it whether or not the cell
+    # raised); capture it before the branches below return.
+    if execution_count_out is not None and "execution_count" in result:
+        execution_count_out.append(result["execution_count"])
+
+    # Check for errors
+    if "error" in result:
+        error_info = result["error"]
+        if not isinstance(error_info, dict):
+            # ExecutionStack reports a request-level failure as a plain string:
+            # the kernel it could not connect to, a request superseded by a
+            # newer one for the same cell, a request cancelled after an earlier
+            # one failed. Only an exception raised inside the kernel arrives as
+            # a mapping with ename/evalue/traceback. Wrap the string so the
+            # reason reaches the caller instead of being lost to an attribute
+            # error on the lines below.
+            error_info = {
+                "ename": "ExecutionError",
+                "evalue": str(error_info),
+                "traceback": [],
+            }
+        logger.error(f"Execution error: {error_info}")
+        if is_missing_kernel_message(error_info.get("evalue", "")):
+            # execute_cell starts a replacement kernel and retries once when
+            # this happens, and it looks for the failure in an exception. Leave
+            # it as one so that path can run; the caller fires the single
+            # AFTER_EXECUTE this execution owes and re-raises.
+            raise MissingKernelError(error_info.get("evalue", ""))
+        error_output = [
+            f"[ERROR: {error_info.get('ename', 'Unknown')}: {error_info.get('evalue', '')}]"
+        ]
+        if raw_outputs is not None:
+            raw_outputs.append(
+                {
+                    "output_type": "error",
+                    "ename": error_info.get("ename", "Unknown"),
+                    "evalue": error_info.get("evalue", ""),
+                    "traceback": error_info.get("traceback", []),
+                }
+            )
+        await HookRegistry.get_instance().fire(
+            HookEvent.AFTER_EXECUTE,
+            code=code,
+            kernel_id=kernel_id,
+            metadata=metadata,
+            outputs=error_output,
+            error=error_info,
+            context=hook_ctx,
+        )
+        return error_output
+
+    # Check for pending input (shouldn't happen with allow_stdin=False)
+    if "input_request" in result:
+        logger.warning("Unexpected input request during execution")
+        input_request_output = ["[ERROR: Unexpected input request]"]
+        await HookRegistry.get_instance().fire(
+            HookEvent.AFTER_EXECUTE,
+            code=code,
+            kernel_id=kernel_id,
+            metadata=metadata,
+            outputs=input_request_output,
+            error=RuntimeError("Unexpected input request during execution"),
+            context=hook_ctx,
+        )
+        return input_request_output
+
+    # Extract outputs
+    outputs = result.get("outputs", [])
+
+    # Parse JSON string if needed (ExecutionStack returns JSON string)
+    if isinstance(outputs, str):
+        import json
+
+        try:
+            outputs = json.loads(outputs)
+        except json.JSONDecodeError as decode_err:
+            logger.error(f"Failed to parse outputs JSON: {outputs}")
+            decode_error_output = ["[ERROR: Invalid output format]"]
+            await HookRegistry.get_instance().fire(
+                HookEvent.AFTER_EXECUTE,
+                code=code,
+                kernel_id=kernel_id,
+                metadata=metadata,
+                outputs=decode_error_output,
+                error=decode_err,
+                context=hook_ctx,
+            )
+            return decode_error_output
+
+    if outputs:
+        formatted = safe_extract_outputs(outputs)
+        if raw_outputs is not None:
+            raw_outputs.extend(outputs)
+        logger.info(
+            f"Execution completed with {len(formatted)} formatted outputs: {formatted}"
+        )
+    else:
+        formatted = []
+        logger.info("Execution completed with no outputs")
+    await HookRegistry.get_instance().fire(
+        HookEvent.AFTER_EXECUTE,
+        code=code,
+        kernel_id=kernel_id,
+        metadata=metadata,
+        outputs=formatted,
+        error=None,
+        context=hook_ctx,
+    )
+    return formatted if formatted else ["[No output generated]"]
+
+
 async def execute_via_execution_stack(
     serverapp: Any,
     kernel_id: str,
@@ -1205,120 +1341,16 @@ async def execute_via_execution_stack(
                 if result is not None:
                     # Execution complete
                     logger.info(f"Execution request {request_id} completed")
-
-                    # The kernel's reply carries the real execution_count for
-                    # both the error and success cases (a kernel increments it
-                    # whether or not the cell raised); capture it before the
-                    # branches below return.
-                    if execution_count_out is not None and "execution_count" in result:
-                        execution_count_out.append(result["execution_count"])
-
-                    # Check for errors
-                    if "error" in result:
-                        error_info = result["error"]
-                        if not isinstance(error_info, dict):
-                            # ExecutionStack reports a request-level failure as a
-                            # plain string: the kernel it could not connect to, a
-                            # request superseded by a newer one for the same cell,
-                            # a request cancelled after an earlier one failed. Only
-                            # an exception raised inside the kernel arrives as a
-                            # mapping with ename/evalue/traceback. Wrap the string
-                            # so the reason reaches the caller instead of being
-                            # lost to an attribute error on the lines below.
-                            error_info = {
-                                "ename": "ExecutionError",
-                                "evalue": str(error_info),
-                                "traceback": [],
-                            }
-                        logger.error(f"Execution error: {error_info}")
-                        if is_missing_kernel_message(error_info.get("evalue", "")):
-                            # execute_cell starts a replacement kernel and retries
-                            # once when this happens, and it looks for the failure
-                            # in an exception. Leave as one so that path can run;
-                            # the handler at the end of this function fires the
-                            # single AFTER_EXECUTE this execution owes and re-raises.
-                            raise MissingKernelError(error_info.get("evalue", ""))
-                        error_output = [
-                            f"[ERROR: {error_info.get('ename', 'Unknown')}: {error_info.get('evalue', '')}]"
-                        ]
-                        if raw_outputs is not None:
-                            raw_outputs.append(
-                                {
-                                    "output_type": "error",
-                                    "ename": error_info.get("ename", "Unknown"),
-                                    "evalue": error_info.get("evalue", ""),
-                                    "traceback": error_info.get("traceback", []),
-                                }
-                            )
-                        await HookRegistry.get_instance().fire(
-                            HookEvent.AFTER_EXECUTE,
-                            code=code,
-                            kernel_id=kernel_id,
-                            metadata=metadata,
-                            outputs=error_output,
-                            error=error_info,
-                            context=hook_ctx,
-                        )
-                        return error_output
-
-                    # Check for pending input (shouldn't happen with allow_stdin=False)
-                    if "input_request" in result:
-                        logger.warning("Unexpected input request during execution")
-                        input_request_output = ["[ERROR: Unexpected input request]"]
-                        await HookRegistry.get_instance().fire(
-                            HookEvent.AFTER_EXECUTE,
-                            code=code,
-                            kernel_id=kernel_id,
-                            metadata=metadata,
-                            outputs=input_request_output,
-                            error=RuntimeError("Unexpected input request during execution"),
-                            context=hook_ctx,
-                        )
-                        return input_request_output
-
-                    # Extract outputs
-                    outputs = result.get("outputs", [])
-
-                    # Parse JSON string if needed (ExecutionStack returns JSON string)
-                    if isinstance(outputs, str):
-                        import json
-
-                        try:
-                            outputs = json.loads(outputs)
-                        except json.JSONDecodeError as decode_err:
-                            logger.error(f"Failed to parse outputs JSON: {outputs}")
-                            decode_error_output = ["[ERROR: Invalid output format]"]
-                            await HookRegistry.get_instance().fire(
-                                HookEvent.AFTER_EXECUTE,
-                                code=code,
-                                kernel_id=kernel_id,
-                                metadata=metadata,
-                                outputs=decode_error_output,
-                                error=decode_err,
-                                context=hook_ctx,
-                            )
-                            return decode_error_output
-
-                    if outputs:
-                        formatted = safe_extract_outputs(outputs)
-                        if raw_outputs is not None:
-                            raw_outputs.extend(outputs)
-                        logger.info(
-                            f"Execution completed with {len(formatted)} formatted outputs: {formatted}"
-                        )
-                    else:
-                        formatted = []
-                        logger.info("Execution completed with no outputs")
-                    await HookRegistry.get_instance().fire(
-                        HookEvent.AFTER_EXECUTE,
+                    return await _finish_execution_stack_result(
+                        result,
                         code=code,
                         kernel_id=kernel_id,
                         metadata=metadata,
-                        outputs=formatted,
-                        error=None,
-                        context=hook_ctx,
+                        logger=logger,
+                        raw_outputs=raw_outputs,
+                        execution_count_out=execution_count_out,
+                        hook_ctx=hook_ctx,
                     )
-                    return formatted if formatted else ["[No output generated]"]
 
                 if (
                     progress_interval > 0
@@ -1375,6 +1407,241 @@ async def execute_via_execution_stack(
         if isinstance(e, MissingKernelError):
             raise
         return [f"[ERROR: {e!s}]"]
+
+
+class _HttpxExecuteTransport:
+    """The default transport for :func:`execute_via_execution_stack_http`.
+
+    A thin async wrapper over httpx that answers ``(status_code, body,
+    headers)`` for ``post``/``get`` — the shape the poll loop needs, because it
+    turns on the HTTP *status code* and the convenience clients that raise on a
+    non-2xx would hide the 202/300/500 the runtime uses to mean pending, input
+    and error. Built lazily so importing this module needs no HTTP client.
+    """
+
+    def __init__(self, base_url: str, token: str | None, auth_headers: dict | None = None):
+        import httpx  # noqa: PLC0415 - optional, only when no transport is injected
+
+        headers = dict(auth_headers or {})
+        if token:
+            headers.setdefault("Authorization", f"token {token}")
+        self._client = httpx.AsyncClient(base_url=base_url.rstrip("/"), headers=headers, timeout=None)
+
+    async def _send(self, method: str, path: str, json=None):
+        response = await self._client.request(method, path, json=json)
+        try:
+            body = response.json()
+        except Exception:  # noqa: BLE001 - a non-JSON body is not a result
+            body = {}
+        return response.status_code, body, dict(response.headers)
+
+    async def post(self, path: str, json=None):
+        return await self._send("POST", path, json=json)
+
+    async def get(self, path: str):
+        return await self._send("GET", path)
+
+    async def aclose(self):
+        await self._client.aclose()
+
+
+async def execute_via_execution_stack_http(
+    *,
+    server_url: str | None = None,
+    token: str | None = None,
+    kernel_id: str,
+    code: str,
+    document_id: str | None = None,
+    cell_id: str | None = None,
+    timeout: int = 300,
+    poll_interval: float = 0.1,
+    logger=None,
+    raw_outputs: list | None = None,
+    execution_count_out: list | None = None,
+    progress_callback=None,
+    progress_interval: int = 5,
+    transport=None,
+    auth_headers: dict | None = None,
+) -> list[str | ImageContent]:
+    """Execute code through the runtime's own HTTP ``/execute`` route.
+
+    The counterpart to :func:`execute_via_execution_stack` for ``MCP_SERVER``
+    mode, where the worker is a separate process from the runtime and cannot
+    reach the in-process ``ExecutionStack``. It POSTs to
+    ``/api/kernels/{kernel_id}/execute`` and polls the request URL the runtime
+    hands back. **The runtime runs the cell and writes its outputs into the
+    collaborative document server-side**, so the outputs — and the rest of the
+    run — survive the loss of *this* worker; what the worker loses when it dies
+    is only the ability to keep reporting progress, not the run.
+
+    The result shape the route serializes is exactly what ``ExecutionStack.get``
+    returns, so the terminal handling is shared with the in-process driver via
+    :func:`_finish_execution_stack_result`. The difference is the transport and
+    that the runtime encodes the state in the HTTP status code: ``202`` pending
+    or running, ``200`` complete, ``300`` input-required, ``500`` error.
+
+    Args:
+        server_url: Base URL of the runtime's Jupyter server (used only to
+            build the default transport).
+        token: The runtime token, presented as ``Authorization: token <…>`` by
+            the default transport.
+        kernel_id: The kernel the runtime should run the code in. A kernel the
+            runtime does not know makes the POST ``404`` and raises
+            :class:`MissingKernelError`, the same signal the in-process path
+            gives so ``execute_cell`` can start a replacement and retry once.
+        document_id: RTC room id (``json:notebook:<file_id>``) the runtime
+            writes outputs into; with ``cell_id`` it is what puts the outputs on
+            the far side of this worker's death. Without both, the runtime runs
+            the code but writes no cell — so a caller that wants the durability
+            must pass both.
+        transport: Async HTTP client with ``post(path, json)`` and ``get(path)``
+            both answering ``(status_code, body, headers)``. Injected for tests;
+            defaults to httpx over ``server_url``/``token``.
+
+    Returns:
+        List of formatted outputs (strings or ImageContent).
+
+    Raises:
+        TimeoutError: If execution exceeds ``timeout``.
+        MissingKernelError: If the runtime does not know ``kernel_id``.
+    """
+    import logging as default_logging
+
+    if logger is None:
+        logger = default_logging.getLogger(__name__)
+
+    owns_transport = transport is None
+    if transport is None:
+        if not server_url:
+            raise ValueError(
+                "execute_via_execution_stack_http needs a server_url when no transport is injected"
+            )
+        transport = _HttpxExecuteTransport(server_url, token, auth_headers)
+
+    metadata = {}
+    if document_id and cell_id:
+        metadata = {"document_id": document_id, "cell_id": cell_id}
+
+    hook_ctx = None
+    after_execute_fired = False
+    try:
+        logger.info(f"Submitting HTTP execution request to kernel {kernel_id}")
+        hook_ctx = await HookRegistry.get_instance().fire(
+            HookEvent.BEFORE_EXECUTE,
+            code=code,
+            kernel_id=kernel_id,
+            metadata=metadata,
+        )
+
+        submit_status, submit_body, submit_headers = await transport.post(
+            f"/api/kernels/{kernel_id}/execute",
+            json={"code": code, "metadata": metadata},
+        )
+        if submit_status == 404:
+            # The runtime does not know this kernel — the HTTP equivalent of the
+            # in-process "kernel not found" the retry path looks for.
+            raise MissingKernelError(f"kernel not found: {kernel_id}")
+        if submit_status not in (200, 201, 202):
+            raise RuntimeError(
+                f"the runtime refused the execution request ({submit_status}): {submit_body}"
+            )
+        # The request to poll: the route hands back a request_url (preferred)
+        # or a Location header; fall back to the documented path only if both
+        # are absent, so a route rename is followed rather than guessed past.
+        request_url = (
+            (submit_body or {}).get("request_url")
+            or submit_headers.get("Location")
+            or submit_headers.get("location")
+        )
+        request_id = (submit_body or {}).get("request_id", "")
+        if not request_url:
+            if not request_id:
+                raise RuntimeError(
+                    f"the runtime accepted the request but named no request to poll: {submit_body}"
+                )
+            request_url = f"/api/kernels/{kernel_id}/requests/{request_id}"
+        logger.info(f"HTTP execution request {request_id or request_url} submitted")
+
+        start_time = asyncio.get_event_loop().time()
+        last_progress_emit = 0.0
+        try:
+            while True:
+                elapsed = asyncio.get_event_loop().time() - start_time
+                if elapsed > timeout:
+                    raise TimeoutError(f"Execution timed out after {timeout} seconds")
+
+                poll_status, poll_body, _ = await transport.get(request_url)
+
+                # 202 is pending or running — the runtime is still working and
+                # the body, if any, is a progress snapshot, never a result. Only
+                # 200 (complete), 300 (input-required) and 500 (error) are
+                # terminal, and each carries the dict the shared handler reads.
+                if poll_status == 202:
+                    if (
+                        progress_interval > 0
+                        and elapsed > 0
+                        and (elapsed - last_progress_emit) >= progress_interval
+                    ):
+                        last_progress_emit = elapsed
+                        await emit_execution_progress(
+                            progress_callback,
+                            elapsed=elapsed,
+                            timeout_seconds=timeout,
+                        )
+                    await asyncio.sleep(poll_interval)
+                    continue
+
+                logger.info(f"HTTP execution request {request_id or request_url} completed")
+                return await _finish_execution_stack_result(
+                    poll_body if isinstance(poll_body, dict) else {},
+                    code=code,
+                    kernel_id=kernel_id,
+                    metadata=metadata,
+                    logger=logger,
+                    raw_outputs=raw_outputs,
+                    execution_count_out=execution_count_out,
+                    hook_ctx=hook_ctx,
+                )
+        except (asyncio.CancelledError, TimeoutError) as interrupt_err:
+            # The server-side request keeps running: there is no HTTP cancel
+            # route on the runtime yet (a later increment adds one), so the most
+            # this can do honestly is stop polling and fire the AFTER_EXECUTE it
+            # owes. CancelledError is not an Exception, so it would not reach the
+            # outer handler — fire here.
+            logger.warning(
+                f"HTTP execution request {request_id or request_url} interrupted; "
+                "the runtime keeps running it until it finishes on its own"
+            )
+            await HookRegistry.get_instance().fire(
+                HookEvent.AFTER_EXECUTE,
+                code=code,
+                kernel_id=kernel_id,
+                metadata=metadata,
+                outputs=[],
+                error=interrupt_err,
+                context=hook_ctx,
+            )
+            after_execute_fired = True
+            raise
+    except Exception as e:
+        logger.error(f"Error executing via HTTP ExecutionStack: {e}", exc_info=True)
+        if hook_ctx is not None and not after_execute_fired:
+            await HookRegistry.get_instance().fire(
+                HookEvent.AFTER_EXECUTE,
+                code=code,
+                kernel_id=kernel_id,
+                metadata=metadata,
+                outputs=[],
+                error=e,
+                context=hook_ctx,
+            )
+        if isinstance(e, MissingKernelError):
+            raise
+        return [f"[ERROR: {e!s}]"]
+    finally:
+        if owns_transport:
+            with contextlib.suppress(Exception):
+                await transport.aclose()
 
 
 def create_isolated_kernel_client(kernel: Any) -> Any:

--- a/jupyter_mcp_server/utils.py
+++ b/jupyter_mcp_server/utils.py
@@ -1214,8 +1214,6 @@ async def _finish_execution_stack_result(
 
     # Parse JSON string if needed (ExecutionStack returns JSON string)
     if isinstance(outputs, str):
-        import json
-
         try:
             outputs = json.loads(outputs)
         except json.JSONDecodeError as decode_err:
@@ -1622,6 +1620,18 @@ async def execute_via_execution_stack_http(
                         )
                     await asyncio.sleep(poll_interval)
                     continue
+
+                # 200 complete, 300 input-required, 500 error each carry the
+                # result dict the shared handler reads. Anything else — a 401/
+                # 403 the token lost, a 404 for a request that expired, a 429 —
+                # is not a result, and passing its body on would surface as a
+                # quiet "[No output generated]". Raise so it reaches the caller
+                # as the error it is.
+                if poll_status not in (200, 300, 500):
+                    raise RuntimeError(
+                        f"the runtime answered {poll_status} polling "
+                        f"{request_id or request_url}: {poll_body}"
+                    )
 
                 logger.info(f"HTTP execution request {request_id or request_url} completed")
                 return await _finish_execution_stack_result(

--- a/tests/test_a_cancelled_cell_hands_back_what_it_printed.py
+++ b/tests/test_a_cancelled_cell_hands_back_what_it_printed.py
@@ -1,3 +1,7 @@
+# Copyright (c) 2024- Datalayer, Inc.
+#
+# BSD 3-Clause License
+
 # Copyright (c) 2023-2026 Datalayer, Inc.
 # BSD 3-Clause License
 

--- a/tests/test_execute_cell_via_http_routing.py
+++ b/tests/test_execute_cell_via_http_routing.py
@@ -1,0 +1,195 @@
+# Copyright (c) 2024- Datalayer, Inc.
+#
+# BSD 3-Clause License
+
+"""`execute_cell` routes through the runtime's /execute route when asked.
+
+With `execute_via_http` on and the default jupyter-server variant, the
+MCP_SERVER branch hands the cell to `execute_via_execution_stack_http` — with
+the document and cell the runtime needs to write outputs server-side — instead
+of driving the kernel from this worker. It falls back to the WebSocket path
+when the flag is off, when the variant has no such route, or when the document
+or cell id cannot be resolved (routing a run whose outputs would land nowhere
+is the one thing this must not do).
+"""
+
+from __future__ import annotations
+
+import contextlib
+import logging
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+
+from jupyter_mcp_server.tools._base import ServerMode
+from jupyter_mcp_server.tools.execute_cell_tool import ExecuteCellTool
+
+LOG = logging.getLogger("test")
+
+
+class _Notebook:
+    """A stand-in for the NbModelClient the connection yields."""
+
+    def __init__(self, cells, ws_url):
+        self._cells = cells
+        self._ws_url = ws_url
+
+    def __len__(self):
+        return len(self._cells)
+
+    def __getitem__(self, index):
+        return self._cells[index]
+
+
+class _Connection:
+    def __init__(self, notebook):
+        self._notebook = notebook
+
+    async def __aenter__(self):
+        return self._notebook
+
+    async def __aexit__(self, *exc):
+        return False
+
+
+class _NotebookManager:
+    def __init__(self, notebook, sandbox_id="kid-1"):
+        self._notebook = notebook
+        self._sandbox_id = sandbox_id
+
+    def get_current_notebook(self):
+        return "nb"
+
+    def get_code_sandbox_id(self, name):
+        return self._sandbox_id
+
+    def get_current_connection(self):
+        return _Connection(self._notebook)
+
+
+def _config(*, execute_via_http, variant="jupyter-server"):
+    return SimpleNamespace(
+        execute_via_http=execute_via_http,
+        sandbox_variant=variant,
+        uses_sandbox_variant=lambda: variant != "jupyter-server",
+        code_sandbox_url="https://runtime.example",
+        code_sandbox_token="tok",
+    )
+
+
+@contextlib.asynccontextmanager
+async def _harness(config):
+    """Patch everything the MCP_SERVER branch reaches so execute() runs offline."""
+
+    async def _idle(*a, **k):
+        return None
+
+    spy = {}
+
+    async def _fake_http(**kwargs):
+        spy.update(kwargs)
+        return ["[http output]"]
+
+    with (
+        patch("jupyter_mcp_server.config.get_config", return_value=config),
+        patch(
+            "jupyter_mcp_server.tools.execute_cell_tool.wait_for_code_sandbox_idle",
+            _idle,
+        ),
+        patch(
+            "jupyter_mcp_server.tools.execute_cell_tool.execute_via_execution_stack_http",
+            _fake_http,
+        ),
+        patch(
+            "jupyter_mcp_server.server_context.ServerContext.get_instance",
+            return_value=SimpleNamespace(code_sandbox_auth_headers=None),
+        ),
+    ):
+        yield spy
+
+
+@pytest.mark.asyncio
+async def test_the_http_route_is_taken_with_the_document_and_cell():
+    notebook = _Notebook(
+        [{"source": "print(1)", "id": "cell-7"}],
+        "wss://runtime.example/api/collaboration/room/json:notebook:FILE1?sessionId=s",
+    )
+    config = _config(execute_via_http=True)
+    async with _harness(config) as spy:
+        outputs = await ExecuteCellTool().execute(
+            mode=ServerMode.MCP_SERVER,
+            notebook_manager=_NotebookManager(notebook),
+            cell_index=0,
+            timeout_seconds=42,
+            ensure_code_sandbox_alive_fn=lambda: object(),
+        )
+
+    assert outputs == ["[http output]"]
+    # It handed the runtime the kernel, the exact document room, and the cell —
+    # the three things it needs to run the cell and place the outputs.
+    assert spy["kernel_id"] == "kid-1"
+    assert spy["document_id"] == "json:notebook:FILE1"
+    assert spy["cell_id"] == "cell-7"
+    assert spy["code"] == "print(1)"
+    assert spy["server_url"] == "https://runtime.example"
+    assert spy["timeout"] == 42
+
+
+@pytest.mark.asyncio
+async def test_the_flag_off_keeps_the_websocket_path():
+    notebook = _Notebook(
+        [{"source": "print(1)", "id": "cell-7"}],
+        "wss://runtime.example/api/collaboration/room/json:notebook:FILE1",
+    )
+    config = _config(execute_via_http=False)
+    async with _harness(config) as spy:
+        # The WebSocket path needs a kernel client to drive; a bare object has
+        # no execute_cell, so the call fails *after* deciding not to route
+        # through HTTP. That the HTTP spy stayed empty is the assertion.
+        with contextlib.suppress(Exception):
+            await ExecuteCellTool().execute(
+                mode=ServerMode.MCP_SERVER,
+                notebook_manager=_NotebookManager(notebook),
+                cell_index=0,
+                timeout_seconds=42,
+                ensure_code_sandbox_alive_fn=lambda: object(),
+            )
+    assert spy == {}
+
+
+@pytest.mark.asyncio
+async def test_a_sandbox_variant_keeps_the_websocket_path():
+    notebook = _Notebook(
+        [{"source": "print(1)", "id": "cell-7"}],
+        "wss://runtime.example/api/collaboration/room/json:notebook:FILE1",
+    )
+    config = _config(execute_via_http=True, variant="modal")
+    async with _harness(config) as spy:
+        with contextlib.suppress(Exception):
+            await ExecuteCellTool().execute(
+                mode=ServerMode.MCP_SERVER,
+                notebook_manager=_NotebookManager(notebook),
+                cell_index=0,
+                timeout_seconds=42,
+                ensure_code_sandbox_alive_fn=lambda: object(),
+            )
+    assert spy == {}
+
+
+@pytest.mark.asyncio
+async def test_an_unresolvable_document_falls_back_rather_than_losing_outputs():
+    # No room id in the ws_url -> document_id_from_ws_url returns None -> the
+    # run must not go through HTTP, where its outputs would land nowhere.
+    notebook = _Notebook([{"source": "print(1)", "id": "cell-7"}], "")
+    config = _config(execute_via_http=True)
+    async with _harness(config) as spy:
+        with contextlib.suppress(Exception):
+            await ExecuteCellTool().execute(
+                mode=ServerMode.MCP_SERVER,
+                notebook_manager=_NotebookManager(notebook),
+                cell_index=0,
+                timeout_seconds=42,
+                ensure_code_sandbox_alive_fn=lambda: object(),
+            )
+    assert spy == {}

--- a/tests/test_execute_via_execution_stack_http.py
+++ b/tests/test_execute_via_execution_stack_http.py
@@ -18,6 +18,7 @@ import pytest
 
 from jupyter_mcp_server.utils import (
     MissingKernelError,
+    document_id_from_ws_url,
     execute_via_execution_stack_http,
 )
 
@@ -34,7 +35,12 @@ class _FakeTransport:
         status, body, headers = post
         self._post = (
             status,
-            body if body is not None else {"request_id": "r1", "request_url": "/api/kernels/k1/requests/r1"},
+            body
+            if body is not None
+            else {
+                "request_id": "r1",
+                "request_url": "/api/kernels/k1/requests/r1",
+            },
             headers or {},
         )
         self._polls = iter(polls)
@@ -231,7 +237,20 @@ async def test_a_run_that_never_finishes_times_out():
     assert outputs == ["[ERROR: Execution timed out after 0 seconds]"]
 
 
-from jupyter_mcp_server.utils import document_id_from_ws_url
+@pytest.mark.asyncio
+async def test_an_unexpected_poll_status_is_an_error_not_silence():
+    # A 401/403/404/429 while polling is not a result; it must surface as an
+    # actionable error rather than a quiet "[No output generated]".
+    transport = _FakeTransport(polls=[(403, {"message": "forbidden"})])
+    outputs = await execute_via_execution_stack_http(
+        kernel_id="k1",
+        code="1+1",
+        poll_interval=0,
+        transport=transport,
+    )
+    assert len(outputs) == 1
+    assert outputs[0].startswith("[ERROR:")
+    assert "403" in outputs[0]
 
 
 def test_document_id_from_ws_url_reads_the_room():

--- a/tests/test_execute_via_execution_stack_http.py
+++ b/tests/test_execute_via_execution_stack_http.py
@@ -1,0 +1,231 @@
+# Copyright (c) 2024- Datalayer, Inc.
+#
+# BSD 3-Clause License
+
+"""`execute_via_execution_stack_http` drives the runtime's HTTP /execute route.
+
+The in-process driver reads `ExecutionStack.get` straight off the extension;
+this one cannot (the worker is a separate process), so it POSTs to
+`/api/kernels/{id}/execute` and polls the request URL, turning on the HTTP
+*status code* — 202 pending/running, 200 complete, 300 input, 500 error. The
+route serializes the same result dict either way, so the terminal handling is
+shared and only the transport is faked here. No live runtime needed.
+"""
+
+import json
+
+import pytest
+
+from jupyter_mcp_server.utils import (
+    MissingKernelError,
+    execute_via_execution_stack_http,
+)
+
+
+class _FakeTransport:
+    """A scripted async transport: one POST answer, a sequence of GET answers.
+
+    Each method answers `(status_code, body, headers)`, the shape the poll loop
+    needs — the real runtime's 202/300/500 would be hidden by a client that
+    raised on non-2xx.
+    """
+
+    def __init__(self, *, post=(202, None, None), polls=()):
+        status, body, headers = post
+        self._post = (
+            status,
+            body if body is not None else {"request_id": "r1", "request_url": "/api/kernels/k1/requests/r1"},
+            headers or {},
+        )
+        self._polls = iter(polls)
+        self.posted: list = []
+        self.got: list = []
+
+    async def post(self, path, json=None):
+        self.posted.append((path, json))
+        return self._post
+
+    async def get(self, path):
+        self.got.append(path)
+        status, body = next(self._polls)
+        return status, body, {}
+
+
+@pytest.mark.asyncio
+async def test_a_complete_run_returns_its_outputs_and_counts():
+    raw_outputs: list = []
+    execution_counts: list = []
+    transport = _FakeTransport(
+        polls=[
+            (202, {"request_status": "running", "outputs": "[]"}),
+            (
+                200,
+                {
+                    "request_status": "complete",
+                    "status": "ok",
+                    "execution_count": 7,
+                    "outputs": json.dumps(
+                        [{"output_type": "stream", "name": "stdout", "text": "done\n"}]
+                    ),
+                },
+            ),
+        ],
+    )
+
+    outputs = await execute_via_execution_stack_http(
+        kernel_id="k1",
+        code="print('done')",
+        document_id="json:notebook:file-1",
+        cell_id="cell-1",
+        poll_interval=0,
+        transport=transport,
+        raw_outputs=raw_outputs,
+        execution_count_out=execution_counts,
+    )
+
+    assert any("done" in str(output) for output in outputs)
+    assert raw_outputs == [{"output_type": "stream", "name": "stdout", "text": "done\n"}]
+    assert execution_counts == [7]
+    # It POSTed the code and polled the request_url the runtime handed back,
+    # not a guessed path.
+    assert transport.posted[0][0] == "/api/kernels/k1/execute"
+    assert transport.posted[0][1]["code"] == "print('done')"
+    assert transport.got == ["/api/kernels/k1/requests/r1", "/api/kernels/k1/requests/r1"]
+
+
+@pytest.mark.asyncio
+async def test_both_document_and_cell_are_carried_so_the_runtime_can_persist():
+    # The durability of outputs past this worker's death depends on the runtime
+    # knowing which cell to write into: both ids must reach it, or neither.
+    transport = _FakeTransport(polls=[(200, {"outputs": "[]"})])
+    await execute_via_execution_stack_http(
+        kernel_id="k1",
+        code="1+1",
+        document_id="json:notebook:file-1",
+        cell_id="cell-9",
+        poll_interval=0,
+        transport=transport,
+    )
+    assert transport.posted[0][1]["metadata"] == {
+        "document_id": "json:notebook:file-1",
+        "cell_id": "cell-9",
+    }
+
+    # Only one id is not enough to place an output, so no half-metadata is sent.
+    transport = _FakeTransport(polls=[(200, {"outputs": "[]"})])
+    await execute_via_execution_stack_http(
+        kernel_id="k1",
+        code="1+1",
+        document_id="json:notebook:file-1",
+        poll_interval=0,
+        transport=transport,
+    )
+    assert transport.posted[0][1]["metadata"] == {}
+
+
+@pytest.mark.asyncio
+async def test_a_string_shaped_error_keeps_its_message():
+    raw_outputs: list = []
+    transport = _FakeTransport(
+        polls=[(500, {"error": "Request superseded by a newer execution for this cell"})]
+    )
+
+    outputs = await execute_via_execution_stack_http(
+        kernel_id="k1",
+        code="print('hi')",
+        poll_interval=0,
+        transport=transport,
+        raw_outputs=raw_outputs,
+    )
+
+    assert outputs == [
+        "[ERROR: ExecutionError: Request superseded by a newer execution for this cell]"
+    ]
+    assert raw_outputs == [
+        {
+            "output_type": "error",
+            "ename": "ExecutionError",
+            "evalue": "Request superseded by a newer execution for this cell",
+            "traceback": [],
+        }
+    ]
+
+
+@pytest.mark.asyncio
+async def test_a_mapping_shaped_error_reports_ename_and_evalue():
+    transport = _FakeTransport(
+        polls=[
+            (
+                500,
+                {
+                    "error": {
+                        "ename": "ZeroDivisionError",
+                        "evalue": "division by zero",
+                        "traceback": ["Traceback line"],
+                    }
+                },
+            )
+        ]
+    )
+
+    outputs = await execute_via_execution_stack_http(
+        kernel_id="k1",
+        code="1/0",
+        poll_interval=0,
+        transport=transport,
+    )
+
+    assert outputs == ["[ERROR: ZeroDivisionError: division by zero]"]
+
+
+@pytest.mark.asyncio
+async def test_a_gone_kernel_raises_missing_kernel_error():
+    # A 404 on the POST is the HTTP equivalent of "kernel not found" — left as
+    # an exception so execute_cell's replace-and-retry-once path can run.
+    transport = _FakeTransport(post=(404, {"message": "kernel not found"}, None))
+
+    with pytest.raises(MissingKernelError):
+        await execute_via_execution_stack_http(
+            kernel_id="gone",
+            code="1+1",
+            poll_interval=0,
+            transport=transport,
+        )
+
+
+@pytest.mark.asyncio
+async def test_an_unexpected_input_request_is_reported():
+    # allow_stdin is False, so a 300 input-required is not expected; it is
+    # reported rather than hung on.
+    transport = _FakeTransport(polls=[(300, {"input_request": {"prompt": "?", "password": False}})])
+
+    outputs = await execute_via_execution_stack_http(
+        kernel_id="k1",
+        code="input()",
+        poll_interval=0,
+        transport=transport,
+    )
+
+    assert outputs == ["[ERROR: Unexpected input request]"]
+
+
+@pytest.mark.asyncio
+async def test_a_run_that_never_finishes_times_out():
+    # Every poll stays 202; the loop must give up at the timeout rather than
+    # spin forever.
+    def _always_running():
+        while True:
+            yield (202, {"request_status": "running"})
+
+    transport = _FakeTransport()
+    transport._polls = _always_running()
+
+    outputs = await execute_via_execution_stack_http(
+        kernel_id="k1",
+        code="while True: pass",
+        timeout=0,
+        poll_interval=0,
+        transport=transport,
+    )
+    # Timeout is caught by the outer handler and surfaced as an error string.
+    assert outputs == ["[ERROR: Execution timed out after 0 seconds]"]

--- a/tests/test_execute_via_execution_stack_http.py
+++ b/tests/test_execute_via_execution_stack_http.py
@@ -229,3 +229,31 @@ async def test_a_run_that_never_finishes_times_out():
     )
     # Timeout is caught by the outer handler and surfaced as an error string.
     assert outputs == ["[ERROR: Execution timed out after 0 seconds]"]
+
+
+from jupyter_mcp_server.utils import document_id_from_ws_url
+
+
+def test_document_id_from_ws_url_reads_the_room():
+    # A Jupyter collaboration room id is already json:notebook:<fileId>.
+    assert (
+        document_id_from_ws_url(
+            "wss://r/api/collaboration/room/json:notebook:FILE1?sessionId=s"
+        )
+        == "json:notebook:FILE1"
+    )
+    # A Datalayer documents endpoint hands back a bare file id; it is wrapped
+    # into the form the /execute route writes outputs under.
+    assert (
+        document_id_from_ws_url("wss://r/api/spacer/documents/ws/FILE2?token=y")
+        == "json:notebook:FILE2"
+    )
+    # Percent-encoded colons are decoded.
+    assert (
+        document_id_from_ws_url("wss://r/api/collaboration/room/json%3Anotebook%3AFILE3")
+        == "json:notebook:FILE3"
+    )
+    # Nothing to read -> None, so the caller stays on the WebSocket path rather
+    # than writing into the wrong (or no) document.
+    assert document_id_from_ws_url("") is None
+    assert document_id_from_ws_url(None) is None


### PR DESCRIPTION
## What

In MCP_SERVER mode the worker drives the kernel over a WebSocket and writes cell outputs into the document itself, so a run's outputs stop when the worker stops (gateway rollout, idle reap, crash). This routes cell execution through the runtime's own `POST /api/kernels/{id}/execute` instead: the runtime runs the cell and writes outputs into the collaborative document **server-side** (`jupyter-server-nbmodel`'s `ExecutionStack`), so a run's outputs — and the rest of the run — survive the loss of the worker that started it.

- `execute_via_execution_stack_http` (utils.py): POSTs and polls the request URL, branching on the HTTP status (202 pending, 200 complete, 300 input, 500 error). The route serializes the same result dict the in-process `ExecutionStack.get` returns, so the terminal handling (execution_count, string-vs-mapping error, `MissingKernelError` for a gone kernel, outputs parse, the single `AFTER_EXECUTE`) is shared with the in-process driver via a new `_finish_execution_stack_result`.
- `document_id_from_ws_url` (utils.py): parses the RTC room id off the `NbModelClient` ws_url (`json:notebook:<fileId>` as-is, a bare Datalayer file id wrapped).
- `config.execute_via_http` (default off; reads `JUPYTER_MCP_EXECUTE_VIA_HTTP`): wired into `execute_cell`'s MCP_SERVER branch, gated on the default `jupyter-server` variant **and** a resolvable document+cell id, WebSocket path the fallback — routing a run whose outputs would land nowhere is the one thing it must not do. `execute_code` (no cell) keeps the WebSocket path.

## Tests

- `tests/test_execute_via_execution_stack_http.py` — the HTTP driver against a faked transport (complete, string/mapping error, missing kernel, input-required, timeout) + `document_id_from_ws_url`.
- `tests/test_execute_cell_via_http_routing.py` — the routing decision (HTTP taken with document+cell; fallback when off, on a sandbox variant, or with no room).
- Existing in-process and dead-kernel-retry tests still green after the shared-helper refactor.

Off by default, so behaviour is unchanged until `JUPYTER_MCP_EXECUTE_VIA_HTTP` is set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)