### PR TITLE
fix(outputs): strip the escapes that are not CSI

### DIFF
--- a/jupyter_mcp_server/utils.py
+++ b/jupyter_mcp_server/utils.py
@@ -539,10 +539,22 @@ def extract_output(output: dict | Any) -> str | ImageContent:
         return f"[Unknown output type: {output_type}]"
 
 
+# Every escape a kernel can write, not only the CSI sequences: an OSC string
+# carries a hyperlink or a window title, DCS and friends carry device control,
+# and the two character forms move the cursor or select a charset.
+_ANSI_ESCAPE = re.compile(
+    r"\x1b(?:"
+    r"\[[0-?]*[ -/]*[@-~]"              # CSI, e.g. colour or cursor movement
+    r"|\][^\x07\x1b]*(?:\x07|\x1b\\)"  # OSC, terminated by BEL or ST
+    r"|[P^_X][^\x1b]*\x1b\\"           # DCS, PM, APC and SOS strings
+    r"|[ -/]*[0-~]"                    # two character and charset sequences
+    r")"
+)
+
+
 def strip_ansi_codes(text: str) -> str:
     """Remove ANSI escape sequences from text."""
-    ansi_escape = re.compile(r"\x1b\[[0-?]*[ -/]*[@-~]")
-    return ansi_escape.sub("", text)
+    return _ANSI_ESCAPE.sub("", text)
 
 
 def clean_notebook_outputs(notebook):

--- a/tests/test_ansi_escape_stripping.py
+++ b/tests/test_ansi_escape_stripping.py
@@ -8,6 +8,11 @@ strip_ansi_codes matched only the SGR colour sequences, so every other escape
 a kernel writes survived into the text handed back to the client. A nested
 tqdm bar moves the cursor with ESC[A on each redraw whether or not the stream
 is a terminal, and those bytes came through in the stream output.
+
+Widening the pattern to every CSI sequence left the escapes that are not CSI.
+An OSC string carries a hyperlink or a window title and is what rich writes for
+a link, and a kernel can also emit the two character forms and the device
+control strings. None of those are CSI, so all of them still came through.
 """
 
 from jupyter_mcp_server.utils import extract_output, strip_ansi_codes
@@ -39,3 +44,36 @@ def test_a_nested_progress_bar_reads_back_without_escapes():
 
 def test_brackets_without_an_escape_are_left_alone():
     assert strip_ansi_codes("matched [0-9]* twice") == "matched [0-9]* twice"
+
+
+# A link printed by rich, which writes an OSC 8 hyperlink whenever it believes
+# it is writing to a terminal, as it does inside Jupyter.
+RICH_HYPERLINK_TEXT = (
+    "see \x1b]8;id=12903882;https://example.com\x1b\\the docs\x1b]8;;\x1b\\ for details\n"
+)
+
+
+def test_an_osc_hyperlink_is_stripped():
+    assert strip_ansi_codes(RICH_HYPERLINK_TEXT) == "see the docs for details\n"
+
+
+def test_an_osc_string_terminated_by_bel_is_stripped():
+    assert strip_ansi_codes("\x1b]0;window title\x07text") == "text"
+
+
+def test_two_character_escapes_are_stripped():
+    assert strip_ansi_codes("a\x1b7b\x1b8c") == "abc"
+    assert strip_ansi_codes("a\x1bMb") == "ab"
+
+
+def test_a_charset_selection_is_stripped():
+    assert strip_ansi_codes("\x1b(Btext") == "text"
+
+
+def test_a_device_control_string_is_stripped():
+    assert strip_ansi_codes("a\x1bPsomething\x1b\\b") == "ab"
+
+
+def test_a_rich_link_reads_back_without_escapes():
+    stream = {"output_type": "stream", "name": "stdout", "text": RICH_HYPERLINK_TEXT}
+    assert "\x1b" not in extract_output(stream)


### PR DESCRIPTION
## What is left behind

#427 widened `strip_ansi_codes` from the SGR colour sequences to every CSI sequence, which is what a progress bar writes. CSI is one of several escape forms, and the rest still reach the client.

The one a kernel is most likely to write is an OSC string, because that is how a hyperlink is expressed. `rich` emits one whenever it believes it is writing to a terminal, as it does inside Jupyter:

```python
>>> from rich.console import Console
>>> import io
>>> buf = io.StringIO()
>>> Console(file=buf, force_terminal=True).print("see [link=https://example.com]the docs[/link] for details")
>>> buf.getvalue()
'see \x1b]8;id=12903882;https://example.com\x1b\\the docs\x1b]8;;\x1b\\ for details\n'
>>> strip_ansi_codes(buf.getvalue())
'see \x1b]8;id=12903882;https://example.com\x1b\\the docs\x1b]8;;\x1b\\ for details\n'
```

Nothing is removed. The same holds for a window title (`ESC ] 0 ; ... BEL`, which any shell command run from a cell can write), for the two character forms such as save and restore cursor or reverse index, for a charset selection like `ESC ( B`, and for the device control strings.

This matters for the same reason #426 did. The text goes to a model, which now reads a URL and an id it was never meant to see, and to a terminal, where the bytes are interpreted rather than displayed.

## The change

The pattern covers the other forms alongside CSI: an OSC string up to its BEL or ST terminator, the DCS, PM, APC and SOS strings up to ST, and the two character and charset sequences. The OSC and DCS bodies are bounded so a sequence that was truncated cannot swallow the rest of the output. The regex is compiled once at import rather than on every call.

Every CSI sequence is matched exactly as before, so nothing that #427 fixed changes.

## Testing

The existing tests are unchanged and still pass. New ones cover an OSC hyperlink captured from `rich`, an OSC string terminated by BEL, the two character escapes, a charset selection, and a device control string, plus a reading of the `rich` output through `extract_output` that asserts no escape byte survives, matching the shape of the nested tqdm test.

On main the six new tests fail and the five existing ones pass. With this change all eleven pass, and the surrounding suite has the same set of failures before and after.
