### PR TITLE
fix(insert_cell): don't write a 4.5 cell id into an older notebook

### DIFF
--- a/jupyter_mcp_server/tools/insert_cell_tool.py
+++ b/jupyter_mcp_server/tools/insert_cell_tool.py
@@ -119,7 +119,8 @@ class InsertCellTool(BaseTool):
         """
         # Read notebook file
         with open(notebook_path, encoding="utf-8") as f:
-            # Read as version 4 (latest) to ensure consistency and support for cell IDs
+            # as_version converts the major version only, so nbformat_minor stays
+            # whatever the file declared.
             notebook = nbformat.read(f, as_version=4)
 
         # Clean any transient fields from existing outputs (kernel protocol field not in nbformat schema)
@@ -138,6 +139,13 @@ class InsertCellTool(BaseTool):
             new_cell = nbformat.v4.new_markdown_cell(source=cell_source or "")
         elif cell_type == "raw":
             new_cell = nbformat.v4.new_raw_cell(source=cell_source or "")
+
+        # Cell ids arrived in nbformat 4.5 and the constructors always attach one.
+        # Writing it into an older notebook produces a file that its own schema
+        # rejects, so drop it rather than silently upgrading the user's notebook.
+        if notebook.nbformat_minor < 5:
+            new_cell.pop("id", None)
+
         notebook.cells.insert(actual_index, new_cell)
 
         # Write back to file

--- a/tests/test_cell_id_addressing.py
+++ b/tests/test_cell_id_addressing.py
@@ -83,6 +83,11 @@ async def test_an_edit_by_id_survives_an_insert_above_it(
     the newcomer; addressed by id, it lands on the cell the agent read.
     """
     async with mcp_client_parametrized as client:
+        # Skip before touching the notebook. This file is shared with the tests
+        # that run after this one, and skipping once TARGET is already in it
+        # would leave TARGET behind as their first cell.
+        await _id_or_skip(client, 0)
+
         await client.insert_cell(0, "markdown", "TARGET")
         assert "TARGET" in _text_of(await _read(client, 0))
         target_id = await _id_or_skip(client, 0)

--- a/tests/test_insert_cell_nbformat_version.py
+++ b/tests/test_insert_cell_nbformat_version.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python3
+# Copyright (c) 2024- Datalayer, Inc.
+#
+# BSD 3-Clause License
+
+"""Inserting a cell must not invalidate an older notebook.
+
+Cell ids arrived in nbformat 4.5, and `nbformat.v4.new_code_cell` and its
+siblings always attach one. `insert_cell` builds cells that way — which is what
+#339 asked for, because the create path was writing 4.5 notebooks whose cells
+had no id — and then writes the cell into whatever notebook it was given.
+
+Reading with `as_version=4` converts the major version only, so a notebook that
+declares 4.2 or 4.4 is still 4.2 or 4.4 when it is written back, now carrying a
+field its own schema forbids. `nbformat.write` logs that the notebook is invalid
+and writes it anyway, so the tool reports success over a file that
+`nbformat.validate` rejects and that a strict reader can refuse.
+
+Launch the tests:
+```
+$ pytest tests/test_insert_cell_nbformat_version.py -v
+```
+"""
+
+import asyncio
+
+import nbformat
+import pytest
+
+from jupyter_mcp_server.tools.insert_cell_tool import InsertCellTool
+
+
+def _notebook(minor: int) -> nbformat.NotebookNode:
+    """A one cell notebook declaring nbformat 4.`minor`."""
+    notebook = nbformat.v4.new_notebook()
+    notebook.nbformat_minor = minor
+    notebook.cells = [nbformat.v4.new_markdown_cell(source="hello")]
+    if minor < 5:
+        for cell in notebook.cells:
+            cell.pop("id", None)
+    return notebook
+
+
+@pytest.fixture
+def notebook_path(tmp_path):
+    def _write(minor: int) -> str:
+        path = tmp_path / f"nb_4_{minor}.ipynb"
+        nbformat.write(_notebook(minor), str(path))
+        return str(path)
+
+    return _write
+
+
+@pytest.mark.parametrize("minor", [2, 4])
+@pytest.mark.parametrize("cell_type", ["code", "markdown", "raw"])
+def test_insert_leaves_a_pre_4_5_notebook_valid(notebook_path, minor, cell_type):
+    path = notebook_path(minor)
+
+    asyncio.run(InsertCellTool()._insert_cell_file(path, 1, cell_type, "print(1)"))
+
+    written = nbformat.read(path, as_version=4)
+    nbformat.validate(written)  # raises if the notebook is not valid
+    assert written.nbformat_minor == minor, "the notebook's own version must not change"
+    assert all("id" not in cell for cell in written.cells)
+
+
+@pytest.mark.parametrize("cell_type", ["code", "markdown", "raw"])
+def test_insert_still_gives_a_4_5_notebook_an_id(notebook_path, cell_type):
+    path = notebook_path(5)
+
+    asyncio.run(InsertCellTool()._insert_cell_file(path, 1, cell_type, "print(1)"))
+
+    written = nbformat.read(path, as_version=4)
+    nbformat.validate(written)
+    assert written.nbformat_minor == 5
+    assert all(cell.get("id") for cell in written.cells)


### PR DESCRIPTION
## What happens

`insert_cell` builds cells with `nbformat.v4.new_code_cell` and its siblings, which always attach a cell id. Cell ids arrived in nbformat 4.5, and the notebook is read with `as_version=4`, which converts the major version only — a file that declares 4.2 or 4.4 is still 4.2 or 4.4 when it is written back, now carrying a field its own schema forbids.

```
input nbformat 4.2 -> written 4.2  ids=[None, '4ba7a514']  INVALID: Additional properties are not allowed ('id' was unexpected)
input nbformat 4.4 -> written 4.4  ids=[None, 'aee3bd20']  INVALID: Additional properties are not allowed ('id' was unexpected)
input nbformat 4.5 -> written 4.5  ids=['8f374d00', '2a74495f']  VALID
```

`nbformat.write` logs `Notebook JSON is invalid` and writes the file anyway, so the tool answers `Cell inserted successfully` over a notebook that `nbformat.validate` rejects.

This is the mirror image of #338. That issue was the create path writing a 4.5 notebook whose cell had no id, and #339 fixed it by building cells through nbformat's constructors. `_insert_cell_file` already builds cells that way, which is exactly why it now writes an id into notebooks that cannot hold one.

The comment above the read says the version is pinned "to ensure consistency and support for cell IDs", which is the assumption that does not hold: `as_version` never touches `nbformat_minor`.

## Why it matters

`FileContentsManager.get()` and `.save()` both report `Notebook validation failed: Additional properties are not allowed ('id' was unexpected)` for the resulting file, and saving does not repair it.

The id is also not durable. `jupyter_ydoc` is minor aware: given a 4.2 notebook it reads the cell ids back as `None`, so the id this path writes disappears the moment the notebook is opened over RTC or through the WebSocket backend. An id that survives only until someone opens the notebook is the situation `cell_ids.py` exists to avoid.

`dev/content/notebook.ipynb` is checked in at `nbformat_minor: 2` with 161 cells, exactly one of which carries `"id": "a92dadf9"` — eight hex characters, the shape `random_cell_id` produces. It fails `nbformat.validate` on main today.

## The change

The id is dropped when the notebook predates 4.5. Upgrading the notebook to 4.5 instead would let the id stay, but that silently rewrites the version of a file the user did not ask to convert, so the file keeps the version it declared. A 4.5 notebook still gets an id exactly as before.

## Testing

`tests/test_insert_cell_nbformat_version.py` inserts each cell type into 4.2, 4.4 and 4.5 notebooks, then runs `nbformat.validate` on the result and checks the notebook's own version did not change.

On main the six pre-4.5 cases fail and the three 4.5 cases pass, which is the shape of the bug. With this change all nine pass, and the surrounding suite has the same set of failures before and after.
