### PR TITLE
feat(instructions): state the ALWAYS MCP rule in the server instructions

### DIFF
--- a/jupyter_mcp_server/server.py
+++ b/jupyter_mcp_server/server.py
@@ -340,7 +340,14 @@ class MCPServerWithCORS(MCPServer):
 INSTRUCTIONS = (
     "Read, edit and run Jupyter notebooks. Cells are addressed by index within "
     "a notebook you have opened with use_notebook, and execution happens on the "
-    "server, so a long computation keeps running after this session ends."
+    "server, so a long computation keeps running after this session ends.\n"
+    "\n"
+    "**ALWAYS MCP**: All operations on the Notebook, such as creating, editing, "
+    "and code execution, MUST be performed via tools provided by Jupyter MCP. "
+    "**NEVER Directly create or modify the Notebook Source File Content**. A "
+    "notebook open in JupyterLab or another agent's session is a live "
+    "collaborative document: a write straight to the file is silently discarded "
+    "or silently overwrites unsaved edits."
 )
 
 mcp = MCPServerWithCORS(


### PR DESCRIPTION
Option 1 from #446.

`extensions/prompt-templates/general/AGENT.md:41` already states the rule, but nothing
loads it — the README asks a human to paste the template into a system prompt, so agents
nobody set up by hand never see it. `INSTRUCTIONS`, returned in the `initialize` reply, is
what every agent does read, and it said nothing about the file. It is also the one thing
about this server an agent cannot infer from `tools/list`.

The rule is pasted verbatim, plus one sentence saying why.

Notes for the reviewer:

- The same server blurb is restated in `docs/sourcey/snapshot.mjs:36` (hardcoded because
  mcp-parser drops `instructions` from the snapshot) and in the generated
  `docs/sourcey/mcp.json`. Left untouched here — the script could read `INSTRUCTIONS` from
  the installed package instead of restating it, if you want that fixed properly.

