### PR TITLE
feat(execute): no WebSocket fallback for execute_via_http (2.1.12)

### DIFF
--- a/docs/docs/architecture/index.mdx
+++ b/docs/docs/architecture/index.mdx
@@ -211,9 +211,12 @@ process stops — a gateway rollout, an idle reap, a crash. Set
 request it returns. The runtime runs the cell and writes the outputs into the
 collaborative document **server-side**, so a run — and its outputs — survive
 the loss of this process; what this process loses when it stops is only the
-ability to keep reporting progress. It is used only when the document and cell
-ids resolve (so the runtime knows where to write); otherwise, and for every
-non-`jupyter-server` variant, execution stays on the WebSocket path above.
+ability to keep reporting progress. **There is no fallback**: once
+`execute_via_http` is on for a variant that has the route, this is the
+execution path for `execute_cell` — a run whose document or cell id cannot be
+resolved is raised as an error (so it is fixed), not quietly downgraded to the
+worker-driven WebSocket path where the outputs would be lost. Variants with no
+such route (Modal, E2B, …) still execute through their sandbox client, and
 `execute_code`, which targets no cell, always uses the WebSocket path — the
 durability is a property of cell execution, where there is a document cell to
 write into.

--- a/docs/sourcey/mcp.json
+++ b/docs/sourcey/mcp.json
@@ -3,7 +3,7 @@
   "mcpVersion": "2025-11-25",
   "server": {
     "name": "Jupyter MCP Server",
-    "version": "2.1.13"
+    "version": "2.1.12"
   },
   "capabilities": {
     "experimental": {},

--- a/docs/sourcey/mcp.json
+++ b/docs/sourcey/mcp.json
@@ -3,7 +3,7 @@
   "mcpVersion": "2025-11-25",
   "server": {
     "name": "Jupyter MCP Server",
-    "version": "2.1.11"
+    "version": "2.1.12"
   },
   "capabilities": {
     "experimental": {},

--- a/docs/sourcey/mcp.json
+++ b/docs/sourcey/mcp.json
@@ -3,7 +3,7 @@
   "mcpVersion": "2025-11-25",
   "server": {
     "name": "Jupyter MCP Server",
-    "version": "2.1.12"
+    "version": "2.1.13"
   },
   "capabilities": {
     "experimental": {},

--- a/extensions/mcpb/manifest.json
+++ b/extensions/mcpb/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": "0.4",
   "name": "jupyter-mcp-server",
   "display_name": "Jupyter MCP Server",
-  "version": "2.1.13",
+  "version": "2.1.12",
   "description": "Connect AI agents to Jupyter Notebooks - execute code, manage notebooks, and interact with kernels in real-time",
   "long_description": "The Jupyter MCP Server enables AI agents like Claude to connect to and manage Jupyter Notebooks in real-time. It provides 14 tools to execute code, manage notebooks, read and write cells, and interact with Jupyter kernels through the standardized Model Context Protocol.\n\n**Requirements:** You need a running Jupyter server (JupyterLab or Jupyter Notebook) to connect to. Start one with:\n```\npip install jupyterlab\njupyter lab --port 8888 --IdentityProvider.token MY_TOKEN\n```",
   "author": {

--- a/extensions/mcpb/manifest.json
+++ b/extensions/mcpb/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": "0.4",
   "name": "jupyter-mcp-server",
   "display_name": "Jupyter MCP Server",
-  "version": "2.1.12",
+  "version": "2.1.13",
   "description": "Connect AI agents to Jupyter Notebooks - execute code, manage notebooks, and interact with kernels in real-time",
   "long_description": "The Jupyter MCP Server enables AI agents like Claude to connect to and manage Jupyter Notebooks in real-time. It provides 14 tools to execute code, manage notebooks, read and write cells, and interact with Jupyter kernels through the standardized Model Context Protocol.\n\n**Requirements:** You need a running Jupyter server (JupyterLab or Jupyter Notebook) to connect to. Start one with:\n```\npip install jupyterlab\njupyter lab --port 8888 --IdentityProvider.token MY_TOKEN\n```",
   "author": {

--- a/extensions/mcpb/manifest.json
+++ b/extensions/mcpb/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": "0.4",
   "name": "jupyter-mcp-server",
   "display_name": "Jupyter MCP Server",
-  "version": "2.1.11",
+  "version": "2.1.12",
   "description": "Connect AI agents to Jupyter Notebooks - execute code, manage notebooks, and interact with kernels in real-time",
   "long_description": "The Jupyter MCP Server enables AI agents like Claude to connect to and manage Jupyter Notebooks in real-time. It provides 14 tools to execute code, manage notebooks, read and write cells, and interact with Jupyter kernels through the standardized Model Context Protocol.\n\n**Requirements:** You need a running Jupyter server (JupyterLab or Jupyter Notebook) to connect to. Start one with:\n```\npip install jupyterlab\njupyter lab --port 8888 --IdentityProvider.token MY_TOKEN\n```",
   "author": {

--- a/extensions/mcpb/pyproject.toml
+++ b/extensions/mcpb/pyproject.toml
@@ -4,7 +4,7 @@
 
 [project]
 name = "jupyter-mcp-server-mcpb"
-version = "2.1.13"
+version = "2.1.12"
 description = "Jupyter MCP Server - MCPB bundle for one-click installation in Claude Desktop"
 requires-python = ">=3.10"
 dependencies = [

--- a/extensions/mcpb/pyproject.toml
+++ b/extensions/mcpb/pyproject.toml
@@ -4,7 +4,7 @@
 
 [project]
 name = "jupyter-mcp-server-mcpb"
-version = "2.1.12"
+version = "2.1.13"
 description = "Jupyter MCP Server - MCPB bundle for one-click installation in Claude Desktop"
 requires-python = ">=3.10"
 dependencies = [

--- a/extensions/mcpb/pyproject.toml
+++ b/extensions/mcpb/pyproject.toml
@@ -4,7 +4,7 @@
 
 [project]
 name = "jupyter-mcp-server-mcpb"
-version = "2.1.11"
+version = "2.1.12"
 description = "Jupyter MCP Server - MCPB bundle for one-click installation in Claude Desktop"
 requires-python = ">=3.10"
 dependencies = [

--- a/jupyter_mcp_server/__version__.py
+++ b/jupyter_mcp_server/__version__.py
@@ -4,4 +4,4 @@
 
 """Jupyter MCP Server."""
 
-__version__ = "2.1.12"
+__version__ = "2.1.13"

--- a/jupyter_mcp_server/__version__.py
+++ b/jupyter_mcp_server/__version__.py
@@ -4,4 +4,4 @@
 
 """Jupyter MCP Server."""
 
-__version__ = "2.1.13"
+__version__ = "2.1.12"

--- a/jupyter_mcp_server/__version__.py
+++ b/jupyter_mcp_server/__version__.py
@@ -4,4 +4,4 @@
 
 """Jupyter MCP Server."""
 
-__version__ = "2.1.11"
+__version__ = "2.1.12"

--- a/jupyter_mcp_server/tools/execute_cell_tool.py
+++ b/jupyter_mcp_server/tools/execute_cell_tool.py
@@ -454,11 +454,13 @@ class ExecuteCellTool(BaseTool):
                 # Execution through the runtime's own /execute route: the
                 # runtime runs the cell and writes its outputs into the
                 # collaborative document server-side, so a run's outputs survive
-                # the loss of this worker. Only the default jupyter-server
-                # variant has that route, and only when both the document and
-                # the cell are known — without them the runtime would run the
-                # cell but write no outputs, so fall back to the WebSocket path
-                # rather than lose the durability this exists for. The HTTP
+                # the loss of this worker. Turned on with execute_via_http, for
+                # the variants that have the route (the default jupyter-server
+                # runtime). **No fallback**: once it is on for such a variant,
+                # this is *the* execution path — the run does not quietly revert
+                # to the worker-driven WebSocket path. A run that cannot be
+                # routed (the document or cell id does not resolve) is a loud
+                # error to fix, not a silent downgrade that hides it. The HTTP
                 # driver fires its own BEFORE/AFTER_EXECUTE, so this branches
                 # before the hook below to avoid firing it twice.
                 from jupyter_mcp_server.config import get_config  # noqa: PLC0415
@@ -466,39 +468,42 @@ class ExecuteCellTool(BaseTool):
                 _config = get_config()
                 if _config.execute_via_http and not _config.uses_sandbox_variant():
                     http_cell_id = notebook[cell_index].get("id")
-                    # Only a real websocket URL carries the RTC room id. The
-                    # notebook *path* must not be a fallback: parsing it would
-                    # make a bogus `json:notebook:<path>` room and misroute the
-                    # run to no document. No ws_url -> unresolved -> the guard
-                    # below keeps this on the WebSocket path.
+                    # Only a real websocket URL carries the RTC room id; the
+                    # notebook *path* is never parsed for it (that would make a
+                    # bogus `json:notebook:<path>` room and write outputs
+                    # nowhere).
                     ws_url = getattr(notebook, "ws_url", None) or getattr(notebook, "_ws_url", None)
                     http_document_id = document_id_from_ws_url(ws_url)
-                    if http_cell_id and http_document_id:
-                        from jupyter_mcp_server.server_context import (  # noqa: PLC0415
-                            ServerContext,
+                    if not http_document_id or not http_cell_id:
+                        raise ValueError(
+                            "execute_via_http is on, but the runtime /execute route cannot be "
+                            f"used for cell {cell_index}: "
+                            f"{'the notebook document id did not resolve from its websocket url' if not http_document_id else 'the cell has no id'}. "
+                            "The runtime writes outputs into the document server-side and needs "
+                            "both ids to do so; there is no WebSocket fallback by design, so this "
+                            "is raised rather than run where the outputs would be lost."
                         )
+                    from jupyter_mcp_server.server_context import (  # noqa: PLC0415
+                        ServerContext,
+                    )
 
-                        auth_headers = ServerContext.get_instance().code_sandbox_auth_headers
-                        logger.info(
-                            f"Executing cell {cell_index} through the runtime's /execute route "
-                            f"(document {http_document_id}, cell {http_cell_id}, timeout: {timeout_seconds}s)"
-                        )
-                        return await execute_via_execution_stack_http(
-                            server_url=_config.code_sandbox_url,
-                            token=None if auth_headers else _config.code_sandbox_token,
-                            auth_headers=auth_headers or None,
-                            kernel_id=kid,
-                            code=cell_source,
-                            document_id=http_document_id,
-                            cell_id=http_cell_id,
-                            timeout=timeout_seconds,
-                            logger=logger,
-                            progress_callback=progress_callback,
-                            progress_interval=progress_interval,
-                        )
+                    auth_headers = ServerContext.get_instance().code_sandbox_auth_headers
                     logger.info(
-                        "execute_via_http is on but the document or cell id could not be "
-                        "resolved; falling back to the WebSocket execution path"
+                        f"Executing cell {cell_index} through the runtime's /execute route "
+                        f"(document {http_document_id}, cell {http_cell_id}, timeout: {timeout_seconds}s)"
+                    )
+                    return await execute_via_execution_stack_http(
+                        server_url=_config.code_sandbox_url,
+                        token=None if auth_headers else _config.code_sandbox_token,
+                        auth_headers=auth_headers or None,
+                        kernel_id=kid,
+                        code=cell_source,
+                        document_id=http_document_id,
+                        cell_id=http_cell_id,
+                        timeout=timeout_seconds,
+                        logger=logger,
+                        progress_callback=progress_callback,
+                        progress_interval=progress_interval,
                     )
 
                 hooks = HookRegistry.get_instance()

--- a/jupyter_mcp_server/tools/execute_cell_tool.py
+++ b/jupyter_mcp_server/tools/execute_cell_tool.py
@@ -478,10 +478,11 @@ class ExecuteCellTool(BaseTool):
                         raise ValueError(
                             "execute_via_http is on, but the runtime /execute route cannot be "
                             f"used for cell {cell_index}: "
-                            f"{'the notebook document id did not resolve from its websocket url' if not http_document_id else 'the cell has no id'}. "
+                            f"{'the notebook document id did not resolve from its WebSocket URL (missing or malformed)' if not http_document_id else 'the cell has no id'}. "
                             "The runtime writes outputs into the document server-side and needs "
                             "both ids to do so; there is no WebSocket fallback by design, so this "
-                            "is raised rather than run where the outputs would be lost."
+                            "is raised rather than run without the server-side output durability "
+                            "this path exists for."
                         )
                     from jupyter_mcp_server.server_context import (  # noqa: PLC0415
                         ServerContext,

--- a/tests/test_execute_cell_via_http_routing.py
+++ b/tests/test_execute_cell_via_http_routing.py
@@ -178,13 +178,14 @@ async def test_a_sandbox_variant_keeps_the_websocket_path():
 
 
 @pytest.mark.asyncio
-async def test_an_unresolvable_document_falls_back_rather_than_losing_outputs():
-    # No room id in the ws_url -> document_id_from_ws_url returns None -> the
-    # run must not go through HTTP, where its outputs would land nowhere.
+async def test_an_unresolvable_document_raises_rather_than_falling_back():
+    # No room id in the ws_url -> document_id_from_ws_url returns None. With no
+    # fallback, this is a loud error (so it gets fixed), not a silent revert to
+    # the WebSocket path — and the HTTP driver is never called with no document.
     notebook = _Notebook([{"source": "print(1)", "id": "cell-7"}], "")
     config = _config(execute_via_http=True)
     async with _harness(config) as spy:
-        with contextlib.suppress(Exception):
+        with pytest.raises(ValueError, match="execute_via_http"):
             await ExecuteCellTool().execute(
                 mode=ServerMode.MCP_SERVER,
                 notebook_manager=_NotebookManager(notebook),


### PR DESCRIPTION
Follow-up to #442. When `execute_via_http` is on for a variant that has the runtime `/execute` route, that route is now **the** execution path for `execute_cell` — **no WebSocket fallback**. A run whose document or cell id cannot be resolved is raised as a clear error (so it is fixed) rather than quietly downgraded to the worker-driven WebSocket path, which would lose the server-side output durability and hide the problem.

- Variants without the route (Modal, E2B, …) still execute through their sandbox client.
- `execute_code` (no cell) keeps the WebSocket path.
- Routing test updated to assert it **raises** rather than falls back; architecture doc updated.

Bumps to 2.1.12.

🤖 Generated with [Claude Code](https://claude.com/claude-code)